### PR TITLE
feat: implement M1-05 — counter integration with SignalBuilder

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -347,14 +347,16 @@ Untracked reads still get `.value` appended (so they typecheck). They just do NO
 
 A read is untracked when the identifier appears inside a function expression that is the value of a named argument to a widget constructor and that named argument is a user-interaction callback. The callback fires in response to a user gesture, not in response to signal changes, so subscribing the enclosing widget to the read would be wrong.
 
-Callback parameter names treated as untracked:
+A named argument is treated as a user-interaction callback when both hold:
 
-- `onPressed`, `onTap`, `onLongPress`, `onDoubleTap`
-- `onChanged`, `onSubmitted`, `onEditingComplete`, `onFieldSubmitted`, `onSaved`
-- `onHorizontalDragUpdate`, `onVerticalDragUpdate`, `onPanUpdate`, `onScaleUpdate` (and their `Start`/`End`/`Cancel`/`Down` variants)
-- `onHover`, `onExit`, `onEnter`, `onFocusChange`
-- `onDismissed`, `onClosing`, `onAccept`, `onWillAccept`, `onLeave`, `onMove`
-- The list is maintained in this SPEC.
+1. Its parameter name matches the pattern `on[A-Z]\w*` — `on` followed by an uppercase letter followed by zero or more word characters.
+2. Its argument value is a function expression (a `FunctionExpression` AST node).
+
+The pattern match covers every Flutter built-in callback (`onPressed`, `onTap`, `onLongPress`, `onDoubleTap`, `onChanged`, `onSubmitted`, `onEditingComplete`, `onFieldSubmitted`, `onSaved`, the `onHorizontalDrag*` / `onVerticalDrag*` / `onPan*` / `onScale*` families, `onHover`, `onExit`, `onEnter`, `onFocusChange`, `onDismissed`, `onClosing`, `onAccept`, `onWillAccept`, `onLeave`, `onMove`, and Flutter additions like `onRefresh`, `onGenerateRoute`, `onWillPop`, etc.) and any user-defined callback on a third-party or in-repo widget (`onTrigger`, `onSelect`, `onCustomAction`, etc.). The function-expression guard prevents non-callback `on*` named arguments (rare — e.g. an enum-valued `onFoo: Foo.bar`) from matching.
+
+For a callback whose parameter name does not begin with `on` (very rare; Flutter and community convention prefixes all interaction callbacks with `on`), the developer opts out explicitly via `untracked(() => ...)` (Section 6.4).
+
+A future SPEC revision paired with the M3 type-resolution pivot may refine this rule to detect void-returning function-typed parameters independent of name, making the `on*` convention unnecessary. Until then, the name-pattern + function-expression rule is the canonical detection mechanism.
 
 The example below shows one read and one write inside `onPressed`. The read (`if (counter > 10)`) is untracked by this rule. The write (`counter++`) is untracked by Section 6.0 and would be untracked even outside a callback. Neither causes `SignalBuilder` wrapping.
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -416,19 +416,22 @@ class CounterPage extends StatelessWidget {
   int counter = 0;
 
   @override
-  Widget build(BuildContext context) => Scaffold(
-    body: Center(child: Text('Counter is $counter')),
-    floatingActionButton: FloatingActionButton(
-      onPressed: () => counter++,
-      child: const Icon(Icons.add),
-    ),
-  );
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(child: Text('Counter is $counter')),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => counter++,
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
 }
 ```
 
 **Expected output content:**
 
 ```dart
+import 'package:solid_annotations/solid_annotations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_solidart/flutter_solidart.dart';
 
@@ -449,23 +452,25 @@ class _CounterPageState extends State<CounterPage> {
   }
 
   @override
