### PR TITLE
feat: implement M1-03 — nullable field without initializer

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -365,7 +365,7 @@ class _ScoreState extends State<Score> {
 
 **Dependencies:** M1-01.
 
-**Status:** TODO
+**Status:** DONE
 
 ---
 

--- a/packages/solid_generator/lib/src/annotation_reader.dart
+++ b/packages/solid_generator/lib/src/annotation_reader.dart
@@ -33,6 +33,11 @@ FieldModel? readSolidStateField(FieldDeclaration decl, String source) {
           ),
     annotationName: _extractNameArgument(annotation),
     isLate: varList.isLate,
+    // `TypeAnnotation.question` is the `?` token at the top level of the
+    // declared type. Using it (vs. a `typeText.endsWith('?')` heuristic)
+    // correctly classifies nested-nullable types like `List<int?>` as
+    // non-nullable at the outer level (SPEC Section 4.3).
+    isNullable: type?.question != null,
   );
 }
 

--- a/packages/solid_generator/lib/src/field_model.dart
+++ b/packages/solid_generator/lib/src/field_model.dart
@@ -14,6 +14,7 @@ class FieldModel {
     required this.initializerText,
     required this.annotationName,
     required this.isLate,
+    required this.isNullable,
   });
 
   /// Declared identifier of the field (e.g. `'counter'`).
@@ -37,4 +38,13 @@ class FieldModel {
   /// Section 4.2). Preserved verbatim on the emitted `Signal` field so that
   /// `Signal` construction is deferred until first access.
   final bool isLate;
+
+  /// Whether the field's declared top-level type is nullable (SPEC Section
+  /// 4.3). True when the type annotation ends with `?` (e.g. `int?`,
+  /// `List<int>?`); false for non-nullable types (e.g. `int`, `List<int?>` —
+  /// the inner `?` does not make the outer type nullable). Determined from
+  /// the analyzer's `TypeAnnotation.question` token so nested generics are
+  /// handled correctly. A nullable field without an initializer emits
+  /// `Signal<T?>(null, name: '…')` rather than `Signal<T>.lazy(…)`.
+  final bool isNullable;
 }

--- a/packages/solid_generator/lib/src/stateless_rewriter.dart
+++ b/packages/solid_generator/lib/src/stateless_rewriter.dart
@@ -100,18 +100,34 @@ $dispose
 }''';
 }
 
-/// Emits one `[late ]final <name> = Signal<T>(…, name: '<debug>');` line per
-/// SPEC Section 4.1. When the source field is `late` with no initializer,
-/// emits `Signal<T>.lazy(name: '<debug>')` per SPEC Section 4.2 — reading
-/// `.value` before the first write throws `StateError`, matching Dart's own
-/// `late` semantics. The `late` modifier is preserved verbatim on the Dart
-/// field so that `Signal` construction itself is deferred to first access.
+/// Emits one `[late ]final <name> = Signal<T>(…, name: '<debug>');` line.
+///
+/// Three cases, in priority order:
+///
+/// 1. **Has initializer** (SPEC Section 4.1) →
+///    `Signal<T>(<init>, name: '<debug>')`. The `late` modifier (if any)
+///    is preserved verbatim so that `Signal` construction itself is deferred
+///    to first access.
+/// 2. **No initializer, nullable type** (SPEC Section 4.3) →
+///    `Signal<T?>(null, name: '<debug>')`. No `late` needed because `null`
+///    is a valid default.
+/// 3. **No initializer, non-nullable type** (SPEC Section 4.2) →
+///    `Signal<T>.lazy(name: '<debug>')`. The source field must have been
+///    declared `late` (the only way Dart accepts a non-nullable field with
+///    no initializer); the modifier is preserved on the emitted field so
+///    reads before the first write throw `StateError`, matching Dart's own
+///    `late` semantics.
 String _emitSignalField(FieldModel f) {
   final debugName = f.annotationName ?? f.fieldName;
   final lateKw = f.isLate ? 'late ' : '';
-  final ctor = f.initializerText.isNotEmpty
-      ? "Signal<${f.typeText}>(${f.initializerText}, name: '$debugName')"
-      : "Signal<${f.typeText}>.lazy(name: '$debugName')";
+  final String ctor;
+  if (f.initializerText.isNotEmpty) {
+    ctor = "Signal<${f.typeText}>(${f.initializerText}, name: '$debugName')";
+  } else if (f.isNullable) {
+    ctor = "Signal<${f.typeText}>(null, name: '$debugName')";
+  } else {
+    ctor = "Signal<${f.typeText}>.lazy(name: '$debugName')";
+  }
   return '  ${lateKw}final ${f.fieldName} = $ctor;';
 }
 

--- a/packages/solid_generator/test/golden/inputs/m1_03_nullable_int_field.dart
+++ b/packages/solid_generator/test/golden/inputs/m1_03_nullable_int_field.dart
@@ -1,0 +1,12 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+
+class Score extends StatelessWidget {
+  Score({super.key});
+
+  @SolidState()
+  int? value;
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/golden/outputs/m1_03_nullable_int_field.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m1_03_nullable_int_field.g.dart
@@ -1,0 +1,23 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class Score extends StatefulWidget {
+  const Score({super.key});
+
+  @override
+  State<Score> createState() => _ScoreState();
+}
+
+class _ScoreState extends State<Score> {
+  final value = Signal<int?>(null, name: 'value');
+
+  @override
+  void dispose() {
+    value.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/integration/golden_test.dart
+++ b/packages/solid_generator/test/integration/golden_test.dart
@@ -18,6 +18,7 @@ import 'package:test/test.dart';
 const List<String> _goldenNames = <String>[
   'm1_01_int_field_with_initializer',
   'm1_02_late_string_no_initializer',
+  'm1_03_nullable_int_field',
 ];
 
 /// Resolves the golden directory relative to the package root, regardless of


### PR DESCRIPTION
## Summary

- Implements M1-03 per SPEC Section 4.3: a `@SolidState()` on a nullable instance field with no initializer emits `final value = Signal<T?>(null, name: '…')` — no `late` modifier because `null` is a valid default.
- Completes the three-case field-emission logic: initializer → `Signal<T>(<init>, …)` (M1-01), nullable no-init → `Signal<T?>(null, …)` (this PR), `late` non-nullable no-init → `Signal<T>.lazy(…)` (M1-02).
- Nullability is determined from the analyzer's `TypeAnnotation.question` token, not a string heuristic, so nested generics (`List<int?>`) are correctly classified as non-nullable at the outer level.

## Changes

- `FieldModel`: new `isNullable` bool, required in the constructor and documented against SPEC Section 4.3.
- `annotation_reader.dart`: populates `isNullable` from `type?.question != null`.
- `stateless_rewriter.dart`: `_emitSignalField` restructured into an `if/else if/else` chain that enumerates the three SPEC cases with inline SPEC-section references.
- New paired golden `test/golden/{inputs,outputs}/m1_03_nullable_int_field{,.g}.dart` and a one-line addition to the `_goldenNames` list in the integration harness.
- `TODOS.md`: M1-03 marked `Status: DONE`.

## Test plan

- [x] `dart test packages/solid_generator/` — all three goldens (m1_01, m1_02, m1_03) pass
- [x] `dart analyze --fatal-infos` on the generator package — zero issues
- [x] `dart analyze --fatal-infos packages/solid_generator/test/golden/outputs/` — zero issues (generated golden is valid Dart)
- [x] `dart format --set-exit-if-changed` — no drift