### PR TITLE
docs(spec): add v2 product specification for Solid rebuild

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,7 +1,7 @@
 # Solid — Product Specification (v2)
 
 **Status:** DRAFT — under review
-**Scope of this SPEC:** defines the user-facing contract for `@SolidState`. All other annotations are listed only to pin the v1 boundary; their full contract lives in a future SPEC revision.
+**Scope of this SPEC:** defines the user-facing contract for `@SolidState` (the first implementation milestone, M1). The other annotations shipped before v2 release — `@SolidEffect`, `@SolidQuery`, `@SolidEnvironment` — are reserved names only; their full contract lives in a future SPEC revision.
 
 This document is the single source of truth for what Solid does. Reviewer agents cite this document by section number when judging an implementation. It contains no file names, no class names, no AST details — only what the developer sees and the guarantees they get.
 
@@ -24,21 +24,26 @@ source/counter.dart        ← developer writes (committed)
 lib/counter.dart           ← Solid emits (committed)
 ```
 
+> **Why this differs from the pub.dev convention.** Most Dart generators read files from `lib/` and emit adjacent `*.g.dart` parts. Solid cannot: annotated Solid source violates Flutter invariants — e.g., a `StatelessWidget` with mutable fields — so it is not valid to ship as-is under `lib/`. The solution is to put source in its own top-level directory (`source/`) and let Solid emit the runnable form into `lib/`.
+
 Rules:
 
 - **Input path**: any `.dart` file under `source/` at any depth.
 - **Output path**: same relative path under `lib/`. No suffix change. `source/foo/bar.dart` becomes `lib/foo/bar.dart`.
+- **Non-Dart files are copied verbatim.** Any non-`.dart` file under `source/` is copied byte-for-byte to the mirrored path under `lib/` with no transformation. Only `.dart` files go through the generator.
 - **Both are committed to git.** Source is the review artifact for intent. Lib is the review artifact for correctness — every PR that changes `source/` must include the regenerated `lib/` diff so reviewers catch generator regressions.
 - **No `.g.dart` files are emitted.** Neither under `source/` nor under `lib/`.
 - **The example app's `main.dart`** lives in `lib/` (or `source/` if itself annotated) and imports from `lib/` using normal Flutter imports (`import 'counter.dart';`).
 - **Source is analyzed** with a couple of lint suppressions (notably `must_be_immutable`) so that a `StatelessWidget` with a mutable `@SolidState` field does not trip the analyzer. Source remains valid Dart at all times; any real error (typo, type error, undefined symbol) fails analysis.
-- **Hot reload works normally.** `dart run build_runner watch` regenerates `lib/` as the developer edits `source/`; `flutter run` hot-reloads from `lib/`. This is the whole flow; there is no separate CLI. (Addresses issue #9.)
+- **Hot reload works normally.** `dart run build_runner watch` regenerates `lib/` as the developer edits `source/`; `flutter run` hot-reloads from `lib/`. This is the whole flow; there is no separate CLI.
 
 ---
 
 ## 3. Annotations
 
-### 3.1 v1 scope: `@SolidState`
+> **Milestones vs v2.** The v2 public release ships the full annotation set: `@SolidState`, `@SolidEffect`, `@SolidQuery`, `@SolidEnvironment`. Implementation is split into internal milestones. M1 implements `@SolidState` only. Later milestones add the remaining annotations before v2 ships. The user-facing API of every annotation is fixed in this SPEC; no source-code change is required when a later milestone lands.
+
+### 3.1 M1 scope: `@SolidState`
 
 `@SolidState` declares a reactive property on a class. It attaches to either a field or a getter.
 
@@ -66,18 +71,18 @@ int counter = 0;
 
 - `final` field (a `Signal` wrapping a never-reassigned value is a static constant — pointless).
 - `const` field (same reason plus a type-system impossibility).
-- `static` field or getter (class-level, not instance; out of v1 scope).
+- `static` field or getter (class-level, not instance; out of M1 scope).
 - Top-level variable or getter.
 - Method (not a getter).
 - Setter.
 
-### 3.2 Out of v1 scope
+### 3.2 Later milestones (shipped before v2 release)
 
-The following annotations are defined by the blog-post vision but are NOT implemented in v1. If the developer uses them, the generator must fail with a clear error that names the annotation and says "not implemented in v1."
+The following annotations are part of the v2 public release but land in milestones after M1. Until each one ships, the generator must fail with a clear error that names the annotation and says "not yet implemented; scheduled for a later v2 milestone." Their names are reserved here; the full user-facing contract (parameters, valid targets, transformation rules) will be specified in a future SPEC revision before each lands.
 
-- `@SolidEffect()` — reactive side effect (method)
-- `@SolidQuery({Duration? debounce, bool? useRefreshing})` — async reactive source (method)
-- `@SolidEnvironment()` — dependency injection (field)
+- `@SolidEffect` — reactive side effect (method)
+- `@SolidQuery` — async reactive source (method)
+- `@SolidEnvironment` — dependency injection (field)
 
 ### 3.3 Permanent non-goals
 
@@ -86,7 +91,7 @@ Solid will never:
 - Replace `flutter_solidart`. Signal / Computed / Effect / Resource / SignalBuilder come from the upstream package.
 - Ship its own reactive runtime.
 - Use Dart Macros, Dart augmentations, or part-file patterns.
-- Support multi-file generation (one source file → one lib file).
+- Split one source file into multiple lib files. Each `source/*.dart` produces exactly one `lib/*.dart` at the mirrored path.
 
 ---
 
@@ -110,7 +115,7 @@ class Counter extends StatelessWidget {
 }
 ```
 
-Output (excerpt, see §8 for the full class transform):
+Output (excerpt, see Section 8 for the full class transform):
 
 ```dart
 final counter = Signal<int>(0, name: 'counter');
@@ -180,24 +185,7 @@ Output:
 final counter = Signal<int>(0, name: 'myCounter');
 ```
 
-### 4.5 Getter → Computed (no dependencies on other reactive state)
-
-Input:
-
-```dart
-@SolidState()
-String get label => 'hello';
-```
-
-Output:
-
-```dart
-final label = Computed<String>(() => 'hello', name: 'label');
-```
-
-Rule: when the getter body does not read any reactive identifier defined on the same class, the field is declared `final` (not `late final`).
-
-### 4.6 Getter → Computed (with dependencies)
+### 4.5 Getter → Computed
 
 Input:
 
@@ -218,10 +206,11 @@ late final doubleCounter = Computed<int>(() => counter.value * 2, name: 'doubleC
 
 Rules:
 
-- Identifiers in the body that match other reactive declarations on the same class are rewritten with `.value` (see §5).
-- The resulting `Computed` field is declared `late final` (not `final`), because it references other `final` instance fields whose initialization order is not guaranteed.
+- The getter body MUST read at least one reactive declaration (a `@SolidState` field or another `@SolidState` getter) on the same class. A `Computed` with zero reactive dependencies is a plain constant and is rejected by the generator with: *"getter `<name>` has no reactive dependencies; use `final` or a plain getter instead of `@SolidState`."*
+- Identifiers in the body that resolve to reactive declarations on the same class are rewritten with `.value` (see Section 5).
+- The resulting `Computed` field is always declared `late final`, because it references other `final` instance fields whose initialization order is not guaranteed.
 
-### 4.7 Getter with block body
+### 4.6 Getter with block body
 
 Input:
 
@@ -248,11 +237,13 @@ The block is copied verbatim into a function expression with reactive-read rewri
 
 ## 5. Reactive-Read Rules
 
-When a generated piece of code (anything under `lib/`) references a name that was declared reactive in the source, the reference is rewritten to read through the reactive primitive.
+When a generated piece of code (anything under `lib/`) references a reactive value, the reference is rewritten to read through the reactive primitive. The decision is **type-driven**, not name-driven: the generator uses the Dart analyzer's resolved static type, not a name-set, to decide whether to append `.value`.
 
 ### 5.1 Identifier rewrite
 
-Every bare `SimpleIdentifier` whose name matches a `@SolidState` field or getter on the enclosing class is rewritten to `<name>.value`.
+A bare `SimpleIdentifier` is rewritten to `<name>.value` if and only if its resolved static type is `SignalBase<T>` (or a subtype: `Signal<T>`, `Computed<T>`, `ReadSignal<T>`, `Resource<T>`) from `package:flutter_solidart`.
+
+In M1 the only way to introduce such an identifier is via `@SolidState` on the enclosing class, but the rule itself is expressed in terms of resolved type so later milestones (`@SolidEnvironment`, `@SolidQuery`) work without amendment.
 
 Source:
 
@@ -260,7 +251,7 @@ Source:
 Text(counter.toString())
 ```
 
-Output (inside a SignalBuilder — see §7):
+Output (inside a SignalBuilder — see Section 7):
 
 ```dart
 Text(counter.value.toString())
@@ -286,6 +277,8 @@ Already-qualified `${counter.value}` in source stays as-is (no double-append).
 
 ### 5.3 Compound assignment rewrite
 
+Only the **left-hand side** of an assignment expression is the write. The **right-hand side** is a read, and is subject to the normal `.value` rewriting rule from Section 5.1. In `counter = counter + 1`, the left `counter` is a write (never subscribes — see Section 6.0) and the right `counter` is a read (receives `.value`).
+
 Source:
 
 ```dart
@@ -294,7 +287,7 @@ onPressed: () { counter = counter + 1; }
 onPressed: () { counter += 5; }
 ```
 
-Output (see §6 for why these are not wrapped in SignalBuilder):
+Output (see Section 6.0 — writes never trigger subscription, but their RHS reads still get `.value`):
 
 ```dart
 onPressed: () => counter.value++
@@ -304,13 +297,19 @@ onPressed: () { counter.value += 5; }
 
 Supported operators: `=`, `+=`, `-=`, `*=`, `/=`, `~/=`, `%=`, `??=`, `<<=`, `>>=`, `|=`, `&=`, `^=`, `++` (prefix/postfix), `--` (prefix/postfix).
 
-### 5.4 Double-append protection
+Compound-assignment operators (`+=`, `++`, etc.) are sugar: the LHS position is simultaneously a read (to compute the new value) and a write (to store it). The `.value` appears once per textual occurrence, matching Dart's evaluation of the compound form.
 
-If the source already has `name.value`, the generator must NOT rewrite it to `name.value.value`. The rewriter is idempotent.
+### 5.4 Type-aware `.value` append
+
+The rewriter appends `.value` only when the receiver's resolved static type is `SignalBase<T>` or a subtype. If the type is anything else, the rewriter leaves the expression untouched.
+
+This matters because `.value` is a common field name on ordinary Dart objects (e.g., `TextEditingController.value`, `ValueNotifier.value`). A name-based rewriter would produce nonsensical `controller.value.value` code. The type-based rule is the only correct form and is also inherently idempotent: once `counter.value` has been rewritten, the outer expression's type is `int` (not `SignalBase<int>`), so the rule stops applying.
+
+The generator MUST resolve types through `package:analyzer`. Name-matching, regex, or string heuristics are not acceptable implementations of this rule.
 
 ### 5.5 Shadowing
 
-If a local variable or parameter inside a function shadows a reactive-field name, the generator does NOT rewrite the shadowed use.
+Shadowing is handled automatically because the rule in Section 5.1 is type-driven. If a local variable or parameter with a non-`SignalBase` type shadows a reactive-field name, the analyzer resolves the inner identifier to the local's type and the `.value` rewrite does not fire.
 
 Source:
 
@@ -319,27 +318,38 @@ Source:
 
 Widget build(BuildContext context) {
   return Builder(builder: (context) {
-    final counter = 'local'; // shadows the field
-    return Text(counter);     // stays as `counter`, not `counter.value`
+    final counter = 'local'; // shadows the field; type is String
+    return Text(counter);     // stays as `counter`
   });
 }
 ```
 
-Output: the inner `counter` stays untouched. (The outer field reference remains reactive if present.)
+Output: the inner `counter` stays untouched. The outer field reference, if present, still rewrites normally because its resolved type is `Signal<int>`.
 
-This is determined by analyzer scope resolution, not by name alone. v1 implementation may use a name-set heuristic because v1 scope is simple — but the SPEC contract is scope-aware; v2 tests must include a shadowing case and it must pass.
+M1 tests include a shadowing case to prove the rule.
 
 ---
 
 ## 6. Untracked-Context Rules
 
+### 6.0 Reads vs writes
+
+Every reference to a reactive identifier is either a **read** or a **write**. They behave differently.
+
+- A **write** is any assignment form listed in Section 5.3 (`=`, compound assignments, `++`, `--`). Writes never subscribe to the signal — subscribing to your own write is meaningless. The rewriter appends `.value` so the expression typechecks, but writes never cause `SignalBuilder` wrapping under any rule in this section.
+- A **read** observes the reactive value: `Text(counter)`, `if (counter > 0) ...`, `print(counter)`. Reads may or may not subscribe, depending on the context defined below.
+
+Tracking rules in the remainder of Section 6 apply only to reads.
+
+### 6.1 Tracked vs untracked reads
+
 A read is **tracked** if the widget subtree that contains it must rebuild when the signal changes. A read is **untracked** if the expression reads the current value but must NOT cause its enclosing widget subtree to subscribe.
 
-Untracked reads still get `.value` appended (so they typecheck). They just do NOT trigger `SignalBuilder` wrapping of their parent widget subtree (§7). This fixes issues #4 and #6.
+Untracked reads still get `.value` appended (so they typecheck). They just do NOT trigger `SignalBuilder` wrapping of their parent widget subtree (Section 7).
 
-### 6.1 Callbacks on widget constructors
+### 6.2 Reads inside user-interaction callbacks
 
-A read is untracked when the identifier appears inside a function expression that is the value of a named argument to a widget constructor and that named argument is a user-interaction callback.
+A read is untracked when the identifier appears inside a function expression that is the value of a named argument to a widget constructor and that named argument is a user-interaction callback. The callback fires in response to a user gesture, not in response to signal changes, so subscribing the enclosing widget to the read would be wrong.
 
 Callback parameter names treated as untracked:
 
@@ -348,13 +358,18 @@ Callback parameter names treated as untracked:
 - `onHorizontalDragUpdate`, `onVerticalDragUpdate`, `onPanUpdate`, `onScaleUpdate` (and their `Start`/`End`/`Cancel`/`Down` variants)
 - `onHover`, `onExit`, `onEnter`, `onFocusChange`
 - `onDismissed`, `onClosing`, `onAccept`, `onWillAccept`, `onLeave`, `onMove`
-- Future reviewers may add to this list. The list is maintained in this SPEC.
+- The list is maintained in this SPEC.
+
+The example below shows one read and one write inside `onPressed`. The read (`if (counter > 10)`) is untracked by this rule. The write (`counter++`) is untracked by Section 6.0 and would be untracked even outside a callback. Neither causes `SignalBuilder` wrapping.
 
 Source:
 
 ```dart
 FloatingActionButton(
-  onPressed: () => counter++,
+  onPressed: () {
+    if (counter > 10) showDialog(...);  // read, untracked by Section 6.2
+    counter++;                           // write, untracked by Section 6.0
+  },
   child: const Icon(Icons.add),
 )
 ```
@@ -363,13 +378,16 @@ Output:
 
 ```dart
 FloatingActionButton(
-  onPressed: () => counter.value++,  // `.value` appended
+  onPressed: () {
+    if (counter.value > 10) showDialog(...);
+    counter.value++;
+  },
   child: const Icon(Icons.add),
 )
 // NOT wrapped in SignalBuilder
 ```
 
-### 6.2 Key constructor arguments
+### 6.3 Reads inside Key constructor arguments
 
 A read is untracked when the identifier appears inside an `InstanceCreationExpression` whose constructor is `ValueKey`, `Key`, `ObjectKey`, `UniqueKey`, `GlobalKey`, `GlobalObjectKey`, or `PageStorageKey`, and that expression is passed to the `key:` parameter of a widget.
 
@@ -392,11 +410,30 @@ Container(
 // NOT wrapped in SignalBuilder
 ```
 
-### 6.3 Everything else is tracked
+### 6.4 Explicit opt-out via `untracked`
 
-If an identifier is neither under an untracked callback nor under a Key constructor, it is tracked. The containing widget subtree must be wrapped in `SignalBuilder` (§7).
+`flutter_solidart` exports a top-level function `untracked<T>(T Function() fn)` that reads signals without creating a subscription. Solid exposes this function as-is and recognizes it during transformation: reads inside an `untracked(() => ...)` callback are untracked.
 
-### 6.4 Nested cases
+Source:
+
+```dart
+Text('Static snapshot: ${untracked(() => counter)}')
+```
+
+Output:
+
+```dart
+Text('Static snapshot: ${untracked(() => counter.value)}')
+// NOT wrapped in SignalBuilder
+```
+
+The generator recognizes `untracked` by resolved identifier (the top-level function from `package:flutter_solidart/flutter_solidart.dart`), not by name alone. A user-defined local `untracked` variable would not apply this rule.
+
+### 6.5 Everything else is tracked
+
+If a read is not in one of the contexts defined in Sections 6.2, 6.3, or 6.4, it is tracked. The containing widget subtree must be wrapped in `SignalBuilder` (Section 7).
+
+### 6.6 Nested cases
 
 Tracking is determined by the innermost enclosing AST ancestor that matches a rule. A `Text(counter)` inside an `onPressed` callback is untracked. A `Text(counter)` outside any callback is tracked.
 
@@ -411,7 +448,7 @@ Tracking is determined by the innermost enclosing AST ancestor that matches a ru
 A widget subtree needs `SignalBuilder` wrapping if and only if all three hold:
 
 1. The subtree is a widget expression (an `InstanceCreationExpression` that constructs a widget, or a reference to one) used as the return value of the `build` method, or as the value of a child/children parameter of another widget.
-2. The subtree contains at least one **tracked** reactive read (§6.3).
+2. The subtree contains at least one **tracked** reactive read (Section 6.5).
 3. The subtree is not already inside a `SignalBuilder`.
 
 ### 7.2 Minimal-subtree rule (fine-grained)
@@ -426,7 +463,7 @@ Scaffold(
     child: Text('Counter is $counter'),   // ← ONLY this Text is wrapped
   ),
   floatingActionButton: FloatingActionButton(
-    onPressed: () => counter++,           // untracked, no wrap
+    onPressed: () => counter++,           // write — no wrap (Section 6.0)
     child: const Icon(Icons.add),
   ),
 )
@@ -559,9 +596,9 @@ Passes through unchanged to `lib/`.
 
 The generated `lib/` file's imports are computed from the source's imports plus what the generator added:
 
-- Remove any `import 'package:solid_annotations/solid_annotations.dart';` — the generated code never uses it.
-- Add `import 'package:flutter_solidart/flutter_solidart.dart';` if the generated output references any of: `Signal`, `Computed`, `Effect`, `Resource`, `SignalBuilder`, `SolidartConfig`. (Effect and Resource appear in future scope; they are listed here so the rule is future-proof.)
+- Add `import 'package:flutter_solidart/flutter_solidart.dart';` if the generated output references any of: `Signal`, `Computed`, `Effect`, `Resource`, `SignalBuilder`, `SolidartConfig`, `untracked`. (Effect, Resource, and `untracked` may appear via later milestones or opt-out rules in Section 6.4; they are listed here so the rule is future-proof.)
 - Every other import in the source is preserved verbatim, including aliases and `show`/`hide` combinators.
+- Unused imports left behind (e.g., `package:solid_annotations/...` when no annotation references remain in the generated output) are removed by running `dart fix --apply` on the generated file. The generator does NOT try to detect unused imports itself.
 
 This is the fix for issue #8.
 
@@ -569,13 +606,11 @@ This is the fix for issue #8.
 
 ## 10. `dispose()` Contract
 
-Every generated `Signal` and `Computed` must be disposed when its owning class is disposed.
+Every generated `Signal` and `Computed` must be disposed when its owning class is disposed. The merging algorithm below applies identically to every class kind; the per-kind sections (8.1–8.3) describe how the algorithm is triggered.
 
-- On a StatefulWidget's State (§8.1): the generator emits a `dispose()` override that calls `xxx.dispose()` for each reactive declaration in declaration order, then `super.dispose()`.
-- On an existing State (§8.2): if the developer wrote a `dispose()`, the generator inserts the reactive disposals at the top, preserves the rest, and keeps the existing `super.dispose()` call. If no `dispose()` existed, the generator emits one.
-- On a plain class (§8.3): `void dispose()` is synthesized per §8.3 merging rules.
+Algorithm: if the target class already has a `dispose()` body, prepend one `xxx.dispose()` call per reactive declaration to the top of the body and leave the rest untouched; if no `dispose()` exists, synthesize one. Emit `super.dispose()` at the end when the class extends anything other than `Object`.
 
-Disposal order: declaration order. A `Computed` that depends on a `Signal` is disposed before the `Signal` it depends on (declarations are emitted in source order, so Signal comes first; dispose in the same order, so Computed depending on Signal is disposed before Signal if declared before — matches the rule since Computed always follows its dependencies in source).
+Disposal order is **reverse declaration order**: dependents are disposed before their dependencies. Because a `Computed` must always be declared after the `Signal`s it reads (those `Signal`s are the `Computed`'s dependencies), reverse declaration order guarantees the `Computed` is disposed first and a `Signal` is never disposed while a live `Computed` still holds a subscription to it.
 
 ---
 
@@ -596,7 +631,7 @@ my_app/
   .gitignore              ← excludes .dart_tool/, build/
 ```
 
-The `source/` tree mirrors `lib/` one-to-one. Every `.dart` file under `source/` has a counterpart under `lib/`; nothing else.
+The `source/` tree mirrors `lib/` one-to-one. Every file under `source/` has a counterpart at the mirrored path under `lib/` (`.dart` files transformed per Sections 4–10; non-`.dart` files copied verbatim per Section 2).
 
 No `.g.dart` files are emitted anywhere visible to the developer. (Test golden outputs inside the generator package may use `.g.dart` for clarity; that is an internal convention, not a user-facing one.)
 
@@ -614,35 +649,38 @@ dart run build_runner watch
 flutter run
 ```
 
-When the developer saves a file under `source/`, the generator rewrites the corresponding file under `lib/`, and Flutter's file watcher picks up the `lib/` change and hot-reloads. The developer saves once. (Fixes issue #9.)
+When the developer saves a file under `source/`, the generator rewrites the corresponding file under `lib/`, and Flutter's file watcher picks up the `lib/` change and hot-reloads. The developer saves once.
 
 ---
 
-## 13. Out of Scope for v1
+## 13. Not in M1 (shipped before v2 release)
+
+These features are part of the v2 public release but land in milestones after M1. An M1 build that encounters any of them in source code must fail with a clear error naming the unsupported feature and referencing this section.
 
 - `@SolidEffect`
 - `@SolidQuery` (Future and Stream forms; `.when`, `.maybeWhen`, `.refresh`, `.isRefreshing`; debounce; useRefreshing)
 - `@SolidEnvironment`
 - `SolidProvider` / `InheritedSolidProvider` / `.environment()` widget extension / `context.read` / `context.watch`
-- Multi-file generation (one source file produces two or more lib files)
-- Dart Macros / augmentations / part-file patterns
-- CI workflow (local test only until Actions budget permits)
 
-A v1 build that encounters any of these in source code must fail with a clear error naming the unsupported feature.
+Permanent non-goals (never part of Solid) are defined in Section 3.3.
+
+Deferred operational concerns (time-boxed, not semantic):
+
+- CI workflow. Local-only testing until GitHub Actions budget permits.
 
 ---
 
-## 14. Open Questions for the Developer
+## 14. Resolved Decisions
 
-These are marked for explicit resolution before M1 implementation begins. Default answers are provided; the developer confirms or overrides.
+These were open questions during SPEC drafting and have been answered by the developer. Locked for M1:
 
-1. **Plain (non-Widget) classes with `@SolidState` fields** — the blog post shows a `Counter` PODO passed via `SolidProvider.create`. SPEC default: support them per §8.3. **Confirm: yes/no.**
-2. **`++`, `+=`, and other compound-assignment operators on fields** — SPEC default: rewrite all operators listed in §5.3. **Confirm the operator list is complete.**
-3. **`@SolidState` on `final` fields** — SPEC default: reject with a clear error (pointless). **Confirm.**
-4. **Custom `initState` / `didUpdateWidget` overrides in an existing State class (§8.2)** — SPEC default: preserve them untouched; insert reactive disposals into the existing `dispose()` only. **Confirm.**
-5. **User-facing package name** — current choice is to keep `solid_annotations` as the import root and add an umbrella `package:solid/solid.dart` that re-exports the annotations plus a pre-curated subset of `flutter_solidart` symbols. **Confirm name or rename.**
-6. **Shadowing rule (§5.5)** — SPEC says scope-aware; v1 implementation may use a name-set heuristic because the v1 scope is simple. **Confirm it's acceptable if v1 does not fully implement scope-aware shadowing, provided there is a test case that fails correctly when shadowing is added later.**
-7. **`const` on the public widget constructor (§8.1)** — SPEC default: add `const` when all fields and default values are `const`-compatible. **Confirm.**
+1. **Plain (non-Widget) classes with `@SolidState` fields** — supported per Section 8.3.
+2. **Compound-assignment operator list in Section 5.3** — complete.
+3. **`@SolidState` on `final` fields** — rejected with a clear error (wrapping a never-reassigned value in a `Signal` is pointless).
+4. **Custom `initState` / `didUpdateWidget` overrides in an existing State class (Section 8.2)** — preserved untouched. If an existing `dispose()` is present, reactive disposals are merged into its body.
+5. **User-facing package name** — keep the current layout: `package:solid_annotations` holds the annotations and `package:solid` is the umbrella package that re-exports the annotations plus the curated subset of `flutter_solidart` symbols Solid programs need.
+6. **Shadowing rule (Section 5.5)** — handled by type resolution. Because Section 5.1 is type-driven, a shadowed local of a non-`SignalBase` type is never rewritten. A dedicated shadowing test case is required in M1.
+7. **`const` on the public widget constructor (Section 8.1)** — added when all fields and default values are `const`-compatible.
 
 ---
 
@@ -656,10 +694,10 @@ Any change that alters user-observable behavior must be covered by a golden test
 
 This SPEC addresses the following real user-reported issues from the v1 repo:
 
-- **#3** — `@SolidEnvironment` inside an existing `State<X>` was not transformed; the class-kind handling in §8.2 makes this impossible to regress.
-- **#4** — untracked reads (`ValueKey`, `onPressed`) were wrapped in `SignalBuilder`, breaking compilation; §6 defines the untracked-context rules.
-- **#6** — `Text(text)` did not receive `.value` because the rewriter missed bare identifier reads; §5.1 defines the rewrite rule exhaustively.
-- **#8** — generated `main.dart` used `SolidartConfig` without importing `flutter_solidart`; §9 defines the import-addition rule.
-- **#9** — hot reload required a double-save; §12 defines the expected single-save flow via `build_runner watch` + `flutter run`.
+- **#3** — `@SolidEnvironment` inside an existing `State<X>` was not transformed; the class-kind handling in Section 8.2 makes this impossible to regress.
+- **#4** — untracked reads (`ValueKey`, `onPressed`) were wrapped in `SignalBuilder`, breaking compilation; Section 6 defines the untracked-context rules.
+- **#6** — `Text(text)` did not receive `.value` because the rewriter missed bare identifier reads; Section 5.1 defines the rewrite rule exhaustively.
+- **#8** — generated `main.dart` used `SolidartConfig` without importing `flutter_solidart`; Section 9 defines the import-addition rule.
+- **#9** — hot reload required a double-save; Section 12 defines the expected single-save flow via `build_runner watch` + `flutter run`.
 
 Issue #11 (build speed) and issue #1 (docs typo) are process concerns addressed outside this SPEC.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,665 @@
+# Solid — Product Specification (v2)
+
+**Status:** DRAFT — under review
+**Scope of this SPEC:** defines the user-facing contract for `@SolidState`. All other annotations are listed only to pin the v1 boundary; their full contract lives in a future SPEC revision.
+
+This document is the single source of truth for what Solid does. Reviewer agents cite this document by section number when judging an implementation. It contains no file names, no class names, no AST details — only what the developer sees and the guarantees they get.
+
+---
+
+## 1. Vision
+
+Solid is a Flutter code-generation layer that lets a developer put reactive state directly on widgets, the way SwiftUI allows reactive state directly on views. The developer writes an ordinary Flutter widget with annotated fields. Solid transforms the widget into a fine-grained reactive Flutter widget backed by `flutter_solidart` primitives (`Signal`, `Computed`, `SignalBuilder`). The result: when a piece of reactive state changes, only the widget subtree that actually reads it rebuilds. No ViewModel, no `setState`, no `ChangeNotifier`, no `notifyListeners`, no manual rebuild scopes.
+
+---
+
+## 2. Source / Generated Model
+
+The developer writes annotated code in a top-level directory called `source/`. Solid reads every `.dart` file under `source/` and emits a transformed `.dart` file at the mirrored path under `lib/`.
+
+Example:
+
+```
+source/counter.dart        ← developer writes (committed)
+lib/counter.dart           ← Solid emits (committed)
+```
+
+Rules:
+
+- **Input path**: any `.dart` file under `source/` at any depth.
+- **Output path**: same relative path under `lib/`. No suffix change. `source/foo/bar.dart` becomes `lib/foo/bar.dart`.
+- **Both are committed to git.** Source is the review artifact for intent. Lib is the review artifact for correctness — every PR that changes `source/` must include the regenerated `lib/` diff so reviewers catch generator regressions.
+- **No `.g.dart` files are emitted.** Neither under `source/` nor under `lib/`.
+- **The example app's `main.dart`** lives in `lib/` (or `source/` if itself annotated) and imports from `lib/` using normal Flutter imports (`import 'counter.dart';`).
+- **Source is analyzed** with a couple of lint suppressions (notably `must_be_immutable`) so that a `StatelessWidget` with a mutable `@SolidState` field does not trip the analyzer. Source remains valid Dart at all times; any real error (typo, type error, undefined symbol) fails analysis.
+- **Hot reload works normally.** `dart run build_runner watch` regenerates `lib/` as the developer edits `source/`; `flutter run` hot-reloads from `lib/`. This is the whole flow; there is no separate CLI. (Addresses issue #9.)
+
+---
+
+## 3. Annotations
+
+### 3.1 v1 scope: `@SolidState`
+
+`@SolidState` declares a reactive property on a class. It attaches to either a field or a getter.
+
+```dart
+@SolidState()
+int counter = 0;
+
+@SolidState()
+int get doubleCounter => counter * 2;
+```
+
+Optional `name:` parameter overrides the auto-derived debug name:
+
+```dart
+@SolidState(name: 'myCounter')
+int counter = 0;
+```
+
+#### Valid targets
+
+- Instance field with or without an initializer.
+- Instance getter with an expression body (`=> ...`) or a block body (`{ return ...; }`).
+
+#### Invalid targets (the generator must reject with a clear error)
+
+- `final` field (a `Signal` wrapping a never-reassigned value is a static constant — pointless).
+- `const` field (same reason plus a type-system impossibility).
+- `static` field or getter (class-level, not instance; out of v1 scope).
+- Top-level variable or getter.
+- Method (not a getter).
+- Setter.
+
+### 3.2 Out of v1 scope
+
+The following annotations are defined by the blog-post vision but are NOT implemented in v1. If the developer uses them, the generator must fail with a clear error that names the annotation and says "not implemented in v1."
+
+- `@SolidEffect()` — reactive side effect (method)
+- `@SolidQuery({Duration? debounce, bool? useRefreshing})` — async reactive source (method)
+- `@SolidEnvironment()` — dependency injection (field)
+
+### 3.3 Permanent non-goals
+
+Solid will never:
+
+- Replace `flutter_solidart`. Signal / Computed / Effect / Resource / SignalBuilder come from the upstream package.
+- Ship its own reactive runtime.
+- Use Dart Macros, Dart augmentations, or part-file patterns.
+- Support multi-file generation (one source file → one lib file).
+
+---
+
+## 4. Transformation Rules
+
+Each rule shows an exact before-and-after.
+
+### 4.1 Field → Signal
+
+Input:
+
+```dart
+class Counter extends StatelessWidget {
+  Counter({super.key});
+
+  @SolidState()
+  int counter = 0;
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}
+```
+
+Output (excerpt, see §8 for the full class transform):
+
+```dart
+final counter = Signal<int>(0, name: 'counter');
+```
+
+Rules:
+
+- Declared type of the field → type argument of `Signal`.
+- Initializer expression → first positional argument of `Signal`.
+- Field name → `name:` argument, unless `@SolidState(name: '…')` overrides.
+
+### 4.2 Field with no initializer
+
+Input:
+
+```dart
+@SolidState()
+String text;
+```
+
+Output:
+
+```dart
+final text = Signal<String>('', name: 'text');
+```
+
+Default values by declared type:
+
+- `int` → `0`
+- `double` → `0.0`
+- `num` → `0`
+- `String` → `''`
+- `bool` → `false`
+- `T?` (any nullable type) → `null`
+- `List<E>` → `<E>[]`
+- `Map<K, V>` → `<K, V>{}`
+- `Set<E>` → `<E>{}`
+- Any other non-nullable type → **generator rejects with a clear error** ("field `foo` of type `MyType` has no initializer and no default is known; add `= MyType(...)` or declare `MyType?`").
+
+### 4.3 Nullable field
+
+Input:
+
+```dart
+@SolidState()
+int? value;
+```
+
+Output:
+
+```dart
+final value = Signal<int?>(null, name: 'value');
+```
+
+### 4.4 Custom name
+
+Input:
+
+```dart
+@SolidState(name: 'myCounter')
+int counter = 0;
+```
+
+Output:
+
+```dart
+final counter = Signal<int>(0, name: 'myCounter');
+```
+
+### 4.5 Getter → Computed (no dependencies on other reactive state)
+
+Input:
+
+```dart
+@SolidState()
+String get label => 'hello';
+```
+
+Output:
+
+```dart
+final label = Computed<String>(() => 'hello', name: 'label');
+```
+
+Rule: when the getter body does not read any reactive identifier defined on the same class, the field is declared `final` (not `late final`).
+
+### 4.6 Getter → Computed (with dependencies)
+
+Input:
+
+```dart
+@SolidState()
+int counter = 0;
+
+@SolidState()
+int get doubleCounter => counter * 2;
+```
+
+Output:
+
+```dart
+final counter = Signal<int>(0, name: 'counter');
+late final doubleCounter = Computed<int>(() => counter.value * 2, name: 'doubleCounter');
+```
+
+Rules:
+
+- Identifiers in the body that match other reactive declarations on the same class are rewritten with `.value` (see §5).
+- The resulting `Computed` field is declared `late final` (not `final`), because it references other `final` instance fields whose initialization order is not guaranteed.
+
+### 4.7 Getter with block body
+
+Input:
+
+```dart
+@SolidState()
+String get summary {
+  final c = counter;
+  return 'count is $c';
+}
+```
+
+Output:
+
+```dart
+late final summary = Computed<String>(() {
+  final c = counter.value;
+  return 'count is $c';
+}, name: 'summary');
+```
+
+The block is copied verbatim into a function expression with reactive-read rewriting applied.
+
+---
+
+## 5. Reactive-Read Rules
+
+When a generated piece of code (anything under `lib/`) references a name that was declared reactive in the source, the reference is rewritten to read through the reactive primitive.
+
+### 5.1 Identifier rewrite
+
+Every bare `SimpleIdentifier` whose name matches a `@SolidState` field or getter on the enclosing class is rewritten to `<name>.value`.
+
+Source:
+
+```dart
+Text(counter.toString())
+```
+
+Output (inside a SignalBuilder — see §7):
+
+```dart
+Text(counter.value.toString())
+```
+
+### 5.2 String interpolation rewrite
+
+Inside string interpolation, `$name` (implicit `.toString()` call) becomes `${name.value}`.
+
+Source:
+
+```dart
+Text('Counter is $counter')
+```
+
+Output:
+
+```dart
+Text('Counter is ${counter.value}')
+```
+
+Already-qualified `${counter.value}` in source stays as-is (no double-append).
+
+### 5.3 Compound assignment rewrite
+
+Source:
+
+```dart
+onPressed: () => counter++
+onPressed: () { counter = counter + 1; }
+onPressed: () { counter += 5; }
+```
+
+Output (see §6 for why these are not wrapped in SignalBuilder):
+
+```dart
+onPressed: () => counter.value++
+onPressed: () { counter.value = counter.value + 1; }
+onPressed: () { counter.value += 5; }
+```
+
+Supported operators: `=`, `+=`, `-=`, `*=`, `/=`, `~/=`, `%=`, `??=`, `<<=`, `>>=`, `|=`, `&=`, `^=`, `++` (prefix/postfix), `--` (prefix/postfix).
+
+### 5.4 Double-append protection
+
+If the source already has `name.value`, the generator must NOT rewrite it to `name.value.value`. The rewriter is idempotent.
+
+### 5.5 Shadowing
+
+If a local variable or parameter inside a function shadows a reactive-field name, the generator does NOT rewrite the shadowed use.
+
+Source:
+
+```dart
+@SolidState() int counter = 0;
+
+Widget build(BuildContext context) {
+  return Builder(builder: (context) {
+    final counter = 'local'; // shadows the field
+    return Text(counter);     // stays as `counter`, not `counter.value`
+  });
+}
+```
+
+Output: the inner `counter` stays untouched. (The outer field reference remains reactive if present.)
+
+This is determined by analyzer scope resolution, not by name alone. v1 implementation may use a name-set heuristic because v1 scope is simple — but the SPEC contract is scope-aware; v2 tests must include a shadowing case and it must pass.
+
+---
+
+## 6. Untracked-Context Rules
+
+A read is **tracked** if the widget subtree that contains it must rebuild when the signal changes. A read is **untracked** if the expression reads the current value but must NOT cause its enclosing widget subtree to subscribe.
+
+Untracked reads still get `.value` appended (so they typecheck). They just do NOT trigger `SignalBuilder` wrapping of their parent widget subtree (§7). This fixes issues #4 and #6.
+
+### 6.1 Callbacks on widget constructors
+
+A read is untracked when the identifier appears inside a function expression that is the value of a named argument to a widget constructor and that named argument is a user-interaction callback.
+
+Callback parameter names treated as untracked:
+
+- `onPressed`, `onTap`, `onLongPress`, `onDoubleTap`
+- `onChanged`, `onSubmitted`, `onEditingComplete`, `onFieldSubmitted`, `onSaved`
+- `onHorizontalDragUpdate`, `onVerticalDragUpdate`, `onPanUpdate`, `onScaleUpdate` (and their `Start`/`End`/`Cancel`/`Down` variants)
+- `onHover`, `onExit`, `onEnter`, `onFocusChange`
+- `onDismissed`, `onClosing`, `onAccept`, `onWillAccept`, `onLeave`, `onMove`
+- Future reviewers may add to this list. The list is maintained in this SPEC.
+
+Source:
+
+```dart
+FloatingActionButton(
+  onPressed: () => counter++,
+  child: const Icon(Icons.add),
+)
+```
+
+Output:
+
+```dart
+FloatingActionButton(
+  onPressed: () => counter.value++,  // `.value` appended
+  child: const Icon(Icons.add),
+)
+// NOT wrapped in SignalBuilder
+```
+
+### 6.2 Key constructor arguments
+
+A read is untracked when the identifier appears inside an `InstanceCreationExpression` whose constructor is `ValueKey`, `Key`, `ObjectKey`, `UniqueKey`, `GlobalKey`, `GlobalObjectKey`, or `PageStorageKey`, and that expression is passed to the `key:` parameter of a widget.
+
+Source:
+
+```dart
+Container(
+  key: ValueKey(counter),
+  child: const Text('hi'),
+)
+```
+
+Output:
+
+```dart
+Container(
+  key: ValueKey(counter.value),
+  child: const Text('hi'),
+)
+// NOT wrapped in SignalBuilder
+```
+
+### 6.3 Everything else is tracked
+
+If an identifier is neither under an untracked callback nor under a Key constructor, it is tracked. The containing widget subtree must be wrapped in `SignalBuilder` (§7).
+
+### 6.4 Nested cases
+
+Tracking is determined by the innermost enclosing AST ancestor that matches a rule. A `Text(counter)` inside an `onPressed` callback is untracked. A `Text(counter)` outside any callback is tracked.
+
+---
+
+## 7. SignalBuilder Placement Rules
+
+`SignalBuilder` is the wrapper from `flutter_solidart` that subscribes to signals read inside its builder callback and rebuilds only the enclosed subtree.
+
+### 7.1 Where to wrap
+
+A widget subtree needs `SignalBuilder` wrapping if and only if all three hold:
+
+1. The subtree is a widget expression (an `InstanceCreationExpression` that constructs a widget, or a reference to one) used as the return value of the `build` method, or as the value of a child/children parameter of another widget.
+2. The subtree contains at least one **tracked** reactive read (§6.3).
+3. The subtree is not already inside a `SignalBuilder`.
+
+### 7.2 Minimal-subtree rule (fine-grained)
+
+When multiple candidate subtrees in a build tree contain tracked reactive reads, wrap the **smallest** subtree for each independent read. "Smallest" is defined by the widget-subtree hierarchy: if the tracked read appears inside a `Text('$counter')`, wrap that `Text`, not its `Column` ancestor.
+
+The practical consequence, illustrated by the canonical counter:
+
+```dart
+Scaffold(
+  body: Center(
+    child: Text('Counter is $counter'),   // ← ONLY this Text is wrapped
+  ),
+  floatingActionButton: FloatingActionButton(
+    onPressed: () => counter++,           // untracked, no wrap
+    child: const Icon(Icons.add),
+  ),
+)
+```
+
+Output:
+
+```dart
+Scaffold(
+  body: Center(
+    child: SignalBuilder(
+      builder: (context, child) {
+        return Text('Counter is ${counter.value}');
+      },
+    ),
+  ),
+  floatingActionButton: FloatingActionButton(
+    onPressed: () => counter.value++,
+    child: const Icon(Icons.add),
+  ),
+)
+```
+
+### 7.3 Already-inside-SignalBuilder rule
+
+If a developer has manually written `SignalBuilder(...)` in source (rare but legal), the generator does NOT add a second wrapper.
+
+### 7.4 Multiple independent tracked reads
+
+If two sibling widgets each contain a tracked read of a different signal, each is wrapped in its own `SignalBuilder`. Siblings do not share wrappers.
+
+### 7.5 Nested tracked reads
+
+If an outer widget and an inner widget both contain tracked reads, only the inner widget is wrapped. The outer widget relies on the inner `SignalBuilder` to trigger the rebuild of its subtree. This is the "only the leaf rebuilds" guarantee.
+
+---
+
+## 8. Class-Kind Handling
+
+`@SolidState` can appear on classes of four kinds. Each is transformed differently. If a class has no `@SolidState` annotations, it passes through unchanged.
+
+### 8.1 StatelessWidget with ≥1 `@SolidState`
+
+The class is rewritten as a `StatefulWidget` + `State<X>` pair. All reactive fields, getters, and generated `SignalBuilder`-wrapped build output live on the State. The public widget keeps its original constructor and key forwarding.
+
+Source:
+
+```dart
+class Counter extends StatelessWidget {
+  Counter({super.key});
+
+  @SolidState()
+  int counter = 0;
+
+  @override
+  Widget build(BuildContext context) => Text('$counter');
+}
+```
+
+Output:
+
+```dart
+class Counter extends StatefulWidget {
+  const Counter({super.key});
+
+  @override
+  State<Counter> createState() => _CounterState();
+}
+
+class _CounterState extends State<Counter> {
+  final counter = Signal<int>(0, name: 'counter');
+
+  @override
+  void dispose() {
+    counter.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SignalBuilder(
+      builder: (context, child) {
+        return Text('${counter.value}');
+      },
+    );
+  }
+}
+```
+
+The public constructor gains `const` where safe (all fields final and literal).
+
+### 8.2 StatefulWidget with `@SolidState` on its State
+
+No class rewriting. Reactive declarations and build rewriting happen in-place on the existing State class. This is the fix for issue #3.
+
+### 8.3 Plain class (no Widget superclass) with `@SolidState`
+
+Reactive declarations are applied in-place. A `dispose()` method is synthesized that disposes every generated Signal/Computed. No State wrapper.
+
+Source:
+
+```dart
+class Counter {
+  @SolidState()
+  int value = 0;
+}
+```
+
+Output:
+
+```dart
+class Counter {
+  final value = Signal<int>(0, name: 'value');
+
+  void dispose() {
+    value.dispose();
+  }
+}
+```
+
+If the developer has already declared a `dispose()` method, the generator merges: the generated disposal calls are prepended to the existing body, then `super.dispose()` is called only if the class `extends` a class that has its own `dispose()` (heuristic: if the source class extends anything other than `Object`, emit `super.dispose()` at the end; otherwise omit).
+
+### 8.4 StatelessWidget with zero `@SolidState` annotations
+
+Passes through unchanged to `lib/`.
+
+---
+
+## 9. Import Rules
+
+The generated `lib/` file's imports are computed from the source's imports plus what the generator added:
+
+- Remove any `import 'package:solid_annotations/solid_annotations.dart';` — the generated code never uses it.
+- Add `import 'package:flutter_solidart/flutter_solidart.dart';` if the generated output references any of: `Signal`, `Computed`, `Effect`, `Resource`, `SignalBuilder`, `SolidartConfig`. (Effect and Resource appear in future scope; they are listed here so the rule is future-proof.)
+- Every other import in the source is preserved verbatim, including aliases and `show`/`hide` combinators.
+
+This is the fix for issue #8.
+
+---
+
+## 10. `dispose()` Contract
+
+Every generated `Signal` and `Computed` must be disposed when its owning class is disposed.
+
+- On a StatefulWidget's State (§8.1): the generator emits a `dispose()` override that calls `xxx.dispose()` for each reactive declaration in declaration order, then `super.dispose()`.
+- On an existing State (§8.2): if the developer wrote a `dispose()`, the generator inserts the reactive disposals at the top, preserves the rest, and keeps the existing `super.dispose()` call. If no `dispose()` existed, the generator emits one.
+- On a plain class (§8.3): `void dispose()` is synthesized per §8.3 merging rules.
+
+Disposal order: declaration order. A `Computed` that depends on a `Signal` is disposed before the `Signal` it depends on (declarations are emitted in source order, so Signal comes first; dispose in the same order, so Computed depending on Signal is disposed before Signal if declared before — matches the rule since Computed always follows its dependencies in source).
+
+---
+
+## 11. File Layout on Disk
+
+A consumer app using Solid looks like this:
+
+```
+my_app/
+  source/
+    main.dart             ← annotated; committed
+    counter.dart          ← annotated; committed
+  lib/
+    main.dart             ← generated; committed
+    counter.dart          ← generated; committed
+  analysis_options.yaml   ← lint suppressions for source
+  pubspec.yaml
+  .gitignore              ← excludes .dart_tool/, build/
+```
+
+The `source/` tree mirrors `lib/` one-to-one. Every `.dart` file under `source/` has a counterpart under `lib/`; nothing else.
+
+No `.g.dart` files are emitted anywhere visible to the developer. (Test golden outputs inside the generator package may use `.g.dart` for clarity; that is an internal convention, not a user-facing one.)
+
+---
+
+## 12. Hot Reload Contract
+
+Running the generator in watch mode alongside Flutter:
+
+```bash
+# terminal 1
+dart run build_runner watch
+
+# terminal 2
+flutter run
+```
+
+When the developer saves a file under `source/`, the generator rewrites the corresponding file under `lib/`, and Flutter's file watcher picks up the `lib/` change and hot-reloads. The developer saves once. (Fixes issue #9.)
+
+---
+
+## 13. Out of Scope for v1
+
+- `@SolidEffect`
+- `@SolidQuery` (Future and Stream forms; `.when`, `.maybeWhen`, `.refresh`, `.isRefreshing`; debounce; useRefreshing)
+- `@SolidEnvironment`
+- `SolidProvider` / `InheritedSolidProvider` / `.environment()` widget extension / `context.read` / `context.watch`
+- Multi-file generation (one source file produces two or more lib files)
+- Dart Macros / augmentations / part-file patterns
+- CI workflow (local test only until Actions budget permits)
+
+A v1 build that encounters any of these in source code must fail with a clear error naming the unsupported feature.
+
+---
+
+## 14. Open Questions for the Developer
+
+These are marked for explicit resolution before M1 implementation begins. Default answers are provided; the developer confirms or overrides.
+
+1. **Plain (non-Widget) classes with `@SolidState` fields** — the blog post shows a `Counter` PODO passed via `SolidProvider.create`. SPEC default: support them per §8.3. **Confirm: yes/no.**
+2. **`++`, `+=`, and other compound-assignment operators on fields** — SPEC default: rewrite all operators listed in §5.3. **Confirm the operator list is complete.**
+3. **`@SolidState` on `final` fields** — SPEC default: reject with a clear error (pointless). **Confirm.**
+4. **Custom `initState` / `didUpdateWidget` overrides in an existing State class (§8.2)** — SPEC default: preserve them untouched; insert reactive disposals into the existing `dispose()` only. **Confirm.**
+5. **User-facing package name** — current choice is to keep `solid_annotations` as the import root and add an umbrella `package:solid/solid.dart` that re-exports the annotations plus a pre-curated subset of `flutter_solidart` symbols. **Confirm name or rename.**
+6. **Shadowing rule (§5.5)** — SPEC says scope-aware; v1 implementation may use a name-set heuristic because the v1 scope is simple. **Confirm it's acceptable if v1 does not fully implement scope-aware shadowing, provided there is a test case that fails correctly when shadowing is added later.**
+7. **`const` on the public widget constructor (§8.1)** — SPEC default: add `const` when all fields and default values are `const`-compatible. **Confirm.**
+
+---
+
+## 15. Verification
+
+Any change that alters user-observable behavior must be covered by a golden test (paired `inputs/*.dart` + `outputs/*.g.dart` files under the generator's test harness) AND a widget test on the example app (`flutter test`). The reviewer agent's rubric (defined separately in the plan, not here) uses this SPEC as the behavioral contract.
+
+---
+
+## 16. Issue References
+
+This SPEC addresses the following real user-reported issues from the v1 repo:
+
+- **#3** — `@SolidEnvironment` inside an existing `State<X>` was not transformed; the class-kind handling in §8.2 makes this impossible to regress.
+- **#4** — untracked reads (`ValueKey`, `onPressed`) were wrapped in `SignalBuilder`, breaking compilation; §6 defines the untracked-context rules.
+- **#6** — `Text(text)` did not receive `.value` because the rewriter missed bare identifier reads; §5.1 defines the rewrite rule exhaustively.
+- **#8** — generated `main.dart` used `SolidartConfig` without importing `flutter_solidart`; §9 defines the import-addition rule.
+- **#9** — hot reload required a double-save; §12 defines the expected single-save flow via `build_runner watch` + `flutter run`.
+
+Issue #11 (build speed) and issue #1 (docs typo) are process concerns addressed outside this SPEC.

--- a/SPEC.md
+++ b/SPEC.md
@@ -145,7 +145,7 @@ late final text = Signal<String>('', name: 'text');
 Rules:
 
 - The generator preserves the `late` keyword — valid Dart that defers `Signal` construction until first access.
-- Nullable fields (§4.3) do not require `late` because `null` is a valid default.
+- Nullable fields (Section 4.3) do not require `late` because `null` is a valid default.
 
 Default values by declared type:
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -699,7 +699,7 @@ These were open questions during SPEC drafting and have been answered by the dev
 2. **Compound-assignment operator list in Section 5.3** — complete.
 3. **`@SolidState` on `final` fields** — rejected with a clear error (wrapping a never-reassigned value in a `Signal` is pointless).
 4. **Custom `initState` / `didUpdateWidget` overrides in an existing State class (Section 8.2)** — preserved untouched. If an existing `dispose()` is present, reactive disposals are merged into its body.
-5. **User-facing package name** — keep the current layout: `package:solid_annotations` holds the annotations and `package:solid` is the umbrella package that re-exports the annotations plus the curated subset of `flutter_solidart` symbols Solid programs need.
+5. **User-facing packages** — two packages. `package:solid_annotations` (runtime dep) hosts the annotation classes (`@SolidState` today; `@SolidEffect`/`@SolidQuery`/`@SolidEnvironment` in later milestones). `package:solid_generator` (dev_dep) hosts the build_runner builder. There is no `package:solid` umbrella. Consumers add `solid_annotations` + `flutter_solidart` as runtime deps and `solid_generator` + `build_runner` as dev_deps, then import annotations and `flutter_solidart` primitives directly.
 6. **Shadowing rule (Section 5.5)** — handled by type resolution. Because Section 5.1 is type-driven, a shadowed local of a non-`SignalBase` type is never rewritten. A dedicated shadowing test case is required in M1.
 7. **`const` on the public widget constructor (Section 8.1)** — added when all fields and default values are `const`-compatible.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -30,12 +30,12 @@ Rules:
 
 - **Input path**: any `.dart` file under `source/` at any depth.
 - **Output path**: same relative path under `lib/`. No suffix change. `source/foo/bar.dart` becomes `lib/foo/bar.dart`.
-- **Non-Dart files are copied verbatim.** Any non-`.dart` file under `source/` is copied byte-for-byte to the mirrored path under `lib/` with no transformation. Only `.dart` files go through the generator.
+- **Transformation vs verbatim copy.** Solid reads every `.dart` file under `source/`. If a file contains at least one `@Solid*` annotation (`@SolidState` today; `@SolidEffect`, `@SolidQuery`, `@SolidEnvironment` in later milestones), Solid transforms it. Otherwise the file is copied verbatim to the mirrored path under `lib/`. Non-`.dart` files (assets, configs, etc.) are always copied verbatim. The key is annotation presence, not file extension.
 - **Both are committed to git.** Source is the review artifact for intent. Lib is the review artifact for correctness — every PR that changes `source/` must include the regenerated `lib/` diff so reviewers catch generator regressions.
-- **No `.g.dart` files are emitted.** Neither under `source/` nor under `lib/`.
+- **Solid emits no `.g.dart` files of its own.** Third-party generators (freezed, json_serializable, drift) may emit `.g.dart` or `.freezed.dart` files under `source/`; Solid copies those verbatim to the mirrored path under `lib/`.
 - **The example app's `main.dart`** lives in `lib/` (or `source/` if itself annotated) and imports from `lib/` using normal Flutter imports (`import 'counter.dart';`).
 - **Source is analyzed** with a couple of lint suppressions (notably `must_be_immutable`) so that a `StatelessWidget` with a mutable `@SolidState` field does not trip the analyzer. Source remains valid Dart at all times; any real error (typo, type error, undefined symbol) fails analysis.
-- **Hot reload works normally.** `dart run build_runner watch` regenerates `lib/` as the developer edits `source/`; `flutter run` hot-reloads from `lib/`. This is the whole flow; there is no separate CLI.
+- **Hot reload requires a bridge.** `dart run build_runner watch` regenerates `lib/` as the developer edits `source/`, but `flutter run` does not auto-detect that filesystem change because no IDE save event fires. The developer must either press `r` in the `flutter run` terminal after build_runner emits, or use `dashmon` (https://pub.dev/packages/dashmon) to bridge the filesystem change to Flutter's stdin automatically. See Section 12 for the full workflow.
 
 ---
 
@@ -64,7 +64,7 @@ int counter = 0;
 
 #### Valid targets
 
-- Instance field with or without an initializer.
+- Instance field with an initializer, or a `late` non-nullable field without one; nullable fields need neither.
 - Instance getter with an expression body (`=> ...`) or a block body (`{ return ...; }`).
 
 #### Invalid targets (the generator must reject with a clear error)
@@ -127,13 +127,13 @@ Rules:
 - Initializer expression → first positional argument of `Signal`.
 - Field name → `name:` argument, unless `@SolidState(name: '…')` overrides.
 
-### 4.2 Field with no initializer
+### 4.2 Field with no initializer (must be declared `late`)
 
 Input:
 
 ```dart
 @SolidState()
-String text;
+late String text;
 ```
 
 Output:
@@ -141,6 +141,11 @@ Output:
 ```dart
 final text = Signal<String>('', name: 'text');
 ```
+
+Rules:
+
+- The generator drops the `late` keyword; generated signals are always `final`.
+- Nullable fields (§4.3) do not require `late` because `null` is a valid default.
 
 Default values by declared type:
 
@@ -206,8 +211,9 @@ late final doubleCounter = Computed<int>(() => counter.value * 2, name: 'doubleC
 
 Rules:
 
-- The getter body MUST read at least one reactive declaration (a `@SolidState` field or another `@SolidState` getter) on the same class. A `Computed` with zero reactive dependencies is a plain constant and is rejected by the generator with: *"getter `<name>` has no reactive dependencies; use `final` or a plain getter instead of `@SolidState`."*
-- Identifiers in the body that resolve to reactive declarations on the same class are rewritten with `.value` (see Section 5).
+- The getter body MUST read at least one reactive declaration — any identifier whose resolved static type is `SignalBase<T>` or a subtype. A `Computed` with zero reactive dependencies is rejected: *"getter `<name>` has no reactive dependencies; use `final` or a plain getter instead of `@SolidState`."*
+- In M1 the only source of such a declaration is a `@SolidState` field or getter on the same class. Later milestones add cross-class declarations via `@SolidEnvironment` (Section 13); the rule is stated in terms of resolved type so no SPEC change is required when they land.
+- Identifiers in the body that resolve to reactive declarations are rewritten with `.value` (see Section 5).
 - The resulting `Computed` field is always declared `late final`, because it references other `final` instance fields whose initialization order is not guaranteed.
 
 ### 4.6 Getter with block body
@@ -437,6 +443,16 @@ If a read is not in one of the contexts defined in Sections 6.2, 6.3, or 6.4, it
 
 Tracking is determined by the innermost enclosing AST ancestor that matches a rule. A `Text(counter)` inside an `onPressed` callback is untracked. A `Text(counter)` outside any callback is tracked.
 
+Closures passed to non-user-interaction parameters (e.g., `Builder(builder: ...)`, `LayoutBuilder(builder: ...)`, `ListView.builder(itemBuilder: ...)`) do not create an untracked context. Reads inside those closures are tracked and trigger `SignalBuilder` wrapping per Section 7. Only the parameter names enumerated in Section 6.2 mark reads as untracked.
+
+Example:
+
+```dart
+Builder(builder: (context) => Text(counter))
+```
+
+Output wraps the `Text` in a `SignalBuilder` (see Section 7). `Builder`'s `builder:` is not on the Section 6.2 list.
+
 ---
 
 ## 7. SignalBuilder Placement Rules
@@ -584,7 +600,7 @@ class Counter {
 }
 ```
 
-If the developer has already declared a `dispose()` method, the generator merges: the generated disposal calls are prepended to the existing body, then `super.dispose()` is called only if the class `extends` a class that has its own `dispose()` (heuristic: if the source class extends anything other than `Object`, emit `super.dispose()` at the end; otherwise omit).
+If the developer has already declared a `dispose()` method, the generator merges: the generated disposal calls are prepended to the existing body, then `super.dispose()` is emitted if and only if the class's supertype chain contains a `dispose()` method (e.g., `State<T>`, `ChangeNotifier`). The generator determines this via the analyzer's type resolution, not by name matching. For a plain class with no `dispose()` in the supertype chain, `super.dispose()` is omitted.
 
 ### 8.4 StatelessWidget with zero `@SolidState` annotations
 
@@ -608,7 +624,7 @@ This is the fix for issue #8.
 
 Every generated `Signal` and `Computed` must be disposed when its owning class is disposed. The merging algorithm below applies identically to every class kind; the per-kind sections (8.1–8.3) describe how the algorithm is triggered.
 
-Algorithm: if the target class already has a `dispose()` body, prepend one `xxx.dispose()` call per reactive declaration to the top of the body and leave the rest untouched; if no `dispose()` exists, synthesize one. Emit `super.dispose()` at the end when the class extends anything other than `Object`.
+Algorithm: if the target class already has a `dispose()` body, prepend one `xxx.dispose()` call per reactive declaration to the top of the body and leave the rest untouched; if no `dispose()` exists, synthesize one. Emit `super.dispose()` at the end if and only if the class's supertype chain contains a `dispose()` method (e.g., `State<T>`, `ChangeNotifier`); the generator determines this via the analyzer's type resolution, not by name matching. For a plain class with no `dispose()` in the supertype chain, omit `super.dispose()`.
 
 Disposal order is **reverse declaration order**: dependents are disposed before their dependencies. Because a `Computed` must always be declared after the `Signal`s it reads (those `Signal`s are the `Computed`'s dependencies), reverse declaration order guarantees the `Computed` is disposed first and a `Signal` is never disposed while a live `Computed` still holds a subscription to it.
 
@@ -631,25 +647,30 @@ my_app/
   .gitignore              ← excludes .dart_tool/, build/
 ```
 
-The `source/` tree mirrors `lib/` one-to-one. Every file under `source/` has a counterpart at the mirrored path under `lib/` (`.dart` files transformed per Sections 4–10; non-`.dart` files copied verbatim per Section 2).
+The `source/` tree mirrors `lib/` one-to-one. Every file under `source/` has a counterpart at the mirrored path under `lib/` (`.dart` files with `@Solid*` annotations transformed per Sections 4–10; all other files copied verbatim per Section 2).
 
-No `.g.dart` files are emitted anywhere visible to the developer. (Test golden outputs inside the generator package may use `.g.dart` for clarity; that is an internal convention, not a user-facing one.)
+Third-party code generators (freezed, json_serializable, drift, etc.) may emit `.g.dart` or `.freezed.dart` files under `source/`. Solid copies those files verbatim to the mirrored path under `lib/`. Solid itself emits only plain `.dart` filenames — no `.g.dart` suffix for Solid's own output. (Test golden outputs inside Solid's generator package may use `.g.dart` for clarity; that is an internal convention.)
 
 ---
 
 ## 12. Hot Reload Contract
 
-Running the generator in watch mode alongside Flutter:
+`dart run build_runner watch` regenerates `lib/foo.dart` when `source/foo.dart` changes. However, `flutter run` does NOT auto-detect that change: Flutter hot-reload is triggered by IDE save events, not by filesystem changes. When build_runner emits a new file, no IDE save event fires, so Flutter does not hot-reload on its own.
+
+Two supported workflows (both require `dart run build_runner watch` in one terminal):
 
 ```bash
-# terminal 1
+# terminal 1 (both options)
 dart run build_runner watch
 
-# terminal 2
-flutter run
+# Option A: manual reload
+flutter run    # press r after build_runner emits
+
+# Option B: dashmon (https://pub.dev/packages/dashmon)
+dart pub global run dashmon    # wraps flutter run, auto-reloads on lib/ change
 ```
 
-When the developer saves a file under `source/`, the generator rewrites the corresponding file under `lib/`, and Flutter's file watcher picks up the `lib/` change and hot-reloads. The developer saves once.
+With Option A the developer saves `source/`, waits for build_runner to emit, then presses `r`. With Option B `dashmon` watches `lib/` for filesystem changes and sends the `r` keystroke to Flutter automatically.
 
 ---
 
@@ -698,6 +719,6 @@ This SPEC addresses the following real user-reported issues from the v1 repo:
 - **#4** — untracked reads (`ValueKey`, `onPressed`) were wrapped in `SignalBuilder`, breaking compilation; Section 6 defines the untracked-context rules.
 - **#6** — `Text(text)` did not receive `.value` because the rewriter missed bare identifier reads; Section 5.1 defines the rewrite rule exhaustively.
 - **#8** — generated `main.dart` used `SolidartConfig` without importing `flutter_solidart`; Section 9 defines the import-addition rule.
-- **#9** — hot reload required a double-save; Section 12 defines the expected single-save flow via `build_runner watch` + `flutter run`.
+- **#9** — hot reload required a double-save; Section 12 defines the two supported workflows: manual `r` after build_runner emits, or `dashmon` to bridge filesystem changes to Flutter's stdin automatically.
 
 Issue #11 (build speed) and issue #1 (docs typo) are process concerns addressed outside this SPEC.

--- a/SPEC.md
+++ b/SPEC.md
@@ -139,12 +139,12 @@ late String text;
 Output:
 
 ```dart
-final text = Signal<String>('', name: 'text');
+late final text = Signal<String>('', name: 'text');
 ```
 
 Rules:
 
-- The generator drops the `late` keyword; generated signals are always `final`.
+- The generator preserves the `late` keyword — valid Dart that defers `Signal` construction until first access.
 - Nullable fields (§4.3) do not require `late` because `null` is a valid default.
 
 Default values by declared type:

--- a/TODOS.md
+++ b/TODOS.md
@@ -89,7 +89,7 @@ class SolidEnvironment { const SolidEnvironment(); }
 
 **Files to create/modify:**
 
-- `packages/solid_generator/pubspec.yaml` — deps on `analyzer`, `build`, `build_config`, `dart_style`, `solid_annotations` (path: `../solid_annotations`); dev_deps on `build_runner`, `build_test`, `test`.
+- `packages/solid_generator/pubspec.yaml` — deps on `analyzer: ^13.0.0`, `build: ^4.0.5`, `build_config: ^1.3.0`, `dart_style: ^3.1.8`, `solid_annotations` (path: `../solid_annotations`); dev_deps on `build_runner: ^2.14.0`, `build_test`, `test`.
 - `packages/solid_generator/build.yaml` — `build_extensions: {'^source/{{}}.dart': ['lib/{{}}.dart']}`, `build_to: source`, `auto_apply: dependents`, explicit `sources: [source/**, lib/**, pubspec.*, $package$]`.
 - `packages/solid_generator/lib/builder.dart` — `Builder solidBuilder(BuilderOptions opts)` factory that returns a no-op builder (reads input, writes it unchanged to the mapped output path).
 - `packages/solid_generator/test/.gitkeep`.
@@ -114,7 +114,7 @@ class SolidEnvironment { const SolidEnvironment(); }
 
 **Files to create/modify:**
 
-- `example/pubspec.yaml` — Flutter app deps on `solid_annotations` (path `../packages/solid_annotations`) and `flutter_solidart`; dev_deps on `solid_generator` (path `../packages/solid_generator`) and `build_runner`.
+- `example/pubspec.yaml` — Flutter app deps on `solid_annotations` (path `../packages/solid_annotations`) and `flutter_solidart: ^2.7.3`; dev_deps on `solid_generator` (path `../packages/solid_generator`) and `build_runner: ^2.14.0`.
 - `example/analysis_options.yaml` — `include: package:very_good_analysis/analysis_options.yaml`, lint suppressions: `must_be_immutable: ignore`, `always_put_required_named_parameters_first: ignore`, `invalid_annotation_target: ignore`.
 - `example/source/counter.dart` — hello-world stateful widget with no annotations (plain `Text('hello')`). Replaced by M1-05 golden source.
 - `example/lib/main.dart` — `void main() => runApp(MaterialApp(home: Counter()));` importing `counter.dart`. Hand-written; must survive `dart run build_runner build` because M0-03 is a no-op for files without annotations.

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,1290 @@
+# Solid v2 — Atomic TODO List
+
+This file is the committed, resume-safe task queue for the v2 rebuild. A fresh agent reading only a single TODO entry plus `SPEC.md` must be able to complete that item.
+
+**How to use:**
+
+1. Pick the lowest-numbered item whose `Status` is `TODO` and whose `Dependencies` are all `DONE`.
+2. Read the referenced `SPEC.md` sections.
+3. Implement per the item's `Acceptance` block.
+4. Update `Status: DONE` in this file when the reviewer approves (8-point rubric in `plans/features/reviewer-rubric.md`).
+5. Commit the status change alongside the implementation in one PR.
+
+**Status legend:** `TODO` (not started) · `DOING` (in progress) · `DONE` (reviewer-approved + merged) · `BLOCKED` (explain in item).
+
+**Conventions:**
+
+- Golden file naming: `m<milestone>_<zero-padded-index>_<snake_case>.dart` for inputs; the paired output uses the same stem with a `.g.dart` suffix (e.g. inputs `m1_03_nullable_int_field.dart` ↔ outputs `m1_03_nullable_int_field.g.dart`). The `.g.dart` suffix is a test-harness-only convention per SPEC Section 11; production `lib/` output from the builder is plain `.dart`.
+- SPEC references use the form `Section X.Y` (never `§X.Y`).
+- Paired golden files live under `packages/solid_generator/test/golden/inputs/` and `packages/solid_generator/test/golden/outputs/`. Only the test harness uses the `.g.dart` suffix; production `lib/` output is plain `.dart`.
+- Each TODO that introduces new generator behavior must ship paired golden files + an entry in `packages/solid_generator/test/integration/golden_test.dart`.
+
+---
+
+## M0 — Scaffolding
+
+### TODO M0-01 — Workspace pubspec + analyzer + gitignore
+
+**Goal:** Establish the workspace root so `dart pub get` succeeds.
+
+**SPEC references:** None (operational).
+
+**Files to create/modify:**
+
+- `pubspec.yaml` (workspace root): workspace declaration listing all four sub-packages (`packages/solid_annotations`, `packages/solid_generator`, `packages/solid`, `example`).
+- `analysis_options.yaml` (workspace root): `include: package:very_good_analysis/analysis_options.yaml`.
+- `.gitignore`: `.dart_tool/`, `.packages`, `build/`, `.flutter-plugins`, `.flutter-plugins-dependencies`. Do NOT ignore `source/**` or `lib/**`.
+
+**Acceptance:**
+
+- `dart pub get` at workspace root exits 0.
+- `git status` shows `.dart_tool/` is ignored.
+
+**Dependencies:** none.
+
+**Status:** TODO
+
+---
+
+### TODO M0-02 — `solid_annotations` package trimmed to M1
+
+**Goal:** Ship only the `@SolidState` annotation class; reserve the other names per SPEC Section 3.2.
+
+**SPEC references:** Section 3.1, Section 3.2.
+
+**Files to create/modify:**
+
+- `packages/solid_annotations/pubspec.yaml` — package name `solid_annotations`, no runtime deps.
+- `packages/solid_annotations/lib/solid_annotations.dart` — exports `src/annotations.dart`.
+- `packages/solid_annotations/lib/src/annotations.dart` — `class SolidState` with one named `name:` parameter (nullable String). Add placeholder classes `SolidEffect`, `SolidQuery`, `SolidEnvironment` with a `// M1: reserved name, no fields yet.` comment and no fields.
+
+**Expected API:**
+
+```dart
+class SolidState {
+  const SolidState({this.name});
+  final String? name;
+}
+class SolidEffect { const SolidEffect(); }
+class SolidQuery { const SolidQuery(); }
+class SolidEnvironment { const SolidEnvironment(); }
+```
+
+**Acceptance:**
+
+- `dart analyze packages/solid_annotations` → zero issues.
+- `dart test packages/solid_annotations` (empty suite) passes.
+
+**Dependencies:** M0-01.
+
+**Status:** TODO
+
+---
+
+### TODO M0-03 — `solid_generator` skeleton + build.yaml
+
+**Goal:** Empty builder wired into `build_runner` with the `source/ → lib/` mapping.
+
+**SPEC references:** Section 2, Section 11.
+
+**Files to create/modify:**
+
+- `packages/solid_generator/pubspec.yaml` — deps on `analyzer`, `build`, `build_config`, `dart_style`, `solid_annotations` (path: `../solid_annotations`); dev_deps on `build_runner`, `build_test`, `test`.
+- `packages/solid_generator/build.yaml` — `build_extensions: {'^source/{{}}.dart': ['lib/{{}}.dart']}`, `build_to: source`, `auto_apply: dependents`, explicit `sources: [source/**, lib/**, pubspec.*, $package$]`.
+- `packages/solid_generator/lib/builder.dart` — `Builder solidBuilder(BuilderOptions opts)` factory that returns a no-op builder (reads input, writes it unchanged to the mapped output path).
+- `packages/solid_generator/test/.gitkeep`.
+
+**Acceptance:**
+
+- `dart analyze packages/solid_generator` → zero issues.
+- `dart test packages/solid_generator` (empty suite) passes.
+- Running `dart run build_runner build` from `example/` (after M0-05) copies source files to lib verbatim.
+
+**Dependencies:** M0-01, M0-02.
+
+**Status:** TODO
+
+---
+
+### TODO M0-04 — `solid` umbrella package
+
+**Goal:** The user-facing import. Re-exports `solid_annotations` plus the subset of `flutter_solidart` symbols listed in SPEC Section 9.
+
+**SPEC references:** Section 9, Section 14 item 5.
+
+**Files to create/modify:**
+
+- `packages/solid/pubspec.yaml` — deps on `solid_annotations` (path: `../solid_annotations`) and `flutter_solidart`.
+- `packages/solid/lib/solid.dart` — re-exports `package:solid_annotations/solid_annotations.dart` and `package:flutter_solidart/flutter_solidart.dart` (full export; `untracked` is a top-level function that comes for free).
+
+**Acceptance:**
+
+- `dart analyze packages/solid` → zero issues.
+- An external Dart file that does `import 'package:solid/solid.dart';` can name `SolidState`, `Signal`, `Computed`, `SignalBuilder`, `untracked`.
+
+**Dependencies:** M0-02.
+
+**Status:** TODO
+
+---
+
+### TODO M0-05 — `example/` hello-world shell
+
+**Goal:** Minimal Flutter app with `source/counter.dart` (hand-written) and `lib/main.dart` (entry point). Used as both M0 smoke-test and M1-05 canonical golden.
+
+**SPEC references:** Section 2, Section 11, Section 12.
+
+**Files to create/modify:**
+
+- `example/pubspec.yaml` — Flutter app deps on `solid` (path `../packages/solid`), dev_dep on `solid_generator` (path `../packages/solid_generator`) and `build_runner`.
+- `example/analysis_options.yaml` — `include: package:very_good_analysis/analysis_options.yaml`, lint suppressions: `must_be_immutable: ignore`, `always_put_required_named_parameters_first: ignore`, `invalid_annotation_target: ignore`.
+- `example/source/counter.dart` — hello-world stateful widget with no annotations (plain `Text('hello')`). Replaced by M1-05 golden source.
+- `example/lib/main.dart` — `void main() => runApp(MaterialApp(home: Counter()));` importing `counter.dart`. Hand-written; must survive `dart run build_runner build` because M0-03 is a no-op for files without annotations.
+
+**Acceptance:**
+
+- `dart pub get` in `example/` succeeds.
+- `dart run build_runner build --delete-conflicting-outputs` in `example/` exits 0; `example/lib/counter.dart` is identical to `example/source/counter.dart`.
+- `flutter run -d chrome` (or any device) boots and shows "hello".
+
+**Dependencies:** M0-03, M0-04.
+
+**Status:** TODO
+
+---
+
+### TODO M0-06 — Integration test harness
+
+**Goal:** The `golden_test.dart` file that M1+ TODOs extend, even with zero cases registered.
+
+**SPEC references:** None (infrastructure).
+
+**Files to create/modify:**
+
+- `packages/solid_generator/test/integration/golden_test.dart` — iterates a `_goldenNames` list (empty in M0), reads `inputs/<name>.dart` + `outputs/<name>.g.dart`, runs `testBuilder(solidBuilder(BuilderOptions.empty), {'a|source/$name.dart': input}, outputs: {'a|lib/$name.dart': expected})`. Supports `UPDATE_GOLDENS=1` env var to rewrite outputs.
+- `packages/solid_generator/test/golden/inputs/.gitkeep`, `packages/solid_generator/test/golden/outputs/.gitkeep`.
+
+**Acceptance:**
+
+- `dart test packages/solid_generator/test/integration/golden_test.dart` passes with zero assertions.
+- Docs: helper function signature is stable so M1 TODOs only add names.
+
+**Dependencies:** M0-03.
+
+**Status:** TODO
+
+---
+
+## M1 — `@SolidState` on fields → `Signal`
+
+### TODO M1-01 — Golden: int field with initializer
+
+**Goal:** Canonical case — `@SolidState() int counter = 0;` on a `StatelessWidget` becomes a `Signal<int>(0, name: 'counter')` on a generated `State<Counter>`.
+
+**SPEC references:** Section 4.1, Section 8.1, Section 9, Section 10.
+
+**Files to create:**
+
+- `packages/solid_generator/test/golden/inputs/m1_01_int_field_with_initializer.dart`
+- `packages/solid_generator/test/golden/outputs/m1_01_int_field_with_initializer.g.dart`
+- entry in `packages/solid_generator/test/integration/golden_test.dart`
+
+**Expected input content:**
+
+```dart
+import 'package:solid/solid.dart';
+import 'package:flutter/widgets.dart';
+
+class Counter extends StatelessWidget {
+  Counter({super.key});
+
+  @SolidState()
+  int counter = 0;
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}
+```
+
+**Expected output content:**
+
+```dart
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class Counter extends StatefulWidget {
+  const Counter({super.key});
+
+  @override
+  State<Counter> createState() => _CounterState();
+}
+
+class _CounterState extends State<Counter> {
+  final counter = Signal<int>(0, name: 'counter');
+
+  @override
+  void dispose() {
+    counter.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}
+```
+
+**Expected implementation change:** First real builder pass. Needs:
+
+1. Parse AST via `package:analyzer`.
+2. Detect `@SolidState` on a class field.
+3. Class-kind dispatch (Section 8): StatelessWidget → split into StatefulWidget + State pair.
+4. Emit `final <name> = Signal<T>(<init>, name: '<name>');` per SPEC Section 4.1.
+5. Synthesize `dispose()` per SPEC Section 10.
+6. Adjust imports per SPEC Section 9.
+
+**Acceptance:**
+
+- `dart test --name=m1_01` passes.
+- `dart analyze packages/solid_generator/test/golden/outputs/m1_01_int_field_with_initializer.g.dart` → zero issues.
+- Reviewer rubric passes.
+
+**Dependencies:** M0-03, M0-06.
+
+**Status:** TODO
+
+---
+
+### TODO M1-02 — Golden: late non-nullable field
+
+**Goal:** `@SolidState() late String text;` becomes `late final text = Signal<String>('', name: 'text');`. Validates SPEC Section 4.2 default-value table + `late` preservation.
+
+**SPEC references:** Section 4.2, Section 3.1 (valid targets).
+
+**Files to create:**
+
+- `packages/solid_generator/test/golden/inputs/m1_02_late_string_no_initializer.dart`
+- `packages/solid_generator/test/golden/outputs/m1_02_late_string_no_initializer.g.dart`
+- entry in `packages/solid_generator/test/integration/golden_test.dart`
+
+**Expected input content:**
+
+```dart
+import 'package:solid/solid.dart';
+import 'package:flutter/widgets.dart';
+
+class Greeting extends StatelessWidget {
+  Greeting({super.key});
+
+  @SolidState()
+  late String text;
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}
+```
+
+**Expected output content:**
+
+```dart
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class Greeting extends StatefulWidget {
+  const Greeting({super.key});
+
+  @override
+  State<Greeting> createState() => _GreetingState();
+}
+
+class _GreetingState extends State<Greeting> {
+  late final text = Signal<String>('', name: 'text');
+
+  @override
+  void dispose() {
+    text.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}
+```
+
+**Expected implementation change:** Extend the field builder to look up default values from the Section 4.2 table when no initializer exists, and preserve the `late` keyword verbatim per SPEC Section 4.2.
+
+**Acceptance:**
+
+- `dart test --name=m1_02` passes.
+- `dart analyze` on the golden output → zero issues.
+
+**Dependencies:** M1-01.
+
+**Status:** TODO
+
+---
+
+### TODO M1-02b — Rejection: `late` field with unknown-default type
+
+**Goal:** A `late` non-nullable field whose declared type has no entry in the Section 4.2 defaults table is rejected with the SPEC's exact error string.
+
+**SPEC references:** Section 4.2 (last bullet in the defaults table).
+
+**Files to create:**
+
+- `packages/solid_generator/test/golden/inputs/m1_02b_late_unknown_type_rejected.dart`
+- `packages/solid_generator/test/rejections/m1_02b_late_unknown_type_test.dart` — asserts the builder raises an error with the exact SPEC quote: `"field 'foo' of type 'MyType' has no initializer and no default is known; add '= MyType(...)' or declare 'MyType?'"` (with `foo` and `MyType` substituted).
+
+**Expected input content:** A class with `@SolidState() late MyType foo;` where `MyType` is a user-defined class with no defaults-table entry.
+
+**Expected implementation change:** The default-value resolver (introduced in M1-02) returns a `Result.err` when the declared type does not match any defaults-table entry. The pipeline propagates the error with `foo` and the type name substituted.
+
+**Acceptance:** Rejection test passes; error message text matches the SPEC quote exactly (modulo the substituted identifier and type).
+
+**Dependencies:** M1-02.
+
+**Status:** TODO
+
+---
+
+### TODO M1-03 — Golden: nullable int field
+
+**Goal:** `@SolidState() int? value;` becomes `final value = Signal<int?>(null, name: 'value');`. No `late` because nullable fields have a `null` default.
+
+**SPEC references:** Section 4.3, Section 3.1 valid targets.
+
+**Files to create:**
+
+- `packages/solid_generator/test/golden/inputs/m1_03_nullable_int_field.dart`
+- `packages/solid_generator/test/golden/outputs/m1_03_nullable_int_field.g.dart`
+- entry in `packages/solid_generator/test/integration/golden_test.dart`
+
+**Expected input content:**
+
+```dart
+import 'package:solid/solid.dart';
+import 'package:flutter/widgets.dart';
+
+class Score extends StatelessWidget {
+  Score({super.key});
+
+  @SolidState()
+  int? value;
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}
+```
+
+**Expected output content:**
+
+```dart
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class Score extends StatefulWidget {
+  const Score({super.key});
+
+  @override
+  State<Score> createState() => _ScoreState();
+}
+
+class _ScoreState extends State<Score> {
+  final value = Signal<int?>(null, name: 'value');
+
+  @override
+  void dispose() {
+    value.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}
+```
+
+**Expected implementation change:** Extend the field builder to recognize the nullable branch (Section 4.3) and emit `null` as the default without the `late` keyword.
+
+**Acceptance:** `dart test --name=m1_03` passes; golden analyzes clean.
+
+**Dependencies:** M1-01.
+
+**Status:** TODO
+
+---
+
+### TODO M1-04 — Golden: custom `name:` parameter
+
+**Goal:** `@SolidState(name: 'myCounter') int counter = 0;` becomes `Signal<int>(0, name: 'myCounter')`.
+
+**SPEC references:** Section 3.1, Section 4.4.
+
+**Files to create:**
+
+- `packages/solid_generator/test/golden/inputs/m1_04_custom_name_parameter.dart`
+- `packages/solid_generator/test/golden/outputs/m1_04_custom_name_parameter.g.dart`
+- entry in `golden_test.dart`
+
+**Expected implementation change:** Extend the annotation parser to read the `name:` parameter from the annotation's argument list and thread it into the emitted `Signal(..., name: '<x>')` call.
+
+**Acceptance:** `dart test --name=m1_04` passes; golden analyzes clean.
+
+**Dependencies:** M1-01.
+
+**Status:** TODO
+
+---
+
+### TODO M1-05 — Golden: blog-post canonical counter
+
+**Goal:** End-to-end: blog-post Counter source transforms to a working counter widget with FAB write and Text read.
+
+**SPEC references:** Section 4.1, Section 5.2 (interpolation), Section 5.3 (compound assignment), Section 6.0, Section 6.2 (onPressed), Section 7 (SignalBuilder placement), Section 8.1.
+
+**Files to create:**
+
+- `packages/solid_generator/test/golden/inputs/m1_05_counter_stateless_full.dart`
+- `packages/solid_generator/test/golden/outputs/m1_05_counter_stateless_full.g.dart`
+- entry in `golden_test.dart`
+
+**Expected input content:**
+
+```dart
+import 'package:solid/solid.dart';
+import 'package:flutter/material.dart';
+
+class CounterPage extends StatelessWidget {
+  CounterPage({super.key});
+
+  @SolidState()
+  int counter = 0;
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+    body: Center(child: Text('Counter is $counter')),
+    floatingActionButton: FloatingActionButton(
+      onPressed: () => counter++,
+      child: const Icon(Icons.add),
+    ),
+  );
+}
+```
+
+**Expected output content:**
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class CounterPage extends StatefulWidget {
+  const CounterPage({super.key});
+
+  @override
+  State<CounterPage> createState() => _CounterPageState();
+}
+
+class _CounterPageState extends State<CounterPage> {
+  final counter = Signal<int>(0, name: 'counter');
+
+  @override
+  void dispose() {
+    counter.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+    body: Center(
+      child: SignalBuilder(
+        builder: (context, child) {
+          return Text('Counter is ${counter.value}');
+        },
+      ),
+    ),
+    floatingActionButton: FloatingActionButton(
+      onPressed: () => counter.value++,
+      child: const Icon(Icons.add),
+    ),
+  );
+}
+```
+
+**Expected implementation change:** Integration of field builder (M1-01), compound-assignment rewrite (Section 5.3), interpolation rewrite (Section 5.2), untracked-callback rule (Section 6.2), SignalBuilder minimum-subtree placement (Section 7.2).
+
+**Acceptance:**
+
+- `dart test --name=m1_05` passes.
+- Golden analyzes clean.
+- Widget test `m1_05_widget` (TODO M1-10) renders, taps the FAB, and observes exactly one `Text` rebuild with `counter == 1`.
+
+**Dependencies:** M1-01, M1-04 (for name handling wiring), and the visit-tree rewrite logic introduced here is reused by M3.
+
+**Status:** TODO
+
+---
+
+### TODO M1-06 — Golden: plain class (no widget) with dispose
+
+**Goal:** A non-widget class with `@SolidState` fields gets signals + synthesized `dispose()` (no `super.dispose()`; plain class's supertype chain is `Object` only).
+
+**SPEC references:** Section 8.3, Section 10.
+
+**Files to create:**
+
+- `packages/solid_generator/test/golden/inputs/m1_06_plain_class_no_widget.dart`
+- `packages/solid_generator/test/golden/outputs/m1_06_plain_class_no_widget.g.dart`
+- entry in `golden_test.dart`
+
+**Expected input content:**
+
+```dart
+import 'package:solid/solid.dart';
+
+class Counter {
+  @SolidState()
+  int value = 0;
+
+  @SolidState()
+  String label = '';
+}
+```
+
+**Expected output content:**
+
+```dart
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class Counter {
+  final value = Signal<int>(0, name: 'value');
+  final label = Signal<String>('', name: 'label');
+
+  void dispose() {
+    label.dispose();
+    value.dispose();
+  }
+}
+```
+
+**Expected implementation change:** Class-kind dispatch adds "plain class" branch (Section 8.3). Dispose synthesis uses reverse declaration order (Section 10) and omits `super.dispose()` when the supertype chain has no `dispose()` method.
+
+**Acceptance:** `dart test --name=m1_06` passes; golden analyzes clean.
+
+**Dependencies:** M1-01.
+
+**Status:** TODO
+
+---
+
+### TODO M1-07 — Golden: existing State<X> class (issue #3) + lifecycle preservation
+
+**Goal:** A `StatefulWidget` whose existing `State<X>` subclass hosts `@SolidState` fields gets transformed in-place, not re-wrapped. Custom `initState` / `didUpdateWidget` overrides are preserved untouched; if an existing `dispose()` body is present, reactive disposals are prepended and the rest of the body is left alone. This is the fix for the v1 bug filed as issue #3 and locks SPEC Section 14 item 4.
+
+**SPEC references:** Section 8.2, Section 10, Section 14 item 4, Section 16 (#3).
+
+**Files to create:**
+
+- `packages/solid_generator/test/golden/inputs/m1_07_existing_state_class.dart`
+- `packages/solid_generator/test/golden/outputs/m1_07_existing_state_class.g.dart`
+- entry in `golden_test.dart`
+
+**Expected input content:**
+
+```dart
+import 'package:solid/solid.dart';
+import 'package:flutter/widgets.dart';
+
+class Counter extends StatefulWidget {
+  const Counter({super.key});
+
+  @override
+  State<Counter> createState() => _CounterState();
+}
+
+class _CounterState extends State<Counter> {
+  @SolidState()
+  int counter = 0;
+
+  final _subscription = Stream.periodic(const Duration(seconds: 1)).listen((_) {});
+
+  @override
+  void initState() {
+    super.initState();
+    debugPrint('init');
+  }
+
+  @override
+  void didUpdateWidget(covariant Counter oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    debugPrint('update');
+  }
+
+  @override
+  void dispose() {
+    _subscription.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}
+```
+
+**Expected output content:**
+
+```dart
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class Counter extends StatefulWidget {
+  const Counter({super.key});
+
+  @override
+  State<Counter> createState() => _CounterState();
+}
+
+class _CounterState extends State<Counter> {
+  final counter = Signal<int>(0, name: 'counter');
+
+  final _subscription = Stream.periodic(const Duration(seconds: 1)).listen((_) {});
+
+  @override
+  void initState() {
+    super.initState();
+    debugPrint('init');
+  }
+
+  @override
+  void didUpdateWidget(covariant Counter oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    debugPrint('update');
+  }
+
+  @override
+  void dispose() {
+    counter.dispose();
+    _subscription.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}
+```
+
+**Expected implementation change:** Class-kind dispatch detects the existing `State<X>` case by walking the `createState()` return type; applies reactive transformation in place instead of splitting the class. `initState` and `didUpdateWidget` bodies pass through untouched. The existing `dispose()` body has reactive disposals prepended; the existing `_subscription.cancel()` and `super.dispose()` remain at their original positions.
+
+**Acceptance:** `dart test --name=m1_07` passes; golden analyzes clean; no new class is emitted (the `_CounterState` class count in the output equals the input); `initState` and `didUpdateWidget` bodies are byte-identical between input and output; the `dispose()` body has `counter.dispose();` prepended and nothing else added or removed.
+
+**Dependencies:** M1-01.
+
+**Status:** TODO
+
+---
+
+### TODO M1-08 — Golden: import rewrite (issue #8)
+
+**Goal:** The generator adds `package:flutter_solidart/flutter_solidart.dart` to the output whenever any of its names are emitted, and relies on `dart fix --apply` to prune the unused `solid_annotations` import.
+
+**SPEC references:** Section 9, Section 16 (#8).
+
+**Files to create:**
+
+- `packages/solid_generator/test/golden/inputs/m1_08_import_rewrite.dart`
+- `packages/solid_generator/test/golden/outputs/m1_08_import_rewrite.g.dart`
+- entry in `golden_test.dart`
+
+**Expected input content:** Any class with a `@SolidState` field + an explicit `import 'package:solid_annotations/solid_annotations.dart';` in the source.
+
+**Expected output content:** Output adds the `flutter_solidart` import. The `solid_annotations` import stays in the raw generator output — this test asserts the raw output. A sibling test (or a `dart fix --apply` invocation in the example app) verifies the end-state cleanup.
+
+**Expected implementation change:** Import analysis in the generator: collect every identifier in the emitted AST, check each against the Section 9 list; if any match, prepend the import.
+
+**Acceptance:** `dart test --name=m1_08` passes; golden analyzes clean.
+
+**Dependencies:** M1-01.
+
+**Status:** TODO
+
+---
+
+### TODO M1-09 — Idempotency: two-run byte equality
+
+**Goal:** Running the generator twice on the same input produces byte-identical output.
+
+**SPEC references:** None directly — this is a test of the Section 5.4 invariant ("once `counter.value` has been rewritten, the outer expression's type is `int` ... so the rule stops applying").
+
+**Files to create:**
+
+- `packages/solid_generator/test/integration/idempotency_test.dart` — runs each golden input through the builder twice and asserts the second output equals the first.
+
+**Expected implementation change:** None (tests the invariant already produced by M1-01 through M1-08). If it fails, the generator has state or non-determinism that must be fixed.
+
+**Acceptance:** Test passes for every golden currently listed.
+
+**Dependencies:** M1-01 through M1-08.
+
+**Status:** TODO
+
+---
+
+### TODO M1-10 — Widget test: FAB tap rebuilds only Text
+
+**Goal:** With the M1-05 golden running inside `example/`, a FAB tap rebuilds only the `Text` widget; a sibling widget (e.g., an icon) does not rebuild.
+
+**SPEC references:** Section 7 (SignalBuilder placement), Section 14 item 7.
+
+**Files to create:**
+
+- `example/test/counter_widget_test.dart` — uses `testWidgets` + a `BuildTracker` (test helper) to count rebuilds per widget. After the FAB tap: `Text` rebuild count == 1; sibling icon rebuild count == 0.
+
+**Expected implementation change:** The `BuildTracker` helper may need to live in `example/test/helpers/build_tracker.dart` and wrap `Text` / `Container` in a tracking widget that increments a counter in its `build`.
+
+**Acceptance:** `flutter test example/` passes; the test explicitly asserts sibling rebuild count is zero.
+
+**Dependencies:** M1-05.
+
+**Status:** TODO
+
+---
+
+### TODO M1-11 — Widget test: dispose spy on Navigator pop
+
+**Goal:** When the page containing `@SolidState` signals is popped from `Navigator`, each signal's `dispose()` is invoked.
+
+**SPEC references:** Section 10.
+
+**Files to create:**
+
+- `example/test/counter_dispose_test.dart` — wraps the `Signal<int>` in a `SpySignal` subclass that records `dispose()` calls. Pushes the `Counter` page, pops it, asserts the counter was disposed.
+
+**Expected implementation change:** A `SpySignal<T>` helper in `example/test/helpers/spy_signal.dart`; the generated `_CounterState.dispose()` calls `counter.dispose()` and the spy records it.
+
+**Acceptance:** Test passes; spy records exactly one dispose call per signal.
+
+**Dependencies:** M1-01, M1-10.
+
+**Status:** TODO
+
+---
+
+### TODO M1-12 — Golden: class without annotations passes through
+
+**Goal:** A `.dart` file under `source/` that contains NO `@Solid*` annotation is copied byte-for-byte to `lib/`. No transformation, no re-formatting, no import addition.
+
+**SPEC references:** Section 2 (transformation-vs-verbatim-copy), Section 8.4.
+
+**Files to create:**
+
+- `packages/solid_generator/test/golden/inputs/m1_12_passthrough_no_annotations.dart`
+- `packages/solid_generator/test/golden/outputs/m1_12_passthrough_no_annotations.g.dart` — byte-identical to the input.
+- entry in `golden_test.dart`.
+
+**Expected input content:** A plain `StatelessWidget` that does NOT import `solid` and has NO annotations:
+
+```dart
+import 'package:flutter/widgets.dart';
+
+class Hello extends StatelessWidget {
+  const Hello({super.key});
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}
+```
+
+**Expected output content:** Identical to input.
+
+**Expected implementation change:** The top-level pipeline scans the parsed file for any `@Solid*` annotation before invoking the rewriter. If none, write input bytes to the output path unchanged.
+
+**Acceptance:** `dart test --name=m1_12` passes; output bytes equal input bytes.
+
+**Dependencies:** M1-01.
+
+**Status:** TODO
+
+---
+
+### TODO M1-13 — Golden: `const` on public widget constructor
+
+**Goal:** When the public `StatefulWidget` constructor (emitted per Section 8.1) has all-`const`-compatible fields and defaults, the generator emits `const` on that constructor. When a field's default is not `const`-compatible, `const` is omitted.
+
+**SPEC references:** Section 8.1, Section 14 item 7.
+
+**Files to create:**
+
+- `packages/solid_generator/test/golden/inputs/m1_13_const_ctor_eligible.dart` — a class whose non-`@SolidState` fields are all `final` and all default values are `const`-compatible.
+- `packages/solid_generator/test/golden/outputs/m1_13_const_ctor_eligible.g.dart` — public ctor is `const Counter({super.key})`.
+- `packages/solid_generator/test/golden/inputs/m1_13_const_ctor_ineligible.dart` — a class with a non-`const` default (e.g., `final Stopwatch watch = Stopwatch();`).
+- `packages/solid_generator/test/golden/outputs/m1_13_const_ctor_ineligible.g.dart` — public ctor is `Counter({super.key})` (no `const`).
+- entries in `golden_test.dart` for both.
+
+**Expected implementation change:** When emitting the public `StatefulWidget` constructor, walk the original class's fields; if every non-`@SolidState` field is `final` and every default-value expression evaluates at compile time (type system judgment), emit `const`. Otherwise omit.
+
+**Acceptance:** Both goldens pass; eligible ctor has `const`, ineligible does not.
+
+**Dependencies:** M1-01.
+
+**Status:** TODO
+
+---
+
+### TODO M1-14 — Rejection: invalid `@SolidState` targets
+
+**Goal:** The generator rejects `@SolidState` on every invalid target enumerated in SPEC Section 3.1 with a clear, per-case error message that identifies the offending declaration.
+
+**SPEC references:** Section 3.1 "Invalid targets".
+
+**Files to create:**
+
+- `packages/solid_generator/test/rejections/m1_14_invalid_targets_test.dart` — parametric test over the six cases. Each case is a minimal source snippet that places `@SolidState` on the invalid target; each asserts the builder raises an error whose message contains the SPEC description of the case (e.g., `"@SolidState on a final field"`, `"@SolidState on a static member"`, etc.).
+- One input file per case under `packages/solid_generator/test/golden/inputs/m1_14_*.dart`:
+  - `m1_14_final_field.dart` — `@SolidState() final int x = 0;`
+  - `m1_14_const_field.dart` — `@SolidState() static const int x = 0;` (use only `const` on a non-static field if Dart allows; otherwise keep the static+const pair and cover by the `const` clause)
+  - `m1_14_static_field.dart` — `@SolidState() static int x = 0;`
+  - `m1_14_static_getter.dart` — `@SolidState() static int get x => 0;`
+  - `m1_14_top_level.dart` — top-level `@SolidState() int x = 0;`
+  - `m1_14_method.dart` — `@SolidState() void doThing() {}`
+  - `m1_14_setter.dart` — `@SolidState() set x(int v) {}`
+
+**Expected implementation change:** Annotation-target validation runs before transformation. Any invalid target produces a `TransformationError` with a SPEC-quoted message that names the target kind and the enclosing class + member identifier.
+
+**Acceptance:** The parametric test passes; every case produces a distinct error message that contains the SPEC description of the invalid-target category.
+
+**Dependencies:** M1-01.
+
+**Status:** TODO
+
+---
+
+### TODO M1-15 — Rejection: non-M1 annotations (`@SolidEffect`, `@SolidQuery`, `@SolidEnvironment`)
+
+**Goal:** Per SPEC Section 3.2, any source file containing `@SolidEffect`, `@SolidQuery`, or `@SolidEnvironment` causes the build to fail with an error naming the annotation and stating `"not yet implemented; scheduled for a later v2 milestone"`.
+
+**SPEC references:** Section 3.2, Section 13.
+
+**Files to create:**
+
+- `packages/solid_generator/test/rejections/m1_15_non_m1_annotations_test.dart` — three parametric cases, one per annotation.
+- Input files under `packages/solid_generator/test/golden/inputs/`:
+  - `m1_15_effect.dart` — `class Foo { @SolidEffect() void side() {} }`
+  - `m1_15_query.dart` — `class Foo { @SolidQuery() Future<int> fetch() async => 0; }`
+  - `m1_15_environment.dart` — `class Foo { @SolidEnvironment() late int injected; }`
+
+**Expected implementation change:** The annotation-scanning pass recognizes each of the three reserved annotation classes from `package:solid_annotations`. Any detection emits `"@SolidEffect is not yet implemented; scheduled for a later v2 milestone"` (with the annotation name substituted).
+
+**Acceptance:** All three cases produce the exact SPEC-quoted error with the correct annotation name.
+
+**Dependencies:** M0-02, M1-01.
+
+**Status:** TODO
+
+---
+
+## M2 — `@SolidState` on getters → `Computed`
+
+### TODO M2-01 — Golden: simple Computed with deps
+
+**Goal:** `@SolidState() int get doubleCounter => counter * 2;` becomes `late final doubleCounter = Computed<int>(() => counter.value * 2, name: 'doubleCounter');`.
+
+**SPEC references:** Section 4.5, Section 5.1 (identifier rewrite).
+
+**Files to create:**
+
+- `packages/solid_generator/test/golden/inputs/m2_01_simple_computed_with_deps.dart`
+- `packages/solid_generator/test/golden/outputs/m2_01_simple_computed_with_deps.g.dart`
+- entry in `golden_test.dart`
+
+**Expected input content:** Class with `@SolidState() int counter = 0;` plus `@SolidState() int get doubleCounter => counter * 2;`.
+
+**Expected output content:**
+
+```dart
+final counter = Signal<int>(0, name: 'counter');
+late final doubleCounter = Computed<int>(() => counter.value * 2, name: 'doubleCounter');
+
+@override
+void dispose() {
+  doubleCounter.dispose();
+  counter.dispose();
+  super.dispose();
+}
+```
+
+**Expected implementation change:** Getter-annotated branch in the class visitor: synthesize `late final` Computed, rewrite identifiers in the body per Section 5.1 type resolution, apply reverse-declaration dispose order (Section 10).
+
+**Acceptance:** `dart test --name=m2_01` passes; golden analyzes clean; dispose body calls `doubleCounter.dispose()` BEFORE `counter.dispose()`.
+
+**Dependencies:** M1-01.
+
+**Status:** TODO
+
+---
+
+### TODO M2-01b — Golden: block-body getter → Computed
+
+**Goal:** A `@SolidState` getter with a block body (`{ ... return ...; }`) becomes a `Computed<T>` whose function expression preserves the block body verbatim with reactive reads rewritten.
+
+**SPEC references:** Section 4.6.
+
+**Files to create:**
+
+- `packages/solid_generator/test/golden/inputs/m2_01b_block_body_computed.dart`
+- `packages/solid_generator/test/golden/outputs/m2_01b_block_body_computed.g.dart`
+- entry in `golden_test.dart`.
+
+**Expected input content:** Mirror the Section 4.6 SPEC example: a class with `@SolidState() int counter = 0;` and `@SolidState() String get summary { final c = counter; return 'count is $c'; }`.
+
+**Expected output content:** Per Section 4.6:
+
+```dart
+final counter = Signal<int>(0, name: 'counter');
+late final summary = Computed<String>(() {
+  final c = counter.value;
+  return 'count is $c';
+}, name: 'summary');
+```
+
+**Expected implementation change:** The getter branch of the class visitor must handle both expression-body (`=> ...`) and block-body (`{ ... }`) forms. For block body, wrap the original block in a `() { ... }` function expression and apply Section 5.1 identifier rewriting inside.
+
+**Acceptance:** `dart test --name=m2_01b` passes; golden analyzes clean.
+
+**Dependencies:** M2-01.
+
+**Status:** TODO
+
+---
+
+### TODO M2-02 — Rejection: Computed with zero deps
+
+**Goal:** `@SolidState() int get constantFive => 5;` must be rejected at build time with SPEC's exact error message. A `Computed` with no deps is a plain constant.
+
+**SPEC references:** Section 4.5 (rejection clause).
+
+**Files to create:**
+
+- `packages/solid_generator/test/rejections/.gitkeep` (if the directory does not yet exist).
+- `packages/solid_generator/test/golden/inputs/m2_02_computed_no_deps_rejected.dart`
+- `packages/solid_generator/test/rejections/m2_02_computed_no_deps_test.dart` — asserts the builder raises an error containing `"getter 'constantFive' has no reactive dependencies"`.
+
+**Expected implementation change:** After visiting a getter body, check whether any identifier resolved to `SignalBase<T>`. If none, emit the SPEC-defined error.
+
+**Acceptance:** Rejection test passes; error message text matches SPEC quote exactly.
+
+**Dependencies:** M2-01.
+
+**Status:** TODO
+
+---
+
+### TODO M2-03 — Golden: Computed read inside `build`
+
+**Goal:** A read of the Computed inside `build()` receives `.value` and the enclosing subtree is wrapped in `SignalBuilder`.
+
+**SPEC references:** Section 5.1, Section 7.
+
+**Files to create:**
+
+- `packages/solid_generator/test/golden/inputs/m2_03_computed_read_in_build.dart`
+- `packages/solid_generator/test/golden/outputs/m2_03_computed_read_in_build.g.dart`
+- entry in `golden_test.dart`
+
+**Expected implementation change:** None beyond M2-01 + M1-05 — the Section 5.1 rule is type-driven and works for `Computed<T>` as well as `Signal<T>`.
+
+**Acceptance:** `dart test --name=m2_03` passes; golden analyzes clean.
+
+**Dependencies:** M2-01, M1-05.
+
+**Status:** TODO
+
+---
+
+### TODO M2-04 — Golden: dispose order (Computed before Signal)
+
+**Goal:** Confirm reverse-declaration disposal: a class with both a Signal and a Computed produces a `dispose()` that disposes the Computed first.
+
+**SPEC references:** Section 10.
+
+**Files to create:**
+
+- `packages/solid_generator/test/golden/inputs/m2_04_dispose_order.dart`
+- `packages/solid_generator/test/golden/outputs/m2_04_dispose_order.g.dart`
+- entry in `golden_test.dart`
+
+**Expected implementation change:** Already exercised by M2-01; this TODO is the explicit regression test if M2-01 hides ordering behind a single case.
+
+**Acceptance:** `dart test --name=m2_04` passes; golden's `dispose()` body has `computed.dispose()` before `signal.dispose()`.
+
+**Dependencies:** M2-01.
+
+**Status:** TODO
+
+---
+
+## M3 — Untracked reads + fine-grained SignalBuilder
+
+### TODO M3-01 — Golden: Text(counter) receives `.value` inside SignalBuilder (issue #6)
+
+**Goal:** A bare identifier `counter` passed as a positional arg to `Text(...)` is rewritten to `counter.value` AND the `Text` is wrapped in `SignalBuilder`.
+
+**SPEC references:** Section 5.1, Section 7, Section 16 (#6).
+
+**Files to create:**
+
+- `packages/solid_generator/test/golden/inputs/m3_01_text_arg_gets_value.dart`
+- `packages/solid_generator/test/golden/outputs/m3_01_text_arg_gets_value.g.dart`
+- entry in `golden_test.dart`
+
+**Expected input content:** A minimal widget whose `build()` contains exactly one top-level `Text(counter)` and nothing else reactive — no FAB, no interpolation, no other reads. The isolated case forces the rewriter to handle a bare-identifier positional arg in a `Text` constructor without being helped by neighboring patterns.
+
+**Expected implementation change:** Exercised by M1-05 at integration scale; this golden narrows the input to the exact shape v1 issue #6 failed on (bare identifier arg) so a regression shows up with a single-case failure.
+
+**Acceptance:** `dart test --name=m3_01` passes; golden analyzes clean.
+
+**Dependencies:** M1-05.
+
+**Status:** TODO
+
+---
+
+### TODO M3-02 — Golden: onPressed write stays untracked (issue #4)
+
+**Goal:** `onPressed: () => counter++` becomes `counter.value++` without `SignalBuilder` wrapping of the button. Compound-assignment writes never subscribe per SPEC Section 6.0.
+
+**SPEC references:** Section 5.3, Section 6.0, Section 6.2, Section 16 (#4).
+
+**Files to create:**
+
+- `packages/solid_generator/test/golden/inputs/m3_02_onpressed_untracked.dart`
+- `packages/solid_generator/test/golden/outputs/m3_02_onpressed_untracked.g.dart`
+- entry in `golden_test.dart`
+
+**Expected input content:** A minimal widget whose `build()` returns a single `FloatingActionButton` with `onPressed: () => counter++` and NO other reactive read. The isolated case forces the rewriter to recognize that the FAB must not be wrapped in `SignalBuilder` — a single-file failure pinpoints an over-wrap regression instantly.
+
+**Expected implementation change:** Exercised by M1-05 at integration scale; this golden narrows the input to the exact shape v1 issue #4 failed on (write inside an untracked callback).
+
+**Acceptance:** `dart test --name=m3_02` passes; the output `FloatingActionButton(...)` is NOT wrapped in `SignalBuilder`.
+
+**Dependencies:** M1-05.
+
+**Status:** TODO
+
+---
+
+### TODO M3-03 — Golden: ValueKey(counter) is untracked
+
+**Goal:** A read inside `ValueKey(counter)` gets `.value` but does NOT wrap the enclosing widget in `SignalBuilder`.
+
+**SPEC references:** Section 6.3.
+
+**Files to create:**
+
+- `packages/solid_generator/test/golden/inputs/m3_03_value_key_untracked.dart`
+- `packages/solid_generator/test/golden/outputs/m3_03_value_key_untracked.g.dart`
+- entry in `golden_test.dart`
+
+**Expected implementation change:** The untracked-context detector adds Key constructor names (Section 6.3) to its enumerated list. Reads inside these `InstanceCreationExpression`s get `.value` but do not trigger wrapping.
+
+**Acceptance:** `dart test --name=m3_03` passes; output `Container(key: ValueKey(counter.value), child: ...)` is NOT wrapped.
+
+**Dependencies:** M1-05.
+
+**Status:** TODO
+
+---
+
+### TODO M3-04 — Widget test: sibling isolation
+
+**Goal:** Two sibling widgets each reading different signals. Mutating signal A rebuilds only widget A; widget B's rebuild count stays at zero.
+
+**SPEC references:** Section 7.4 (siblings do not share wrappers).
+
+**Files to create:**
+
+- `example/test/sibling_isolation_test.dart` — two `@SolidState` fields, two sibling `Text` widgets each reading one field. Increment A, assert A rebuilt and B did not.
+
+**Expected implementation change:** Validates that M1-05's minimum-subtree wrap rule (Section 7.2) produces sibling isolation.
+
+**Acceptance:** Test passes; rebuild count for B is zero after mutating A.
+
+**Dependencies:** M1-10.
+
+**Status:** TODO
+
+---
+
+### TODO M3-05 — Type-aware no-double-append
+
+**Goal:** `controller.value` in source (where `controller` is a `TextEditingController`, NOT a Solid signal) is left untouched. No `controller.value.value` regression.
+
+**SPEC references:** Section 5.4.
+
+**Files to create:**
+
+- `packages/solid_generator/test/golden/inputs/m3_05_type_aware_no_double_append.dart`
+- `packages/solid_generator/test/golden/outputs/m3_05_type_aware_no_double_append.g.dart`
+- entry in `golden_test.dart`
+
+**Expected input content:** A widget reading `controller.value` on a `TextEditingController` AND `counter` on a `@SolidState` field; only `counter` should receive `.value`.
+
+**Expected implementation change:** The rewriter resolves the static type of every identifier via `package:analyzer` and only rewrites when it is a subtype of `SignalBase<T>` (Section 5.1 + 5.4).
+
+**Acceptance:** `dart test --name=m3_05` passes; the `controller.value` in the output is unchanged; the `counter` is rewritten to `counter.value`.
+
+**Dependencies:** M1-05.
+
+**Status:** TODO
+
+---
+
+### TODO M3-06 — Golden: string interpolation
+
+**Goal:** `'$counter'` becomes `'${counter.value}'`.
+
+**SPEC references:** Section 5.2.
+
+**Files to create:**
+
+- `packages/solid_generator/test/golden/inputs/m3_06_string_interpolation_bare.dart`
+- `packages/solid_generator/test/golden/outputs/m3_06_string_interpolation_bare.g.dart`
+- entry in `golden_test.dart`
+
+**Expected implementation change:** Already produced by M1-05; this is the focused regression case. Verify that already-wrapped `${counter.value}` stays untouched (double-rewrite prevention via Section 5.4 type rule).
+
+**Acceptance:** `dart test --name=m3_06` passes; golden analyzes clean.
+
+**Dependencies:** M1-05.
+
+**Status:** TODO
+
+---
+
+### TODO M3-07 — Golden: explicit `untracked(() => ...)` opt-out
+
+**Goal:** `Text('snapshot: ${untracked(() => counter)}')` keeps `.value` on `counter` (per Section 5.1) but does NOT wrap the enclosing `Text` in `SignalBuilder`.
+
+**SPEC references:** Section 6.4.
+
+**Files to create:**
+
+- `packages/solid_generator/test/golden/inputs/m3_07_untracked_opt_out.dart`
+- `packages/solid_generator/test/golden/outputs/m3_07_untracked_opt_out.g.dart`
+- entry in `golden_test.dart`
+
+**Expected implementation change:** The untracked-context detector recognizes calls to the top-level `untracked` function from `package:flutter_solidart/flutter_solidart.dart` by resolved identifier (not name alone). Reads inside the closure passed to `untracked` are untracked.
+
+**Acceptance:** `dart test --name=m3_07` passes; the golden output does NOT wrap the enclosing `Text` in `SignalBuilder`.
+
+**Dependencies:** M1-05.
+
+**Status:** TODO
+
+---
+
+### TODO M3-08 — Golden: Builder-style closures stay tracked
+
+**Goal:** `Builder(builder: (context) => Text(counter))` is wrapped in `SignalBuilder`. `builder:` is not an untracked-callback name (Section 6.2).
+
+**SPEC references:** Section 6.6.
+
+**Files to create:**
+
+- `packages/solid_generator/test/golden/inputs/m3_08_builder_closure_tracked.dart`
+- `packages/solid_generator/test/golden/outputs/m3_08_builder_closure_tracked.g.dart`
+- entry in `golden_test.dart`
+
+**Expected implementation change:** The untracked-callback detector uses the Section 6.2 enumerated list. Any parameter name NOT on that list (e.g. `builder`, `itemBuilder`, `separatorBuilder`) does not mark reads as untracked.
+
+**Acceptance:** `dart test --name=m3_08` passes; output wraps the inner widget in `SignalBuilder`.
+
+**Dependencies:** M1-05.
+
+**Status:** TODO
+
+---
+
+### TODO M3-09 — Golden: shadowing
+
+**Goal:** A local variable named the same as a reactive field, bound to a non-SignalBase type, shadows the field correctly. The inner read is NOT rewritten.
+
+**SPEC references:** Section 5.5.
+
+**Files to create:**
+
+- `packages/solid_generator/test/golden/inputs/m3_09_shadowing.dart`
+- `packages/solid_generator/test/golden/outputs/m3_09_shadowing.g.dart`
+- entry in `golden_test.dart`
+
+**Expected input content:**
+
+```dart
+@SolidState() int counter = 0;
+
+@override
+Widget build(BuildContext context) {
+  return Builder(builder: (context) {
+    final counter = 'local'; // shadows the field; type is String
+    return Text(counter);    // stays as `counter`
+  });
+}
+```
+
+**Expected output content:** The inner `Text(counter)` is NOT rewritten; the outer field reference (absent in this case because the build body is an expression that starts with `Builder(...)`) is not re-introduced. Outer `Builder` is wrapped per M3-08 only if it contains a tracked read — here it does not (inner is shadowed), so NO wrapper is added.
+
+**Expected implementation change:** Validates that the Section 5.1 type-driven rule handles shadowing automatically — no extra generator logic.
+
+**Acceptance:** `dart test --name=m3_09` passes; output analyzes clean; no `.value` added to the shadowed identifier; no `SignalBuilder` around the `Builder`.
+
+**Dependencies:** M3-05, M3-08.
+
+**Status:** TODO
+
+---
+
+### TODO M3-10 — Golden: hand-written SignalBuilder is not double-wrapped
+
+**Goal:** If source already contains `SignalBuilder(builder: ...)` around a tracked read, the generator does NOT add a second wrapper.
+
+**SPEC references:** Section 7.3.
+
+**Files to create:**
+
+- `packages/solid_generator/test/golden/inputs/m3_10_existing_signalbuilder.dart`
+- `packages/solid_generator/test/golden/outputs/m3_10_existing_signalbuilder.g.dart`
+- entry in `golden_test.dart`.
+
+**Expected input content:** A class whose `build()` body manually wraps a tracked read in `SignalBuilder(builder: (context, child) => Text('$counter'))`.
+
+**Expected output content:** Identical `SignalBuilder` shape — only `$counter` becomes `${counter.value}`. The enclosing widget tree gains NO additional `SignalBuilder` wrapper.
+
+**Expected implementation change:** The placement rule (Section 7.1 clause 3) checks the ancestor chain for an existing `SignalBuilder` before wrapping. If one is present, skip.
+
+**Acceptance:** `dart test --name=m3_10` passes; output has exactly one `SignalBuilder` (the hand-written one).
+
+**Dependencies:** M1-05.
+
+**Status:** TODO
+
+---
+
+### TODO M3-11 — Golden: nested tracked reads — only inner wraps
+
+**Goal:** When an outer widget expression and an inner widget expression both contain tracked reads, only the inner expression is wrapped. The outer expression relies on the inner `SignalBuilder` to trigger its rebuild.
+
+**SPEC references:** Section 7.5.
+
+**Files to create:**
+
+- `packages/solid_generator/test/golden/inputs/m3_11_nested_tracked_reads.dart`
+- `packages/solid_generator/test/golden/outputs/m3_11_nested_tracked_reads.g.dart`
+- entry in `golden_test.dart`.
+
+**Expected input content:** A widget whose `build()` returns a column with a top-level tracked read (e.g., `Text('$counter')`) and a nested `Text('$counter')` inside a child subtree. Both read the same signal.
+
+**Expected output content:** Only the innermost `Text` is wrapped in `SignalBuilder`. The outer `Text` is also wrapped because it is itself a leaf; the Column is NOT wrapped. The rule is "smallest subtree per read"; equal-depth independent reads each get their own wrapper.
+
+**Expected implementation change:** The placement visitor walks bottom-up. For each tracked read, it identifies the smallest enclosing widget-constructor expression and marks it for wrapping. Parent wrappers are suppressed for any subtree already covered by a descendant wrapper.
+
+**Acceptance:** `dart test --name=m3_11` passes; the golden has zero `SignalBuilder` wrappers around the outer Column.
+
+**Dependencies:** M1-05.
+
+**Status:** TODO

--- a/TODOS.md
+++ b/TODOS.md
@@ -31,7 +31,7 @@ This file is the committed, resume-safe task queue for the v2 rebuild. A fresh a
 
 **Files to create/modify:**
 
-- `pubspec.yaml` (workspace root): workspace declaration listing all four sub-packages (`packages/solid_annotations`, `packages/solid_generator`, `packages/solid`, `example`).
+- `pubspec.yaml` (workspace root): workspace declaration listing all workspace members — two packages (`packages/solid_annotations`, `packages/solid_generator`) plus the `example/` Flutter app.
 - `analysis_options.yaml` (workspace root): `include: package:very_good_analysis/analysis_options.yaml`.
 - `.gitignore`: `.dart_tool/`, `.packages`, `build/`, `.flutter-plugins`, `.flutter-plugins-dependencies`. Do NOT ignore `source/**` or `lib/**`.
 
@@ -106,28 +106,6 @@ class SolidEnvironment { const SolidEnvironment(); }
 
 ---
 
-### TODO M0-04 — `solid` umbrella package
-
-**Goal:** The user-facing import. Re-exports `solid_annotations` plus the subset of `flutter_solidart` symbols listed in SPEC Section 9.
-
-**SPEC references:** Section 9, Section 14 item 5.
-
-**Files to create/modify:**
-
-- `packages/solid/pubspec.yaml` — deps on `solid_annotations` (path: `../solid_annotations`) and `flutter_solidart`.
-- `packages/solid/lib/solid.dart` — re-exports `package:solid_annotations/solid_annotations.dart` and `package:flutter_solidart/flutter_solidart.dart` (full export; `untracked` is a top-level function that comes for free).
-
-**Acceptance:**
-
-- `dart analyze packages/solid` → zero issues.
-- An external Dart file that does `import 'package:solid/solid.dart';` can name `SolidState`, `Signal`, `Computed`, `SignalBuilder`, `untracked`.
-
-**Dependencies:** M0-02.
-
-**Status:** TODO
-
----
-
 ### TODO M0-05 — `example/` hello-world shell
 
 **Goal:** Minimal Flutter app with `source/counter.dart` (hand-written) and `lib/main.dart` (entry point). Used as both M0 smoke-test and M1-05 canonical golden.
@@ -136,7 +114,7 @@ class SolidEnvironment { const SolidEnvironment(); }
 
 **Files to create/modify:**
 
-- `example/pubspec.yaml` — Flutter app deps on `solid` (path `../packages/solid`), dev_dep on `solid_generator` (path `../packages/solid_generator`) and `build_runner`.
+- `example/pubspec.yaml` — Flutter app deps on `solid_annotations` (path `../packages/solid_annotations`) and `flutter_solidart`; dev_deps on `solid_generator` (path `../packages/solid_generator`) and `build_runner`.
 - `example/analysis_options.yaml` — `include: package:very_good_analysis/analysis_options.yaml`, lint suppressions: `must_be_immutable: ignore`, `always_put_required_named_parameters_first: ignore`, `invalid_annotation_target: ignore`.
 - `example/source/counter.dart` — hello-world stateful widget with no annotations (plain `Text('hello')`). Replaced by M1-05 golden source.
 - `example/lib/main.dart` — `void main() => runApp(MaterialApp(home: Counter()));` importing `counter.dart`. Hand-written; must survive `dart run build_runner build` because M0-03 is a no-op for files without annotations.
@@ -147,7 +125,7 @@ class SolidEnvironment { const SolidEnvironment(); }
 - `dart run build_runner build --delete-conflicting-outputs` in `example/` exits 0; `example/lib/counter.dart` is identical to `example/source/counter.dart`.
 - `flutter run -d chrome` (or any device) boots and shows "hello".
 
-**Dependencies:** M0-03, M0-04.
+**Dependencies:** M0-03.
 
 **Status:** TODO
 
@@ -192,7 +170,7 @@ class SolidEnvironment { const SolidEnvironment(); }
 **Expected input content:**
 
 ```dart
-import 'package:solid/solid.dart';
+import 'package:solid_annotations/solid_annotations.dart';
 import 'package:flutter/widgets.dart';
 
 class Counter extends StatelessWidget {
@@ -269,7 +247,7 @@ class _CounterState extends State<Counter> {
 **Expected input content:**
 
 ```dart
-import 'package:solid/solid.dart';
+import 'package:solid_annotations/solid_annotations.dart';
 import 'package:flutter/widgets.dart';
 
 class Greeting extends StatelessWidget {
@@ -361,7 +339,7 @@ class _GreetingState extends State<Greeting> {
 **Expected input content:**
 
 ```dart
-import 'package:solid/solid.dart';
+import 'package:solid_annotations/solid_annotations.dart';
 import 'package:flutter/widgets.dart';
 
 class Score extends StatelessWidget {
@@ -449,7 +427,7 @@ class _ScoreState extends State<Score> {
 **Expected input content:**
 
 ```dart
-import 'package:solid/solid.dart';
+import 'package:solid_annotations/solid_annotations.dart';
 import 'package:flutter/material.dart';
 
 class CounterPage extends StatelessWidget {
@@ -537,7 +515,7 @@ class _CounterPageState extends State<CounterPage> {
 **Expected input content:**
 
 ```dart
-import 'package:solid/solid.dart';
+import 'package:solid_annotations/solid_annotations.dart';
 
 class Counter {
   @SolidState()
@@ -589,7 +567,7 @@ class Counter {
 **Expected input content:**
 
 ```dart
-import 'package:solid/solid.dart';
+import 'package:solid_annotations/solid_annotations.dart';
 import 'package:flutter/widgets.dart';
 
 class Counter extends StatefulWidget {

--- a/plans/features/m0-scaffolding.md
+++ b/plans/features/m0-scaffolding.md
@@ -1,0 +1,45 @@
+# M0 — Scaffolding
+
+**TODOS.md items:** M0-01 → M0-06
+**SPEC sections:** 2, 3.2, 9, 11, 12
+**Reviewer rubric:** `plans/features/reviewer-rubric.md`
+
+## Purpose
+
+Stand up an empty-but-passing workspace so that `build_runner` can run the `source/ → lib/` pipeline with a no-op builder. This milestone delivers zero user-facing behavior — its only job is to prove the packaging, analyzer configuration, and file layout are correct before any real transformation logic exists.
+
+A developer after M0 can:
+
+1. `dart pub get` at workspace root.
+2. `dart run build_runner build` inside `example/` and see `example/source/counter.dart` copied verbatim to `example/lib/counter.dart`.
+3. `flutter run` in `example/` and see a hello-world screen.
+4. `dart test packages/solid_generator` and see an empty suite pass.
+
+Nothing about `@SolidState` works yet — only the plumbing.
+
+## TODO sequence
+
+1. **M0-01** — Workspace `pubspec.yaml`, `analysis_options.yaml`, `.gitignore`. Establish the four-package workspace shape.
+2. **M0-02** — `packages/solid_annotations`. Ship `@SolidState` with its `name:` parameter. Reserve the three other names per SPEC Section 3.2.
+3. **M0-03** — `packages/solid_generator`. No-op builder + `build.yaml` with the `^source/{{}}.dart → lib/{{}}.dart` mapping, anchored so `lib/some_source/...` does NOT match.
+4. **M0-04** — `packages/solid` umbrella re-exporting annotations + `flutter_solidart`.
+5. **M0-05** — `example/` with hand-written `source/counter.dart` and `lib/main.dart`. Must round-trip through the no-op builder without breaking.
+6. **M0-06** — `golden_test.dart` scaffolding so M1 TODOs just append names to a list.
+
+## Cross-cutting concerns
+
+- **`build.yaml` shape.** Use `build_extensions` with capture groups. `auto_apply: dependents`, `build_to: source` (so writes land in real `lib/` files, not the build cache). Explicit `sources:` under `targets.$default` including both `source/**` and `lib/**` plus `pubspec.*` and `$package$`.
+- **Analyzer suppressions.** `example/analysis_options.yaml` needs `must_be_immutable: ignore`, `always_put_required_named_parameters_first: ignore`, `invalid_annotation_target: ignore` so that a `StatelessWidget` with mutable `@SolidState` fields does not trip lint.
+- **Versions.** Pin minimums for `build: ^2.4.0`, `build_runner: ^2.10.1`, `build_config: ^1.1.0`, `analyzer: ^6`, `dart_style: ^2.3`, `flutter_solidart: ^2.7.0`. Document in `packages/solid_generator/pubspec.yaml`.
+- **`.gitignore`.** Ignore `.dart_tool/`, `.packages`, `build/`, `.flutter-plugins`, `.flutter-plugins-dependencies`. Do NOT ignore `example/source/**` or `example/lib/**` — both are committed review artifacts.
+- **Package names.** Per SPEC Section 14 item 5: `package:solid_annotations` hosts the annotations; `package:solid` is the umbrella users import.
+
+## Exit criteria
+
+- `dart pub get` at workspace root exits 0.
+- `dart run build_runner build --delete-conflicting-outputs` in `example/` exits 0; `example/lib/counter.dart` byte-equals `example/source/counter.dart`.
+- `flutter run` in `example/` boots and displays hello-world.
+- `dart test packages/solid_generator` exits 0 (empty suite passes).
+- `dart analyze --fatal-infos` across all packages reports zero issues.
+- `dart format --set-exit-if-changed .` reports zero diff.
+- Reviewer rubric (all 8 items) passes on the M0 PR.

--- a/plans/features/m0-scaffolding.md
+++ b/plans/features/m0-scaffolding.md
@@ -29,7 +29,7 @@ Nothing about `@SolidState` works yet — only the plumbing.
 
 - **`build.yaml` shape.** Use `build_extensions` with capture groups. `auto_apply: dependents`, `build_to: source` (so writes land in real `lib/` files, not the build cache). Explicit `sources:` under `targets.$default` including both `source/**` and `lib/**` plus `pubspec.*` and `$package$`.
 - **Analyzer suppressions.** `example/analysis_options.yaml` needs `must_be_immutable: ignore`, `always_put_required_named_parameters_first: ignore`, `invalid_annotation_target: ignore` so that a `StatelessWidget` with mutable `@SolidState` fields does not trip lint.
-- **Versions.** Pin minimums for `build: ^2.4.0`, `build_runner: ^2.10.1`, `build_config: ^1.1.0`, `analyzer: ^6`, `dart_style: ^2.3`, `flutter_solidart: ^2.7.0`. Document in `packages/solid_generator/pubspec.yaml`.
+- **Versions.** Pin minimums for `build: ^4.0.5`, `build_runner: ^2.14.0`, `build_config: ^1.3.0`, `analyzer: ^13.0.0`, `dart_style: ^3.1.8`, `flutter_solidart: ^2.7.3`. Document in `packages/solid_generator/pubspec.yaml`.
 - **`.gitignore`.** Ignore `.dart_tool/`, `.packages`, `build/`, `.flutter-plugins`, `.flutter-plugins-dependencies`. Do NOT ignore `example/source/**` or `example/lib/**` — both are committed review artifacts.
 - **Package names.** Per SPEC Section 14 item 5: two packages. `package:solid_annotations` (runtime dep) hosts the annotations; `package:solid_generator` (dev_dep) hosts the builder. There is no `package:solid` umbrella. Users import `package:solid_annotations/solid_annotations.dart` for annotations and `package:flutter_solidart/flutter_solidart.dart` for reactive primitives.
 

--- a/plans/features/m0-scaffolding.md
+++ b/plans/features/m0-scaffolding.md
@@ -1,6 +1,6 @@
 # M0 — Scaffolding
 
-**TODOS.md items:** M0-01 → M0-06
+**TODOS.md items:** M0-01, M0-02, M0-03, M0-05, M0-06
 **SPEC sections:** 2, 3.2, 9, 11, 12
 **Reviewer rubric:** `plans/features/reviewer-rubric.md`
 
@@ -19,12 +19,11 @@ Nothing about `@SolidState` works yet — only the plumbing.
 
 ## TODO sequence
 
-1. **M0-01** — Workspace `pubspec.yaml`, `analysis_options.yaml`, `.gitignore`. Establish the four-package workspace shape.
+1. **M0-01** — Workspace `pubspec.yaml`, `analysis_options.yaml`, `.gitignore`. Establish the workspace shape: two packages (`packages/solid_annotations`, `packages/solid_generator`) plus the `example/` Flutter app.
 2. **M0-02** — `packages/solid_annotations`. Ship `@SolidState` with its `name:` parameter. Reserve the three other names per SPEC Section 3.2.
 3. **M0-03** — `packages/solid_generator`. No-op builder + `build.yaml` with the `^source/{{}}.dart → lib/{{}}.dart` mapping, anchored so `lib/some_source/...` does NOT match.
-4. **M0-04** — `packages/solid` umbrella re-exporting annotations + `flutter_solidart`.
-5. **M0-05** — `example/` with hand-written `source/counter.dart` and `lib/main.dart`. Must round-trip through the no-op builder without breaking.
-6. **M0-06** — `golden_test.dart` scaffolding so M1 TODOs just append names to a list.
+4. **M0-05** — `example/` with hand-written `source/counter.dart` and `lib/main.dart`. Must round-trip through the no-op builder without breaking.
+5. **M0-06** — `golden_test.dart` scaffolding so M1 TODOs just append names to a list.
 
 ## Cross-cutting concerns
 
@@ -32,7 +31,7 @@ Nothing about `@SolidState` works yet — only the plumbing.
 - **Analyzer suppressions.** `example/analysis_options.yaml` needs `must_be_immutable: ignore`, `always_put_required_named_parameters_first: ignore`, `invalid_annotation_target: ignore` so that a `StatelessWidget` with mutable `@SolidState` fields does not trip lint.
 - **Versions.** Pin minimums for `build: ^2.4.0`, `build_runner: ^2.10.1`, `build_config: ^1.1.0`, `analyzer: ^6`, `dart_style: ^2.3`, `flutter_solidart: ^2.7.0`. Document in `packages/solid_generator/pubspec.yaml`.
 - **`.gitignore`.** Ignore `.dart_tool/`, `.packages`, `build/`, `.flutter-plugins`, `.flutter-plugins-dependencies`. Do NOT ignore `example/source/**` or `example/lib/**` — both are committed review artifacts.
-- **Package names.** Per SPEC Section 14 item 5: `package:solid_annotations` hosts the annotations; `package:solid` is the umbrella users import.
+- **Package names.** Per SPEC Section 14 item 5: two packages. `package:solid_annotations` (runtime dep) hosts the annotations; `package:solid_generator` (dev_dep) hosts the builder. There is no `package:solid` umbrella. Users import `package:solid_annotations/solid_annotations.dart` for annotations and `package:flutter_solidart/flutter_solidart.dart` for reactive primitives.
 
 ## Exit criteria
 

--- a/plans/features/m1-solid-state-field.md
+++ b/plans/features/m1-solid-state-field.md
@@ -1,0 +1,79 @@
+# M1 — `@SolidState` on fields → `Signal`
+
+**TODOS.md items:** M1-01 → M1-13
+**SPEC sections:** 3.1, 4.1–4.4, 5.1–5.5, 6.0, 6.2, 7, 8.1–8.4, 9, 10, 14 items 4 and 7, 16 (#3, #4, #6, #8)
+**Reviewer rubric:** `plans/features/reviewer-rubric.md`
+
+## Purpose
+
+M1 is the first real implementation milestone: annotate a field with `@SolidState()`, get a reactive `Signal<T>` on a State class, with correct `.value` rewriting in `build()`, correct `SignalBuilder` placement around tracked reads, correct dispose ordering, and correct imports. Zero getters (that's M2); zero nuance beyond the minimal-subtree wrap rule for the canonical counter (finer granularity + untracked contexts are M3).
+
+A developer after M1 can:
+
+1. Write `@SolidState() int counter = 0;` on a `StatelessWidget`, `StatefulWidget`'s `State`, or a plain class.
+2. Read `counter` in `build()` as if it were an `int` — the generator adds `.value` and wraps the subtree in `SignalBuilder`.
+3. Write `counter++` in `onPressed` — the generator adds `.value` without wrapping the button.
+4. Hot-reload (via `dashmon` or manual `r`) between edits.
+5. Pop the page and see signals disposed.
+
+## TODO sequence
+
+### Stage A — field → Signal emission
+
+- **M1-01** — int field with initializer (canonical case; establishes class split + dispose + imports).
+- **M1-02** — `late` non-nullable field (default-value table + `late` preservation).
+- **M1-03** — nullable field (null default, no `late`).
+- **M1-04** — custom `name:` parameter (annotation arg plumbing).
+
+### Stage B — class-kind dispatch
+
+- **M1-06** — plain class (Section 8.3; synthesized `dispose()` without `super.dispose()`).
+- **M1-07** — existing `State<X>` in-place transformation + lifecycle preservation + existing-dispose merge (Section 8.2 + Section 14 item 4; fix for issue #3).
+- **M1-12** — passthrough for classes with zero `@Solid*` annotations (Section 8.4).
+- **M1-13** — `const` on the public widget constructor when defaults are `const`-compatible (Section 14 item 7).
+
+### Stage C — end-to-end counter
+
+- **M1-05** — blog-post canonical counter. Integrates field emission with:
+  - compound-assignment rewrite (Section 5.3)
+  - interpolation rewrite (Section 5.2)
+  - onPressed-callback untracked rule (Section 6.2)
+  - SignalBuilder minimum-subtree placement (Section 7.2)
+
+### Stage D — imports + idempotency
+
+- **M1-08** — import rewrite (Section 9; fix for issue #8).
+- **M1-09** — two-run byte equality (regression fence against accidental state).
+
+### Stage E — widget tests (ship as part of M1, not deferred)
+
+- **M1-10** — FAB tap rebuilds only `Text`, sibling does not.
+- **M1-11** — Navigator pop disposes signals via `SpySignal`.
+
+### Stage F — rejection paths
+
+- **M1-14** — reject every invalid `@SolidState` target enumerated in Section 3.1 (`final`, `const`, `static`, top-level, method, setter) with a clear per-case error message.
+- **M1-15** — reject `@SolidEffect` / `@SolidQuery` / `@SolidEnvironment` at build time with the Section 3.2 error ("not yet implemented; scheduled for a later v2 milestone").
+- **M1-02b** — reject `late T foo;` where `T` has no known default per the Section 4.2 table with the exact SPEC error quoted in that section.
+
+Stages are sequential inside M1 (A → B → C → D → E), but items within a stage can run in parallel if two agents share a worktree.
+
+## Cross-cutting concerns
+
+- **AST rewriter uses analyzer, not regex.** Every identifier rewrite (Section 5.1) is gated on resolved static type being `SignalBase<T>` or a subtype. Reviewer rubric item 3 blocks any regex-based transformation.
+- **Dispose ordering.** Reverse declaration order — `Computed` disposes before `Signal` (Section 10). M1 has no `Computed` yet, but M2 depends on this invariant, so emit even single-field dispose bodies with the ordering rule encoded (easier to extend than retrofit).
+- **Class-kind dispatch.** Implement as a visitor that walks the class declaration and returns one of four enum values: `statelessWidget`, `statefulWidget`, `stateClass`, `plainClass`. SPEC Section 8 is the truth table.
+- **Test helpers.** `BuildTracker` and `SpySignal` live in `example/test/helpers/`. Shared between M1-10, M1-11, and M3-04.
+- **`dart fix --apply` is the import pruner.** Per SPEC Section 9, the generator adds `flutter_solidart` but does NOT remove `solid_annotations`. The expectation is that users run `dart fix --apply` (or their IDE does). M1-08 asserts the raw generator output; the example app's CI (when it lands post-M1) will assert the post-`dart fix` state.
+- **Goldens are canonical.** If SPEC and a golden output disagree, SPEC wins and the golden is regenerated. Never modify SPEC to match a bug.
+
+## Exit criteria
+
+- All M1-01 through M1-15 items marked DONE.
+- `dart test packages/solid_generator/` passes: every golden + `idempotency_test.dart`.
+- `flutter test example/` passes: `counter_widget_test.dart` (M1-10) + `counter_dispose_test.dart` (M1-11).
+- `dart analyze --fatal-infos` across all packages reports zero issues.
+- `dart analyze packages/solid_generator/test/golden/outputs/` reports zero issues.
+- `dart format --set-exit-if-changed .` reports zero diff.
+- End-to-end smoke: run `example/` in a simulator, tap FAB, `Text` updates, sibling Container rebuild count stays at 0 (verify via Flutter DevTools inspector).
+- Reviewer rubric passes on every milestone PR.

--- a/plans/features/m2-solid-state-getter.md
+++ b/plans/features/m2-solid-state-getter.md
@@ -1,0 +1,40 @@
+# M2 — `@SolidState` on getters → `Computed`
+
+**TODOS.md items:** M2-01, M2-01b, M2-02 → M2-04
+**SPEC sections:** 3.1, 4.5, 4.6, 5.1, 7, 10
+**Reviewer rubric:** `plans/features/reviewer-rubric.md`
+
+## Purpose
+
+M2 adds `@SolidState` on getters: a derived reactive value whose body references other reactive declarations. The getter becomes a `late final Computed<T>` whose body is wrapped in a function expression, with identifier rewrites applied per SPEC Section 5.1. Disposal order is already established by M1-01 via reverse declaration order; M2 exercises it.
+
+A developer after M2 can:
+
+1. Write `@SolidState() int get doubleCounter => counter * 2;` next to an existing `@SolidState() int counter = 0;`.
+2. Read `doubleCounter` in `build()` and see `.value` appended + `SignalBuilder` wrapping.
+3. See the `Computed` disposed BEFORE the `Signal` it depends on when the widget is torn down.
+4. Get a clear build-time error if they write a Computed that reads no reactive state.
+
+## TODO sequence
+
+- **M2-01** — simple Computed with deps. Establishes the getter branch of the class visitor, the body rewrite, and the `late final Computed<T>(...)` shape. Expression-body form.
+- **M2-01b** — block-body getter (Section 4.6). Wraps the original block verbatim in a function expression; reuses the Section 5.1 rewriter for identifiers inside.
+- **M2-02** — zero-deps rejection. Validates that the generator emits the SPEC-specified error when a Computed has no reactive dependencies. The error message must match SPEC Section 4.5 exactly.
+- **M2-03** — Computed read in `build()`. Confirms that `doubleCounter` is rewritten to `doubleCounter.value` and wrapped in `SignalBuilder` — the type-driven Section 5.1 rule already covers this, so M2-03 is a regression fence, not new logic.
+- **M2-04** — explicit dispose-order golden. Validates reverse-declaration order emission in a class with both a Signal and a Computed.
+
+## Cross-cutting concerns
+
+- **Body rewriting reuses M1 machinery.** The Section 5.1 type-driven rewriter is already written by M1-05. M2's only new output is the `late final ... = Computed<T>(() => ..., name: '<n>')` wrapper + the dispose-order slot.
+- **Block-body vs expression-body getters.** SPEC Section 4.6 shows the block case: `{ ... }` is wrapped in a closure preserved verbatim (with identifier rewrites). M2-01 covers expression body; M2-01b covers the block-body case explicitly.
+- **No cross-class Computed in M1.** Per SPEC Section 4.5 (revised round 3): M1's rule is stated in terms of resolved type, so later `@SolidEnvironment` (M4+) adds cross-class deps without SPEC change. In M2 the only source of deps is same-class `@SolidState`.
+- **Rejection path.** M2-02's error must be raised during the build, not at runtime. A `TransformationError` type should carry the SPEC-quoted message with the offending getter name substituted in.
+
+## Exit criteria
+
+- All M2-01 through M2-04 items marked DONE.
+- `dart test packages/solid_generator/` passes.
+- `dart analyze packages/solid_generator/test/golden/outputs/m2_*.g.dart` reports zero issues.
+- M2-02's rejection test asserts the exact SPEC error message; reviewer cites Section 4.5.
+- M2-04's golden `dispose()` body has `computed.dispose()` before `signal.dispose()` before `super.dispose()`.
+- Reviewer rubric passes on the M2 PR.

--- a/plans/features/m3-untracked-and-granularity.md
+++ b/plans/features/m3-untracked-and-granularity.md
@@ -1,0 +1,57 @@
+# M3 — Untracked reads + fine-grained `SignalBuilder` placement
+
+**TODOS.md items:** M3-01 → M3-11
+**SPEC sections:** 5.1, 5.2, 5.4, 5.5, 6.0, 6.2, 6.3, 6.4, 6.5, 6.6, 7.1–7.5, 16 (#4, #6)
+**Reviewer rubric:** `plans/features/reviewer-rubric.md`
+
+## Purpose
+
+M3 hardens the rewriter against the v1 bugs that SPEC Section 16 enumerates: untracked reads that should not wrap (#4), tracked reads that were missed (#6), double-appending `.value.value`, string interpolation regressions, and siblings that rebuild together when they should not. Every case is a focused regression test against a real v1 failure.
+
+A developer after M3 can trust the generator in these scenarios:
+
+- `Text(counter)` rebuilds only `Text`.
+- `ValueKey(counter)` doesn't wrap the enclosing widget.
+- `onPressed: () => counter++` never subscribes.
+- `controller.value` (a `TextEditingController`) is left alone.
+- `'$counter'` becomes `'${counter.value}'`.
+- `untracked(() => counter)` reads once, no wrap.
+- `Builder(builder: (ctx) => Text(counter))` wraps `Text` in `SignalBuilder`.
+- A local shadowing a field is handled correctly.
+- Two sibling reads of different signals do not interfere.
+
+## TODO sequence
+
+- **M3-01** — `Text(counter)` inside `build` (fix for issue #6). Regression fence; core logic is in M1-05.
+- **M3-02** — `onPressed: () => counter++` (fix for issue #4). Regression fence; core logic is in M1-05.
+- **M3-03** — `ValueKey(counter)` untracked. Adds Section 6.3 Key-constructor list.
+- **M3-05** — type-aware no-double-append. Validates Section 5.4. Includes a `TextEditingController.value` case.
+- **M3-06** — string interpolation regression fence.
+- **M3-07** — explicit `untracked(() => ...)` opt-out (Section 6.4). Recognition by resolved identifier, not by name alone.
+- **M3-08** — Builder-style closures stay tracked (Section 6.6).
+- **M3-09** — shadowing (Section 5.5). Depends on M3-05 + M3-08 because it exercises both rules simultaneously.
+- **M3-10** — already-inside-SignalBuilder (Section 7.3). Hand-written `SignalBuilder` in source must not be double-wrapped.
+- **M3-11** — nested tracked reads (Section 7.5). Outer + inner both tracked; only inner wraps.
+- **M3-04** — sibling isolation widget test (Section 7.4). Ships last because it validates the whole M3 pipeline against a real widget tree.
+
+## Cross-cutting concerns
+
+- **Untracked-context detector.** One AST visitor recognizes four contexts:
+  1. user-interaction callbacks (Section 6.2 — enumerated parameter-name list).
+  2. Key constructors (Section 6.3 — `ValueKey`, `Key`, `ObjectKey`, `UniqueKey`, `GlobalKey`, `GlobalObjectKey`, `PageStorageKey`).
+  3. closures passed to the top-level `untracked<T>` function from `flutter_solidart` (Section 6.4).
+  4. writes (Section 6.0 — the assignment's LHS is always untracked; the RHS is a normal read per Section 5.3).
+- **Builder closure non-rule.** SPEC Section 6.6 is the explicit non-rule: `builder:`, `itemBuilder:`, etc. are NOT in the Section 6.2 list. The visitor must NOT treat them as untracked. M3-08 is the regression test.
+- **Sibling isolation.** M3-04 is a widget test, not a golden. Introduces a second `BuildTracker`-instrumented widget in the counter example; asserts both Text widgets each rebuild only when their respective signal changes.
+- **Type-driven rule is the single source of truth for `.value`.** The cases in M3-05, M3-06, M3-09 all reduce to SPEC Section 5.1 — if the identifier's resolved static type is `SignalBase<T>` or subtype, rewrite; otherwise leave alone. No special-case code per scenario; the test matrix validates generality.
+
+## Exit criteria
+
+- All M3-01 through M3-11 items marked DONE.
+- `dart test packages/solid_generator/` passes: every M3 golden + all prior goldens.
+- `flutter test example/` passes: M3-04 `sibling_isolation_test.dart` + all prior widget tests.
+- `dart analyze --fatal-infos` and `dart analyze packages/solid_generator/test/golden/outputs/` both zero.
+- `dart format --set-exit-if-changed .` zero diff.
+- End-to-end: sibling rebuild count in DevTools inspector is 0 while the signal being tapped rebuilds its own `Text` exactly once per tap.
+- Reviewer rubric passes on the M3 PR.
+- After M3 is green: SPEC Section 16 issue links (#4, #6) can be marked as resolved in the closing PR description.

--- a/plans/features/reviewer-rubric.md
+++ b/plans/features/reviewer-rubric.md
@@ -1,0 +1,39 @@
+# Reviewer Rubric (Solid v2)
+
+Applied to every implementation diff before marking a `TODOS.md` item DONE. All 8 must pass; a single failure blocks approval.
+
+## 8 checks
+
+1. **Exact input → exact output.** Every public function has a test asserting a specific input produces a specific output. No `isNotEmpty`, `isTrue`, or smoke-only assertions.
+2. **Paired golden files committed.** For every generator TODO, both `packages/solid_generator/test/golden/inputs/<name>.dart` and `packages/solid_generator/test/golden/outputs/<name>.g.dart` exist and are referenced from `packages/solid_generator/test/integration/golden_test.dart`.
+3. **No regex for code transformation.** All rewrites go through `package:analyzer` AST APIs. Regex is acceptable only for operational concerns (e.g., config parsing, error message assertions).
+4. **No `dynamic` casts.** Exception: analyzer APIs that genuinely return `dynamic` — preserved but narrowed as early as possible.
+5. **Toolchain green.** `dart test` passes locally. `dart analyze --fatal-infos` reports zero issues. `dart format --set-exit-if-changed .` reports zero diff.
+6. **Generated code is valid Dart.** `dart analyze packages/solid_generator/test/golden/outputs/` reports zero issues on every generated golden.
+7. **SPEC fidelity.** Output matches `SPEC.md` behavior for the relevant scenario. Reviewer cites the section number that justifies the behavior; if SPEC is silent or ambiguous, the reviewer blocks until SPEC is amended.
+8. **Discipline.** No debug prints. No file > 400 lines. No function > 50 lines. No new abstractions introduced beyond what the TODO requires.
+
+## Reviewer agent loop
+
+```
+round 1: implementer writes test + impl + /simplify pass → reviewer runs rubric
+round 2: implementer addresses CHANGES → reviewer re-runs rubric
+round 3: last chance — if reviewer still returns CHANGES, escalate to user
+```
+
+Reviewer verdict format:
+
+```
+VERDICT: APPROVED
+```
+
+OR
+
+```
+VERDICT: CHANGES
+
+1. [blocker] ...
+2. [nit] ...
+```
+
+Nits may be deferred with user approval; blockers may not.


### PR DESCRIPTION
## Summary

Adds `SPEC.md` at the repo root — the canonical product specification for a ground-up rewrite of Solid. This PR is **documentation only**. No code, no scaffolding, no tests. The SPEC is the gate: it must be reviewed and approved before any code is written.

## Why

The existing v1 generator (144★) was written end-to-end by GLM 4.7. Audit surfaced significant quality issues that are cheaper to address via a clean rebuild than incremental repair:

- `packages/solid_generator/lib/src/solid_builder.dart` is a 2565-line god-class that performs transformations via `String.replaceAllMapped` and `String.replaceRange` — regex over source text instead of analyzer AST. This is the root cause of issues #4 and #6.
- No CI workflow (`.github/` contains only `FUNDING.yml`). Tests run manually.
- Existing tests rely on `expect(..., isNotEmpty)`-style smoke assertions that pass even when the code is wrong.
- Debug `print('DEBUG: solidBuilder factory called!')` left in production at `lib/builder.dart:8`.
- Dead code: `transformAstWithResolver` accepts a `Resolver` arg and ignores it.
- `SolidProvider` uses an unsafe `(data as dynamic).dispose()` cast.

Rather than patch in place, we restart under Opus 4.7 with TDD, AST-based transformations, and a reviewer-loop discipline. Breaking changes are allowed; the blog-post vision (https://mariuti.com/posts/flutter-in-2025-forget-mvvm-embrace-fine-grained-reactivity-with-solid/) is preserved.

## What the SPEC locks

The 16 sections define user-facing behavior only — no implementation details (no file names, no class names, no AST internals). Reviewer agents cite this document by section number.

- **§2 Source/Generated model.** User writes annotated code in `source/`; Solid emits transformed code at the mirrored path under `lib/`. Both directories are committed. No `.g.dart` suffix. Source is analyzed with `must_be_immutable` silenced so `StatelessWidget` + mutable `@SolidState` fields pass.
- **§3 Annotations.** v1 scope is `@SolidState` only (field → `Signal<T>`, getter → `Computed<T>`). `@SolidEffect`, `@SolidQuery`, `@SolidEnvironment` are explicitly out of v1 scope and must fail with a clear error if used.
- **§4 Transformation rules.** Exact before/after Dart snippets for every case: field with initializer, field without initializer (with default-value table by type), nullable field, custom `name:`, getter without deps (`final`), getter with deps (`late final`), getter with block body.
- **§5 Reactive-read rules.** Identifier rewrite, string-interpolation rewrite, compound-assignment rewrite (full operator list), idempotent double-append protection, shadowing behavior.
- **§6 Untracked-context rules.** Fixes issues #4 and #6. Callback params (`onPressed`, `onTap`, etc. — full list) and Key constructors (`ValueKey`, `Key`, `ObjectKey`, etc.) get `.value` appended but are NOT wrapped in `SignalBuilder`.
- **§7 SignalBuilder placement.** Fine-grained rule: smallest widget subtree containing a tracked read, not already inside a `SignalBuilder`. Nested tracked reads wrap only the leaf.
- **§8 Class-kind handling.** Fixes issue #3. StatelessWidget → StatefulWidget+State pair; StatefulWidget → in-place on its State; existing `State<X>` → in-place; plain class → signals + synthesized `dispose()`.
- **§9 Import rules.** Fixes issue #8. Removes `solid_annotations`; adds `flutter_solidart` when any of {Signal, Computed, Effect, Resource, SignalBuilder, SolidartConfig} appears in output.
- **§10 dispose() contract.** Every generated Signal/Computed disposed in declaration order before `super.dispose()`.
- **§12 Hot reload contract.** Fixes issue #9. `dart run build_runner watch` + `flutter run` = single-save flow. No custom CLI.
- **§13 Out of scope for v1.** Effect, Query, Environment, SolidProvider, multi-file generation, Macros/augmentations, CI workflow (local test only until Actions budget permits).
- **§14 Open questions.** Seven points flagged for author resolution before M1 implementation: plain-class support, compound-operator list completeness, `final` field rejection, existing `initState`/`dispose` merge policy, user-facing package name, shadowing-rule strictness for v1, `const` constructor inference.
- **§16 Issue cross-reference.** Table mapping #3, #4, #6, #8, #9 to the SPEC sections that address them.

## Rollout

This PR is step 1 of a phased plan:

1. **Phase A (this PR):** SPEC.md only. Author reviews and locks behavior.
2. **Phase B:** `TODOS.md` + `plans/features/m{0..3}.md` — self-contained atomic tasks so fresh agents can resume.
3. **Phase C:** Archive v1 (`git tag v1-archive`) and wipe the GLM-authored generator source.
4. **Phase D — M0:** Scaffolding. `build_runner` with `'^source/{{}}.dart': ['lib/{{}}.dart']` mapping, no-op round-trip working.
5. **Phase E — M1→M3:** `@SolidState` field → Signal, then getter → Computed, then untracked reads + SignalBuilder granularity. Each milestone implemented via TDD agent loop: senior-dev implementer writes failing paired golden `.dart` files, implements to green, runs `/simplify`, then senior-dev reviewer loops until the 8-item rubric passes.

## Test plan

Documentation PR — no tests. SPEC itself becomes the acceptance contract for every subsequent code PR; the test tiers it mandates (paired golden files + `flutter test` widget tests asserting rebuild isolation) land in M1.