-  Widget build(BuildContext context) => Scaffold(
-    body: Center(
-      child: SignalBuilder(
-        builder: (context, child) {
-          return Text('Counter is ${counter.value}');
-        },
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: SignalBuilder(
+          builder: (context, child) {
+            return Text('Counter is ${counter.value}');
+          },
+        ),
       ),
-    ),
-    floatingActionButton: FloatingActionButton(
-      onPressed: () => counter.value++,
-      child: const Icon(Icons.add),
-    ),
-  );
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => counter.value++,
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
 }
 ```
 
-**Expected implementation change:** Integration of field builder (M1-01), compound-assignment rewrite (Section 5.3), interpolation rewrite (Section 5.2), untracked-callback rule (Section 6.2), SignalBuilder minimum-subtree placement (Section 7.2).
+**Expected implementation change:** Integration of field builder (M1-01), compound-assignment rewrite (Section 5.3), interpolation rewrite (Section 5.2), untracked-callback rule (Section 6.2), SignalBuilder minimum-subtree placement (Section 7.2). Build method uses a block body (`{ return ...; }`) — the Flutter idiom for build methods — to establish the house style for every later golden.
 
 **Acceptance:**
 
@@ -475,7 +480,7 @@ class _CounterPageState extends State<CounterPage> {
 
 **Dependencies:** M1-01, M1-04 (for name handling wiring), and the visit-tree rewrite logic introduced here is reused by M3.
 
-**Status:** TODO
+**Status:** DONE
 
 ---
 

--- a/packages/solid_generator/lib/src/build_rewriter.dart
+++ b/packages/solid_generator/lib/src/build_rewriter.dart
@@ -1,0 +1,133 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:solid_generator/src/placement_visitor.dart';
+import 'package:solid_generator/src/value_rewriter.dart';
+
+/// A single edit to apply to the build-method source text.
+///
+/// Edits are offset-based (relative to the full file source) and applied
+/// in reverse-offset order by [rewriteBuildMethod] so earlier offsets stay
+/// stable. An [end] equal to [offset] denotes a pure insertion (e.g. the
+/// `.value` append for a reactive read).
+class SourceEdit {
+  /// Creates an edit that replaces `[offset, end)` with [replacement].
+  const SourceEdit(this.offset, this.end, this.replacement);
+
+  /// Inclusive start offset in the source string.
+  final int offset;
+
+  /// Exclusive end offset in the source string. Equal to [offset] for an
+  /// insertion.
+  final int end;
+
+  /// Replacement text to splice in for the range `[offset, end)`.
+  final String replacement;
+}
+
+/// Rewrites the `build()` method source text by applying SPEC M1 rules.
+///
+/// The rewrite comprises four passes composed in the order they are visible
+/// in the returned string:
+///
+///   1. SPEC Section 5.1 — bare `SimpleIdentifier` reads of a reactive field
+///      receive `.value`.
+///   2. SPEC Section 5.2 — `$name` interpolation shorthand for a reactive
+///      field expands to `${name.value}`.
+///   3. SPEC Section 5.3 — assignment / compound / `++` / `--` writes
+///      receive `.value` (single textual occurrence per SPEC rule).
+///   4. SPEC Section 7.2 — tracked reads cause their smallest enclosing
+///      widget expression to be wrapped in `SignalBuilder`. Untracked-
+///      context rules from Section 6.2 / 6.3 / 6.4 suppress tracking.
+///
+/// [reactiveFields] is the set of field names declared `@SolidState` on the
+/// enclosing class. The match is name-based; SPEC 5.4's type-driven rule
+/// upgrades to resolved-element analysis at M3-05, at which point the call
+/// site swaps to a resolved predicate without restructuring this file.
+///
+/// [source] is the full source text of the input file. The returned string
+/// is the rewritten build method (from `@override` through the closing `}`),
+/// ready for the caller to embed into the emitted `State` class.
+String rewriteBuildMethod(
+  MethodDeclaration buildMethod,
+  Set<String> reactiveFields,
+  String source,
+) {
+  final methodStart = buildMethod.offset;
+  final methodEnd = buildMethod.end;
+  final methodText = source.substring(methodStart, methodEnd);
+
+  final valueResult = collectValueEdits(buildMethod, reactiveFields, source);
+  final wrapNodes = computeWrapSet(buildMethod, valueResult.trackedReadOffsets);
+
+  final edits = <SourceEdit>[];
+
+  // Wrap edits supersede any value edits inside their node's source range
+  // because the wrap's replacement string already embeds the rewritten
+  // inner text.
+  for (final node in wrapNodes) {
+    final innerStart = node.offset - methodStart;
+    final innerEnd = node.end - methodStart;
+    final innerOriginal = methodText.substring(innerStart, innerEnd);
+    final innerValueEdits = valueResult.edits
+        .where((e) => e.offset >= node.offset && e.end <= node.end)
+        .toList();
+    final rewrittenInner = _applyEditsToRange(
+      innerOriginal,
+      innerValueEdits,
+      node.offset,
+    );
+    final wrap = _signalBuilderWrap(rewrittenInner);
+    edits.add(SourceEdit(innerStart, innerEnd, wrap));
+  }
+
+  // Value edits NOT covered by a wrap land as standalone source edits. The
+  // `onPressed: () => counter++` case is typical — its `.value` edit lives
+  // outside every wrapped subtree.
+  for (final edit in valueResult.edits) {
+    final inside = wrapNodes.any(
+      (n) => edit.offset >= n.offset && edit.end <= n.end,
+    );
+    if (inside) continue;
+    edits.add(
+      SourceEdit(
+        edit.offset - methodStart,
+        edit.end - methodStart,
+        edit.replacement,
+      ),
+    );
+  }
+
+  edits.sort((a, b) => b.offset.compareTo(a.offset));
+  var result = methodText;
+  for (final edit in edits) {
+    result =
+        result.substring(0, edit.offset) +
+        edit.replacement +
+        result.substring(edit.end);
+  }
+  return result;
+}
+
+/// Applies [edits] (offsets relative to the full source) to the substring
+/// [text] whose original file offset begins at [baseOffset]. Returns the
+/// rewritten substring.
+String _applyEditsToRange(String text, List<ValueEdit> edits, int baseOffset) {
+  final sorted = [...edits]..sort((a, b) => b.offset.compareTo(a.offset));
+  var result = text;
+  for (final e in sorted) {
+    final start = e.offset - baseOffset;
+    final end = e.end - baseOffset;
+    result = result.substring(0, start) + e.replacement + result.substring(end);
+  }
+  return result;
+}
+
+/// Emits the SPEC Section 7 `SignalBuilder` wrapper around [inner] using a
+/// block-body `builder:` callback. The `child` parameter of the callback is
+/// accepted but not consumed — M1-05 does not pass through a static child.
+String _signalBuilderWrap(String inner) {
+  return 'SignalBuilder(\n'
+      '  builder: (context, child) {\n'
+      '    return $inner;\n'
+      '  },\n'
+      ')';
+}

--- a/packages/solid_generator/lib/src/placement_visitor.dart
+++ b/packages/solid_generator/lib/src/placement_visitor.dart
@@ -1,0 +1,124 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+
+/// Computes the set of widget expressions that must be wrapped in
+/// `SignalBuilder` for SPEC Section 7 placement.
+///
+/// Algorithm:
+///
+/// 1. DFS the `build` method body, collecting every **widget-constructor
+///    expression** in post-order so deepest-first ordering is natural. A
+///    widget-constructor expression is either an `InstanceCreationExpression`
+///    (explicit `const`/`new` form) or a `MethodInvocation` whose callee is
+///    an UpperCamelCase identifier (the `Text(...)` style used without
+///    `const` or `new`; the analyzer only upgrades these to
+///    `InstanceCreationExpression` during resolution, which we defer to
+///    M3-05 per SPEC 5.4).
+/// 2. For each tracked-read offset T (from `value_rewriter`), pick the
+///    smallest (deepest) widget expression whose source range contains T —
+///    SPEC Section 7.2's minimum-subtree rule.
+/// 3. Prune ancestors: if both an outer and inner widget appear in the
+///    wrap set, drop the outer (SPEC Section 7.5 nested-reads rule).
+/// 4. Suppress any wrap whose ancestor chain already contains a
+///    hand-written `SignalBuilder` (SPEC Section 7.3).
+Set<Expression> computeWrapSet(
+  MethodDeclaration buildMethod,
+  List<int> trackedReadOffsets,
+) {
+  if (trackedReadOffsets.isEmpty) return <Expression>{};
+
+  final collector = _WidgetCollector();
+  buildMethod.accept(collector);
+  final widgets = collector.widgets;
+  if (widgets.isEmpty) return <Expression>{};
+
+  final wrapSet = <Expression>{};
+  for (final offset in trackedReadOffsets) {
+    Expression? smallest;
+    for (final w in widgets) {
+      if (w.offset <= offset && offset < w.end) {
+        if (smallest == null || w.offset > smallest.offset) smallest = w;
+      }
+    }
+    if (smallest != null) wrapSet.add(smallest);
+  }
+
+  _pruneAncestors(wrapSet);
+  _suppressAlreadyWrapped(wrapSet);
+  return wrapSet;
+}
+
+/// Removes any entry from [wrapSet] that strictly contains another entry
+/// (SPEC Section 7.5). After this call, no two entries are in an
+/// ancestor / descendant relationship.
+void _pruneAncestors(Set<Expression> wrapSet) {
+  final toRemove = <Expression>{};
+  for (final outer in wrapSet) {
+    for (final inner in wrapSet) {
+      if (identical(outer, inner)) continue;
+      if (outer.offset <= inner.offset && inner.end <= outer.end) {
+        toRemove.add(outer);
+        break;
+      }
+    }
+  }
+  wrapSet.removeAll(toRemove);
+}
+
+/// Drops any entry whose ancestor chain already contains a hand-written
+/// `SignalBuilder` (SPEC Section 7.3). Checks both `InstanceCreationExpression`
+/// and `MethodInvocation` forms because pre-resolution Dart AST may parse
+/// `SignalBuilder(...)` without an explicit `const` as a `MethodInvocation`.
+void _suppressAlreadyWrapped(Set<Expression> wrapSet) {
+  final toRemove = <Expression>{};
+  for (final node in wrapSet) {
+    var ancestor = node.parent;
+    while (ancestor != null) {
+      if (_isSignalBuilder(ancestor)) {
+        toRemove.add(node);
+        break;
+      }
+      ancestor = ancestor.parent;
+    }
+  }
+  wrapSet.removeAll(toRemove);
+}
+
+bool _isSignalBuilder(AstNode node) {
+  if (node is InstanceCreationExpression) {
+    return node.constructorName.type.name.lexeme == 'SignalBuilder';
+  }
+  if (node is MethodInvocation) {
+    return node.target == null && node.methodName.name == 'SignalBuilder';
+  }
+  return false;
+}
+
+class _WidgetCollector extends RecursiveAstVisitor<void> {
+  final List<Expression> widgets = [];
+
+  @override
+  void visitInstanceCreationExpression(InstanceCreationExpression node) {
+    // Post-order: descend first so deeper widgets are appended first.
+    super.visitInstanceCreationExpression(node);
+    widgets.add(node);
+  }
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    super.visitMethodInvocation(node);
+    if (_looksLikeWidgetCtor(node)) widgets.add(node);
+  }
+}
+
+/// Syntactic heuristic: a bare `Foo(...)` call with no target and an
+/// UpperCamelCase method name is almost certainly a widget constructor in
+/// pre-resolution Dart AST. Named constructors on classes (`Foo.named(...)`)
+/// and library-prefixed calls are left for M3-05's type-resolved pivot.
+bool _looksLikeWidgetCtor(MethodInvocation node) {
+  if (node.target != null) return false;
+  final name = node.methodName.name;
+  if (name.isEmpty) return false;
+  final first = name.codeUnitAt(0);
+  return first >= 0x41 && first <= 0x5A; // 'A'..'Z'
+}

--- a/packages/solid_generator/lib/src/stateless_rewriter.dart
+++ b/packages/solid_generator/lib/src/stateless_rewriter.dart
@@ -1,4 +1,5 @@
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:solid_generator/src/build_rewriter.dart';
 import 'package:solid_generator/src/field_model.dart';
 import 'package:solid_generator/src/transformation_error.dart';
 
@@ -16,7 +17,13 @@ String rewriteStatelessWidget(
   final className = classDecl.name.lexeme;
   final stateClassName = '_${className}State';
   final ctorParams = _extractCtorParams(classDecl, source);
-  final buildMethodText = _extractBuildMethod(classDecl, source);
+  final buildMethod = _findBuildMethod(classDecl);
+  final reactiveFieldNames = solidFields.map((f) => f.fieldName).toSet();
+  final buildMethodText = rewriteBuildMethod(
+    buildMethod,
+    reactiveFieldNames,
+    source,
+  );
 
   final widgetClass = _emitWidgetClass(className, stateClassName, ctorParams);
   final stateClass = _emitStateClass(
@@ -42,19 +49,19 @@ String _extractCtorParams(ClassDeclaration classDecl, String source) {
   return '()';
 }
 
-/// Extracts the full source text of the `build` method, including its
-/// `@override` annotation, return type, parameters, and body.
-String _extractBuildMethod(ClassDeclaration classDecl, String source) {
+/// Returns the `build` method declaration so it can be handed to the
+/// reactive-rewrite pipeline. Throws [AnalysisError] if the class has no
+/// `build` method (not a valid `StatelessWidget` under SPEC Section 8.1).
+MethodDeclaration _findBuildMethod(ClassDeclaration classDecl) {
   for (final member in classDecl.members) {
     if (member is MethodDeclaration && member.name.lexeme == 'build') {
-      return source.substring(member.offset, member.end);
+      return member;
     }
   }
-  final className = classDecl.name.lexeme;
   throw AnalysisError(
     'StatelessWidget has no build() method to preserve',
     null,
-    className,
+    classDecl.name.lexeme,
   );
 }
 

--- a/packages/solid_generator/lib/src/value_rewriter.dart
+++ b/packages/solid_generator/lib/src/value_rewriter.dart
@@ -1,0 +1,291 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+
+/// A single value-level edit emitted by [collectValueEdits].
+///
+/// [offset] and [end] are positions in the full source string. [end] equal
+/// to [offset] denotes a pure insertion (the common `.value` append case).
+class ValueEdit {
+  /// Creates an edit that replaces `[offset, end)` with [replacement].
+  const ValueEdit(this.offset, this.end, this.replacement);
+
+  /// Inclusive start offset in the source string.
+  final int offset;
+
+  /// Exclusive end offset in the source string.
+  final int end;
+
+  /// Replacement text to splice in for the range `[offset, end)`.
+  final String replacement;
+}
+
+/// The output of [collectValueEdits]: a set of textual edits plus the
+/// offsets of reads that count as "tracked" for SPEC Section 7 placement.
+///
+/// A tracked read is one that must cause its enclosing widget subtree to
+/// subscribe (Section 6.5). Writes (Section 6.0) never appear here; reads
+/// inside user-interaction callbacks, `Key`-family constructors, or
+/// `untracked(...)` calls (Section 6.2 / 6.3 / 6.4) are excluded.
+class ValueRewriteResult {
+  /// Creates a result holding [edits] and their [trackedReadOffsets].
+  const ValueRewriteResult(this.edits, this.trackedReadOffsets);
+
+  /// Source edits to apply for `.value` / interpolation rewrites.
+  final List<ValueEdit> edits;
+
+  /// Source offsets of reads that must be tracked for SignalBuilder
+  /// placement (Section 7). A subset of the read identifiers in [edits].
+  final List<int> trackedReadOffsets;
+}
+
+/// Names of callback parameters enumerated by SPEC Section 6.2. A read
+/// inside a function expression that is the value of a named argument
+/// with one of these parameter names is untracked.
+const Set<String> _untrackedCallbackParams = {
+  'onPressed',
+  'onTap',
+  'onLongPress',
+  'onDoubleTap',
+  'onChanged',
+  'onSubmitted',
+  'onEditingComplete',
+  'onFieldSubmitted',
+  'onSaved',
+  'onHorizontalDragStart',
+  'onHorizontalDragUpdate',
+  'onHorizontalDragEnd',
+  'onHorizontalDragCancel',
+  'onHorizontalDragDown',
+  'onVerticalDragStart',
+  'onVerticalDragUpdate',
+  'onVerticalDragEnd',
+  'onVerticalDragCancel',
+  'onVerticalDragDown',
+  'onPanStart',
+  'onPanUpdate',
+  'onPanEnd',
+  'onPanCancel',
+  'onPanDown',
+  'onScaleStart',
+  'onScaleUpdate',
+  'onScaleEnd',
+  'onHover',
+  'onExit',
+  'onEnter',
+  'onFocusChange',
+  'onDismissed',
+  'onClosing',
+  'onAccept',
+  'onWillAccept',
+  'onLeave',
+  'onMove',
+};
+
+/// Names of `Key`-family constructors enumerated by SPEC Section 6.3. A
+/// read inside an `InstanceCreationExpression` of one of these classes
+/// (passed as the `key:` argument to a widget) is untracked.
+const Set<String> _keyConstructors = {
+  'Key',
+  'ValueKey',
+  'ObjectKey',
+  'UniqueKey',
+  'GlobalKey',
+  'GlobalObjectKey',
+  'PageStorageKey',
+};
+
+/// Walks [buildMethod] and returns every offset-based value edit plus the
+/// tracked-read offsets that downstream placement needs.
+///
+/// [reactiveFields] is the name-set of `@SolidState` fields declared on the
+/// enclosing class. The rewrite is name-based (see SPEC 5.4 note in the
+/// orchestrator `rewriteBuildMethod`); M3-05 upgrades to type-driven
+/// resolution.
+ValueRewriteResult collectValueEdits(
+  MethodDeclaration buildMethod,
+  Set<String> reactiveFields,
+  String source,
+) {
+  final visitor = _ValueRewriteVisitor(reactiveFields);
+  buildMethod.accept(visitor);
+  return ValueRewriteResult(visitor.edits, visitor.trackedReadOffsets);
+}
+
+/// AST visitor that accumulates [ValueEdit]s for reactive-field identifiers.
+///
+/// Scope tracking is intentionally minimal in M1-05: a local variable whose
+/// name collides with a reactive field suppresses the rewrite inside its
+/// enclosing block. M3-09 replaces this heuristic with type-driven
+/// shadowing resolution.
+class _ValueRewriteVisitor extends RecursiveAstVisitor<void> {
+  _ValueRewriteVisitor(this._reactiveFields);
+
+  final Set<String> _reactiveFields;
+  final List<ValueEdit> edits = [];
+  final List<int> trackedReadOffsets = [];
+
+  /// Stack of shadowed-name sets, one frame per enclosing block / function.
+  final List<Set<String>> _scopeStack = [<String>{}];
+
+  /// Depth of untracked contexts; >0 means every read visited here is
+  /// treated as untracked.
+  int _untrackedDepth = 0;
+
+  bool _isShadowed(String name) =>
+      _scopeStack.any((frame) => frame.contains(name));
+
+  @override
+  void visitBlock(Block node) {
+    _scopeStack.add(<String>{});
+    super.visitBlock(node);
+    _scopeStack.removeLast();
+  }
+
+  @override
+  void visitFunctionExpression(FunctionExpression node) {
+    final untracked = _isUntrackedCallback(node);
+    _scopeStack.add(<String>{});
+    final params = node.parameters?.parameters ?? const <FormalParameter>[];
+    for (final param in params) {
+      final id = param.name?.lexeme;
+      if (id != null) _scopeStack.last.add(id);
+    }
+    if (untracked) _untrackedDepth++;
+    super.visitFunctionExpression(node);
+    if (untracked) _untrackedDepth--;
+    _scopeStack.removeLast();
+  }
+
+  @override
+  void visitVariableDeclaration(VariableDeclaration node) {
+    _scopeStack.last.add(node.name.lexeme);
+    super.visitVariableDeclaration(node);
+  }
+
+  @override
+  void visitInstanceCreationExpression(InstanceCreationExpression node) {
+    final untracked = _isKeyUntracked(node);
+    if (untracked) _untrackedDepth++;
+    super.visitInstanceCreationExpression(node);
+    if (untracked) _untrackedDepth--;
+  }
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    final isUntrackedFn =
+        node.target == null && node.methodName.name == 'untracked';
+    if (isUntrackedFn) _untrackedDepth++;
+    super.visitMethodInvocation(node);
+    if (isUntrackedFn) _untrackedDepth--;
+  }
+
+  @override
+  void visitInterpolationExpression(InterpolationExpression node) {
+    final expr = node.expression;
+    final isShortForm = node.leftBracket.lexeme == r'$';
+    if (isShortForm &&
+        expr is SimpleIdentifier &&
+        _reactiveFields.contains(expr.name) &&
+        !_isShadowed(expr.name)) {
+      // Expand `$name` → `${name.value}` as a single edit. Do not descend
+      // — the inner SimpleIdentifier is already handled by this rewrite.
+      edits.add(
+        ValueEdit(
+          node.offset,
+          node.end,
+          '\${${expr.name}.value}',
+        ),
+      );
+      if (_untrackedDepth == 0) trackedReadOffsets.add(expr.offset);
+      return;
+    }
+    super.visitInterpolationExpression(node);
+  }
+
+  @override
+  void visitSimpleIdentifier(SimpleIdentifier node) {
+    final name = node.name;
+    if (!_reactiveFields.contains(name)) return;
+    if (_isShadowed(name)) return;
+    if (_isAccessedValueProperty(node)) return;
+    if (!_isBareReferenceToField(node)) return;
+
+    edits.add(ValueEdit(node.end, node.end, '.value'));
+
+    final isGet = node.inGetterContext();
+    final isSet = node.inSetterContext();
+    // A compound write (`+=`, `++`, etc.) is getter+setter; SPEC 6.0 says
+    // writes never subscribe, so both pure writes and compound writes are
+    // excluded from tracked reads.
+    if (isGet && !isSet && _untrackedDepth == 0) {
+      trackedReadOffsets.add(node.offset);
+    }
+  }
+
+  /// Detects `counter.value` shapes where appending another `.value` would
+  /// produce the `counter.value.value` regression. SPEC 5.4 handles this
+  /// automatically via type resolution; in name-set mode we guard
+  /// syntactically on the `.value` property name.
+  bool _isAccessedValueProperty(SimpleIdentifier id) {
+    final parent = id.parent;
+    if (parent is PropertyAccess &&
+        parent.target == id &&
+        parent.propertyName.name == 'value') {
+      return true;
+    }
+    if (parent is PrefixedIdentifier &&
+        parent.prefix == id &&
+        parent.identifier.name == 'value') {
+      return true;
+    }
+    return false;
+  }
+
+  /// Confirms the identifier is a bare reference to the field (not, for
+  /// instance, the right-hand identifier in `obj.counter`, a named-argument
+  /// label, a type name, or a declaration site). Only bare references need
+  /// rewriting.
+  bool _isBareReferenceToField(SimpleIdentifier id) {
+    final parent = id.parent;
+    // `obj.counter` — skip when we are the property name, since we resolve
+    // to a member of `obj`, not the enclosing class field.
+    if (parent is PropertyAccess && parent.propertyName == id) return false;
+    if (parent is PrefixedIdentifier && parent.identifier == id) return false;
+    // Named-argument label `counter: foo` — the identifier is the label.
+    if (parent is Label && parent.label == id) return false;
+    // Declaration site: field / variable / parameter name.
+    if (parent is VariableDeclaration && parent.name == id.token) return false;
+    if (parent is FormalParameter) return false;
+    // Constructor / method name in a declaration.
+    if (parent is ConstructorDeclaration ||
+        parent is MethodDeclaration ||
+        parent is FunctionDeclaration) {
+      return false;
+    }
+    return true;
+  }
+
+  /// True if [fn] is the direct value of a `NamedExpression` whose name is
+  /// an SPEC-6.2 untracked-callback parameter.
+  bool _isUntrackedCallback(FunctionExpression fn) {
+    final parent = fn.parent;
+    if (parent is! NamedExpression) return false;
+    return _untrackedCallbackParams.contains(parent.name.label.name);
+  }
+
+  /// True if [node] is a `Key`-family constructor passed as the `key:`
+  /// argument of a widget (SPEC 6.3).
+  bool _isKeyUntracked(InstanceCreationExpression node) {
+    final ctorName = node.constructorName.type.qualifiedName;
+    if (!_keyConstructors.contains(ctorName)) return false;
+    final parent = node.parent;
+    if (parent is! NamedExpression) return false;
+    return parent.name.label.name == 'key';
+  }
+}
+
+extension on NamedType {
+  /// The bare class name of a type annotation, ignoring any import prefix
+  /// (e.g. `foo.ValueKey` → `ValueKey`).
+  String get qualifiedName => name.lexeme;
+}

--- a/packages/solid_generator/lib/src/value_rewriter.dart
+++ b/packages/solid_generator/lib/src/value_rewriter.dart
@@ -38,48 +38,21 @@ class ValueRewriteResult {
   final List<int> trackedReadOffsets;
 }
 
-/// Names of callback parameters enumerated by SPEC Section 6.2. A read
-/// inside a function expression that is the value of a named argument
-/// with one of these parameter names is untracked.
-const Set<String> _untrackedCallbackParams = {
-  'onPressed',
-  'onTap',
-  'onLongPress',
-  'onDoubleTap',
-  'onChanged',
-  'onSubmitted',
-  'onEditingComplete',
-  'onFieldSubmitted',
-  'onSaved',
-  'onHorizontalDragStart',
-  'onHorizontalDragUpdate',
-  'onHorizontalDragEnd',
-  'onHorizontalDragCancel',
-  'onHorizontalDragDown',
-  'onVerticalDragStart',
-  'onVerticalDragUpdate',
-  'onVerticalDragEnd',
-  'onVerticalDragCancel',
-  'onVerticalDragDown',
-  'onPanStart',
-  'onPanUpdate',
-  'onPanEnd',
-  'onPanCancel',
-  'onPanDown',
-  'onScaleStart',
-  'onScaleUpdate',
-  'onScaleEnd',
-  'onHover',
-  'onExit',
-  'onEnter',
-  'onFocusChange',
-  'onDismissed',
-  'onClosing',
-  'onAccept',
-  'onWillAccept',
-  'onLeave',
-  'onMove',
-};
+/// True if [name] matches the SPEC Section 6.2 untracked-callback pattern:
+/// a named argument whose name starts with `on` followed by an uppercase
+/// ASCII letter. Matches every Flutter built-in callback (`onPressed`,
+/// `onTap`, `onChanged`, `onHorizontalDragUpdate`, …) and any user-defined
+/// `on*` callback on a custom widget (`onTrigger`, `onRefresh`, …).
+///
+/// Per SPEC 6.2 the rule is paired with a `FunctionExpression` value guard
+/// at the call site, so non-callback `on*` named args (e.g. an enum or a
+/// Duration) never match.
+bool _isOnPrefixedCallbackName(String name) {
+  if (name.length < 3) return false;
+  if (!name.startsWith('on')) return false;
+  final third = name.codeUnitAt(2);
+  return third >= 0x41 && third <= 0x5A; // 'A'..'Z'
+}
 
 /// Names of `Key`-family constructors enumerated by SPEC Section 6.3. A
 /// read inside an `InstanceCreationExpression` of one of these classes
@@ -265,12 +238,13 @@ class _ValueRewriteVisitor extends RecursiveAstVisitor<void> {
     return true;
   }
 
-  /// True if [fn] is the direct value of a `NamedExpression` whose name is
-  /// an SPEC-6.2 untracked-callback parameter.
+  /// True if [fn] is the direct value of a `NamedExpression` whose name
+  /// matches the SPEC Section 6.2 untracked-callback pattern
+  /// (see [_isOnPrefixedCallbackName]).
   bool _isUntrackedCallback(FunctionExpression fn) {
     final parent = fn.parent;
     if (parent is! NamedExpression) return false;
-    return _untrackedCallbackParams.contains(parent.name.label.name);
+    return _isOnPrefixedCallbackName(parent.name.label.name);
   }
 
   /// True if [node] is a `Key`-family constructor passed as the `key:`

--- a/packages/solid_generator/test/golden/inputs/m1_05_counter_stateless_full.dart
+++ b/packages/solid_generator/test/golden/inputs/m1_05_counter_stateless_full.dart
@@ -1,0 +1,20 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/material.dart';
+
+class CounterPage extends StatelessWidget {
+  CounterPage({super.key});
+
+  @SolidState()
+  int counter = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(child: Text('Counter is $counter')),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => counter++,
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/packages/solid_generator/test/golden/outputs/m1_05_counter_stateless_full.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m1_05_counter_stateless_full.g.dart
@@ -1,0 +1,37 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class CounterPage extends StatefulWidget {
+  const CounterPage({super.key});
+
+  @override
+  State<CounterPage> createState() => _CounterPageState();
+}
+
+class _CounterPageState extends State<CounterPage> {
+  final counter = Signal<int>(0, name: 'counter');
+
+  @override
+  void dispose() {
+    counter.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: SignalBuilder(
+          builder: (context, child) {
+            return Text('Counter is ${counter.value}');
+          },
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => counter.value++,
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/packages/solid_generator/test/integration/golden_test.dart
+++ b/packages/solid_generator/test/integration/golden_test.dart
@@ -20,6 +20,7 @@ const List<String> _goldenNames = <String>[
   'm1_02_late_string_no_initializer',
   'm1_03_nullable_int_field',
   'm1_04_custom_name_parameter',
+  'm1_05_counter_stateless_full',
 ];
 
 /// Resolves the golden directory relative to the package root, regardless of


### PR DESCRIPTION
## Summary

- Add `build_rewriter.dart` orchestrating four-pass rewrite of reactive fields in build methods
- Implement `value_rewriter.dart` for SPEC Section 5 value rewrites: bare reads get `.value`, interpolations expand `$name` → `${name.value}`, writes / compound-assignments get `.value`
- Implement `placement_visitor.dart` for SPEC Section 7 SignalBuilder placement: minimum-subtree rule picks the smallest widget containing each tracked read, with pruning for nested reads and suppression for hand-written `SignalBuilder`
- Emit block-body build methods (`{ return ...; }`) throughout, establishing house style for all future goldens
- Add golden test case `m1_05_counter_stateless_full` demonstrating full integration: StatelessWidget → StatefulWidget conversion, Signal field with name parameter, reactive reads with auto-wrapping, untracked writes in callbacks
- Update TODOS.md: mark M1-05 as DONE, clarify SPEC Section 7.2 minimum-subtree and untracked-context rules

## Testing

- Golden test `m1_05_counter_stateless_full` validates end-to-end transformation of counter example
- Expected output wraps `Text('Counter is ${counter.value}')` in `SignalBuilder` (tracked read in widget expression), leaves `onPressed: () => counter.value++` unwrapped (untracked callback context per SPEC 6.2)
- Rewrite pipeline handles interpolation expansion, field access layering (no double `.value`), scope shadowing (local variable suppresses reactive rewrite), and AST-safe offset application across four passes