### PR TITLE
feat: implement M1-06 — plain class with signals

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -513,6 +513,7 @@ class Counter {
 **Expected output content:**
 
 ```dart
+import 'package:solid_annotations/solid_annotations.dart';
 import 'package:flutter_solidart/flutter_solidart.dart';
 
 class Counter {
@@ -526,13 +527,15 @@ class Counter {
 }
 ```
 
+(Per SPEC §9 the generator preserves every source import verbatim and never prunes; unused-import cleanup is `dart fix --apply`'s job.)
+
 **Expected implementation change:** Class-kind dispatch adds "plain class" branch (Section 8.3). Dispose synthesis uses reverse declaration order (Section 10) and omits `super.dispose()` when the supertype chain has no `dispose()` method.
 
 **Acceptance:** `dart test --name=m1_06` passes; golden analyzes clean.
 
 **Dependencies:** M1-01.
 
-**Status:** TODO
+**Status:** DONE
 
 ---
 

--- a/packages/solid_generator/lib/builder.dart
+++ b/packages/solid_generator/lib/builder.dart
@@ -8,6 +8,7 @@ import 'package:solid_generator/src/annotation_reader.dart';
 import 'package:solid_generator/src/class_kind.dart';
 import 'package:solid_generator/src/field_model.dart';
 import 'package:solid_generator/src/import_rewriter.dart';
+import 'package:solid_generator/src/plain_class_rewriter.dart';
 import 'package:solid_generator/src/stateless_rewriter.dart';
 import 'package:solid_generator/src/transformation_error.dart';
 
@@ -143,11 +144,12 @@ String _rewriteClass(
   switch (kind) {
     case ClassKind.statelessWidget:
       return rewriteStatelessWidget(decl, fields, source);
+    case ClassKind.plainClass:
+      return rewritePlainClass(decl, fields, source);
     case ClassKind.statefulWidget:
     case ClassKind.stateClass:
-    case ClassKind.plainClass:
       throw CodeGenerationError(
-        'class-kind $kind is not supported in M1-01 '
+        'class-kind $kind is not supported yet '
         '(scheduled for a later M1 TODO)',
         null,
         decl.name.lexeme,

--- a/packages/solid_generator/lib/src/plain_class_rewriter.dart
+++ b/packages/solid_generator/lib/src/plain_class_rewriter.dart
@@ -10,21 +10,17 @@ import 'package:solid_generator/src/transformation_error.dart';
 /// See SPEC §8.3 and §10. The synthesized `dispose()` has neither `@override`
 /// nor `super.dispose()` because the supertype chain is `Object` only.
 ///
-/// **M1-06 scope.** This rewriter only handles classes whose every member is
-/// an `@SolidState`-annotated field. The following deferred cases throw
-/// [CodeGenerationError] rather than silently dropping data:
-///
-/// - Existing user-declared `dispose()` method (SPEC §10 merge algorithm) —
-///   scheduled for a later M1 TODO.
-/// - Any non-annotated field, constructor, method, or other member —
-///   scheduled for a later M1 TODO that introduces in-place SourceEdit
-///   patching (analogous to M1-07's `State<X>` approach).
+/// Currently only classes whose every member is an `@SolidState`-annotated
+/// field are supported. Any other member (existing `dispose()`, constructors,
+/// non-annotated fields, methods, …) throws [CodeGenerationError] —
+/// dispose-merge and in-place patching are scheduled for later milestones.
 ///
 /// The emitted string is syntactically valid Dart but is not guaranteed to be
 /// pretty-printed — run through `DartFormatter` before writing.
 ///
-/// The [source] parameter is unused today (full reconstruction) but is kept
-/// for signature parity with the other class-kind rewriters.
+/// [source] is unused here (full reconstruction from AST); it is part of the
+/// signature so the dispatcher in `builder.dart` can pass it uniformly to
+/// every class-kind rewriter.
 String rewritePlainClass(
   ClassDeclaration classDecl,
   List<FieldModel> solidFields,
@@ -34,11 +30,7 @@ String rewritePlainClass(
   _checkUnsupportedMembers(classDecl, solidFields, className);
 
   final signalFields = solidFields.map(emitSignalField).join('\n');
-  final dispose = emitDispose(
-    solidFields,
-    emitOverride: false,
-    emitSuperCall: false,
-  );
+  final dispose = emitDispose(solidFields, inheritsDispose: false);
 
   return '''
 class $className {
@@ -48,9 +40,9 @@ $dispose
 }''';
 }
 
-/// Throws [CodeGenerationError] if the class contains any member that is not
-/// an `@SolidState` field. Deferred cases are surfaced explicitly rather than
-/// silently dropped so the developer learns the case is unsupported.
+/// Throws [CodeGenerationError] if [classDecl] contains any member other than
+/// an `@SolidState` field. Surfacing these explicitly avoids silently dropping
+/// user code while the rewriter is incomplete.
 void _checkUnsupportedMembers(
   ClassDeclaration classDecl,
   List<FieldModel> solidFields,
@@ -62,29 +54,30 @@ void _checkUnsupportedMembers(
       final varName = member.fields.variables.first.name.lexeme;
       if (!annotatedNames.contains(varName)) {
         throw CodeGenerationError(
-          'plain class with non-annotated field "$varName" is not supported '
-          'in M1-06 (scheduled for a later M1 TODO that introduces in-place '
-          'patching)',
+          'plain class with non-annotated field "$varName" is not yet '
+          'supported',
           null,
           className,
         );
       }
-    } else if (member is MethodDeclaration && member.name.lexeme == 'dispose') {
-      throw CodeGenerationError(
-        'plain class with existing dispose() method is not supported in '
-        'M1-06 (scheduled for a later M1 TODO that adds dispose-merge '
-        'support per SPEC §10)',
-        null,
-        className,
-      );
-    } else {
-      throw CodeGenerationError(
-        'plain class with member of kind ${member.runtimeType} is not '
-        'supported in M1-06 (scheduled for a later M1 TODO that introduces '
-        'in-place patching)',
-        null,
-        className,
-      );
+      continue;
     }
+    throw CodeGenerationError(
+      'plain class with ${_memberKindLabel(member)} is not yet supported',
+      null,
+      className,
+    );
   }
+}
+
+/// Human-readable label for an unsupported [ClassMember], used in error
+/// messages. Avoids leaking the analyzer's `…Impl` runtime type names.
+String _memberKindLabel(ClassMember member) {
+  if (member is MethodDeclaration) {
+    return member.name.lexeme == 'dispose'
+        ? 'existing dispose() method'
+        : 'method "${member.name.lexeme}"';
+  }
+  if (member is ConstructorDeclaration) return 'constructor';
+  return 'member';
 }

--- a/packages/solid_generator/lib/src/plain_class_rewriter.dart
+++ b/packages/solid_generator/lib/src/plain_class_rewriter.dart
@@ -1,0 +1,90 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:solid_generator/src/field_model.dart';
+import 'package:solid_generator/src/signal_emitter.dart';
+import 'package:solid_generator/src/transformation_error.dart';
+
+/// Rewrites a plain Dart class (no widget supertype) containing `@SolidState`
+/// fields by replacing each annotated field with a `Signal<T>(…)` and
+/// synthesizing a fresh `dispose()` method.
+///
+/// See SPEC §8.3 and §10. The synthesized `dispose()` has neither `@override`
+/// nor `super.dispose()` because the supertype chain is `Object` only.
+///
+/// **M1-06 scope.** This rewriter only handles classes whose every member is
+/// an `@SolidState`-annotated field. The following deferred cases throw
+/// [CodeGenerationError] rather than silently dropping data:
+///
+/// - Existing user-declared `dispose()` method (SPEC §10 merge algorithm) —
+///   scheduled for a later M1 TODO.
+/// - Any non-annotated field, constructor, method, or other member —
+///   scheduled for a later M1 TODO that introduces in-place SourceEdit
+///   patching (analogous to M1-07's `State<X>` approach).
+///
+/// The emitted string is syntactically valid Dart but is not guaranteed to be
+/// pretty-printed — run through `DartFormatter` before writing.
+///
+/// The [source] parameter is unused today (full reconstruction) but is kept
+/// for signature parity with the other class-kind rewriters.
+String rewritePlainClass(
+  ClassDeclaration classDecl,
+  List<FieldModel> solidFields,
+  String source,
+) {
+  final className = classDecl.name.lexeme;
+  _checkUnsupportedMembers(classDecl, solidFields, className);
+
+  final signalFields = solidFields.map(emitSignalField).join('\n');
+  final dispose = emitDispose(
+    solidFields,
+    emitOverride: false,
+    emitSuperCall: false,
+  );
+
+  return '''
+class $className {
+$signalFields
+
+$dispose
+}''';
+}
+
+/// Throws [CodeGenerationError] if the class contains any member that is not
+/// an `@SolidState` field. Deferred cases are surfaced explicitly rather than
+/// silently dropped so the developer learns the case is unsupported.
+void _checkUnsupportedMembers(
+  ClassDeclaration classDecl,
+  List<FieldModel> solidFields,
+  String className,
+) {
+  final annotatedNames = solidFields.map((f) => f.fieldName).toSet();
+  for (final member in classDecl.members) {
+    if (member is FieldDeclaration) {
+      final varName = member.fields.variables.first.name.lexeme;
+      if (!annotatedNames.contains(varName)) {
+        throw CodeGenerationError(
+          'plain class with non-annotated field "$varName" is not supported '
+          'in M1-06 (scheduled for a later M1 TODO that introduces in-place '
+          'patching)',
+          null,
+          className,
+        );
+      }
+    } else if (member is MethodDeclaration && member.name.lexeme == 'dispose') {
+      throw CodeGenerationError(
+        'plain class with existing dispose() method is not supported in '
+        'M1-06 (scheduled for a later M1 TODO that adds dispose-merge '
+        'support per SPEC §10)',
+        null,
+        className,
+      );
+    } else {
+      throw CodeGenerationError(
+        'plain class with member of kind ${member.runtimeType} is not '
+        'supported in M1-06 (scheduled for a later M1 TODO that introduces '
+        'in-place patching)',
+        null,
+        className,
+      );
+    }
+  }
+}

--- a/packages/solid_generator/lib/src/signal_emitter.dart
+++ b/packages/solid_generator/lib/src/signal_emitter.dart
@@ -1,11 +1,6 @@
 import 'package:solid_generator/src/field_model.dart';
 
 /// Shared signal-emission helpers used by every class-kind rewriter.
-///
-/// Centralising these here keeps the SPEC §4.1/4.2/4.3 signal construction
-/// rules and the SPEC §10 dispose contract in a single place — rewriters for
-/// `StatelessWidget`, plain classes, and (later) `State<X>` all share the same
-/// output shape.
 
 /// Emits one `[late ]final <name> = Signal<T>(…, name: '<debug>');` line.
 ///
@@ -39,30 +34,26 @@ String emitSignalField(FieldModel f) {
 }
 
 /// Emits a `dispose()` method disposing every signal in reverse declaration
-/// order (SPEC Section 10).
+/// order (SPEC §10).
 ///
-/// [emitOverride] controls whether `@override` is prepended — `true` for
-/// `State<X>` subclasses (which override `State.dispose`), `false` for plain
-/// classes (no inherited `dispose` to override).
-///
-/// [emitSuperCall] controls whether `super.dispose();` is appended — `true`
-/// when the supertype chain contains a `dispose()` method (e.g. `State<T>`,
-/// `ChangeNotifier`), `false` for a plain class whose supertype chain is just
-/// `Object` (SPEC §8.3 / §10).
+/// [inheritsDispose] is `true` when the owning class's supertype chain contains
+/// a `dispose()` method (e.g. `State<T>`, `ChangeNotifier`); the emitted method
+/// is then `@override` and ends with `super.dispose();`. For a plain class
+/// whose supertype is `Object`, pass `false` — neither annotation nor
+/// super-call is emitted (SPEC §8.3).
 String emitDispose(
   List<FieldModel> fields, {
-  required bool emitOverride,
-  required bool emitSuperCall,
+  required bool inheritsDispose,
 }) {
   final buffer = StringBuffer();
-  if (emitOverride) {
+  if (inheritsDispose) {
     buffer.writeln('  @override');
   }
   buffer.writeln('  void dispose() {');
   for (final f in fields.reversed) {
     buffer.writeln('    ${f.fieldName}.dispose();');
   }
-  if (emitSuperCall) {
+  if (inheritsDispose) {
     buffer.writeln('    super.dispose();');
   }
   buffer.write('  }');

--- a/packages/solid_generator/lib/src/signal_emitter.dart
+++ b/packages/solid_generator/lib/src/signal_emitter.dart
@@ -1,0 +1,70 @@
+import 'package:solid_generator/src/field_model.dart';
+
+/// Shared signal-emission helpers used by every class-kind rewriter.
+///
+/// Centralising these here keeps the SPEC §4.1/4.2/4.3 signal construction
+/// rules and the SPEC §10 dispose contract in a single place — rewriters for
+/// `StatelessWidget`, plain classes, and (later) `State<X>` all share the same
+/// output shape.
+
+/// Emits one `[late ]final <name> = Signal<T>(…, name: '<debug>');` line.
+///
+/// Three cases, in priority order:
+///
+/// 1. **Has initializer** (SPEC Section 4.1) →
+///    `Signal<T>(<init>, name: '<debug>')`. The `late` modifier (if any)
+///    is preserved verbatim so that `Signal` construction itself is deferred
+///    to first access.
+/// 2. **No initializer, nullable type** (SPEC Section 4.3) →
+///    `Signal<T?>(null, name: '<debug>')`. No `late` needed because `null`
+///    is a valid default.
+/// 3. **No initializer, non-nullable type** (SPEC Section 4.2) →
+///    `Signal<T>.lazy(name: '<debug>')`. The source field must have been
+///    declared `late` (the only way Dart accepts a non-nullable field with
+///    no initializer); the modifier is preserved on the emitted field so
+///    reads before the first write throw `StateError`, matching Dart's own
+///    `late` semantics.
+String emitSignalField(FieldModel f) {
+  final debugName = f.annotationName ?? f.fieldName;
+  final lateKw = f.isLate ? 'late ' : '';
+  final String ctor;
+  if (f.initializerText.isNotEmpty) {
+    ctor = "Signal<${f.typeText}>(${f.initializerText}, name: '$debugName')";
+  } else if (f.isNullable) {
+    ctor = "Signal<${f.typeText}>(null, name: '$debugName')";
+  } else {
+    ctor = "Signal<${f.typeText}>.lazy(name: '$debugName')";
+  }
+  return '  ${lateKw}final ${f.fieldName} = $ctor;';
+}
+
+/// Emits a `dispose()` method disposing every signal in reverse declaration
+/// order (SPEC Section 10).
+///
+/// [emitOverride] controls whether `@override` is prepended — `true` for
+/// `State<X>` subclasses (which override `State.dispose`), `false` for plain
+/// classes (no inherited `dispose` to override).
+///
+/// [emitSuperCall] controls whether `super.dispose();` is appended — `true`
+/// when the supertype chain contains a `dispose()` method (e.g. `State<T>`,
+/// `ChangeNotifier`), `false` for a plain class whose supertype chain is just
+/// `Object` (SPEC §8.3 / §10).
+String emitDispose(
+  List<FieldModel> fields, {
+  required bool emitOverride,
+  required bool emitSuperCall,
+}) {
+  final buffer = StringBuffer();
+  if (emitOverride) {
+    buffer.writeln('  @override');
+  }
+  buffer.writeln('  void dispose() {');
+  for (final f in fields.reversed) {
+    buffer.writeln('    ${f.fieldName}.dispose();');
+  }
+  if (emitSuperCall) {
+    buffer.writeln('    super.dispose();');
+  }
+  buffer.write('  }');
+  return buffer.toString();
+}

--- a/packages/solid_generator/lib/src/stateless_rewriter.dart
+++ b/packages/solid_generator/lib/src/stateless_rewriter.dart
@@ -1,6 +1,7 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:solid_generator/src/build_rewriter.dart';
 import 'package:solid_generator/src/field_model.dart';
+import 'package:solid_generator/src/signal_emitter.dart';
 import 'package:solid_generator/src/transformation_error.dart';
 
 /// Rewrites a `StatelessWidget` class containing `@SolidState` fields as a
@@ -88,14 +89,21 @@ class $className extends StatefulWidget {
 }
 
 /// Emits the private `State<X>` half of the class split (SPEC Section 8.1).
+///
+/// `State<T>` has `dispose()` in its supertype chain, so the synthesized
+/// `dispose()` is `@override` and ends with `super.dispose();` (SPEC §10).
 String _emitStateClass(
   String className,
   String stateClassName,
   List<FieldModel> fields,
   String buildMethodText,
 ) {
-  final signalFields = fields.map(_emitSignalField).join('\n');
-  final dispose = _emitDispose(fields);
+  final signalFields = fields.map(emitSignalField).join('\n');
+  final dispose = emitDispose(
+    fields,
+    emitOverride: true,
+    emitSuperCall: true,
+  );
 
   return '''
 class $stateClassName extends State<$className> {
@@ -105,51 +113,4 @@ $dispose
 
   $buildMethodText
 }''';
-}
-
-/// Emits one `[late ]final <name> = Signal<T>(…, name: '<debug>');` line.
-///
-/// Three cases, in priority order:
-///
-/// 1. **Has initializer** (SPEC Section 4.1) →
-///    `Signal<T>(<init>, name: '<debug>')`. The `late` modifier (if any)
-///    is preserved verbatim so that `Signal` construction itself is deferred
-///    to first access.
-/// 2. **No initializer, nullable type** (SPEC Section 4.3) →
-///    `Signal<T?>(null, name: '<debug>')`. No `late` needed because `null`
-///    is a valid default.
-/// 3. **No initializer, non-nullable type** (SPEC Section 4.2) →
-///    `Signal<T>.lazy(name: '<debug>')`. The source field must have been
-///    declared `late` (the only way Dart accepts a non-nullable field with
-///    no initializer); the modifier is preserved on the emitted field so
-///    reads before the first write throw `StateError`, matching Dart's own
-///    `late` semantics.
-String _emitSignalField(FieldModel f) {
-  final debugName = f.annotationName ?? f.fieldName;
-  final lateKw = f.isLate ? 'late ' : '';
-  final String ctor;
-  if (f.initializerText.isNotEmpty) {
-    ctor = "Signal<${f.typeText}>(${f.initializerText}, name: '$debugName')";
-  } else if (f.isNullable) {
-    ctor = "Signal<${f.typeText}>(null, name: '$debugName')";
-  } else {
-    ctor = "Signal<${f.typeText}>.lazy(name: '$debugName')";
-  }
-  return '  ${lateKw}final ${f.fieldName} = $ctor;';
-}
-
-/// Emits the `dispose()` method disposing every signal in reverse declaration
-/// order (SPEC Section 10). `super.dispose()` is always emitted here because
-/// `State<T>` has `dispose()` in its supertype chain.
-String _emitDispose(List<FieldModel> fields) {
-  final buffer = StringBuffer()
-    ..writeln('  @override')
-    ..writeln('  void dispose() {');
-  for (final f in fields.reversed) {
-    buffer.writeln('    ${f.fieldName}.dispose();');
-  }
-  buffer
-    ..writeln('    super.dispose();')
-    ..write('  }');
-  return buffer.toString();
 }

--- a/packages/solid_generator/lib/src/stateless_rewriter.dart
+++ b/packages/solid_generator/lib/src/stateless_rewriter.dart
@@ -99,11 +99,7 @@ String _emitStateClass(
   String buildMethodText,
 ) {
   final signalFields = fields.map(emitSignalField).join('\n');
-  final dispose = emitDispose(
-    fields,
-    emitOverride: true,
-    emitSuperCall: true,
-  );
+  final dispose = emitDispose(fields, inheritsDispose: true);
 
   return '''
 class $stateClassName extends State<$className> {

--- a/packages/solid_generator/test/golden/inputs/m1_06_plain_class_no_widget.dart
+++ b/packages/solid_generator/test/golden/inputs/m1_06_plain_class_no_widget.dart
@@ -1,0 +1,9 @@
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Counter {
+  @SolidState()
+  int value = 0;
+
+  @SolidState()
+  String label = '';
+}

--- a/packages/solid_generator/test/golden/outputs/m1_06_plain_class_no_widget.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m1_06_plain_class_no_widget.g.dart
@@ -1,0 +1,12 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class Counter {
+  final value = Signal<int>(0, name: 'value');
+  final label = Signal<String>('', name: 'label');
+
+  void dispose() {
+    label.dispose();
+    value.dispose();
+  }
+}

--- a/packages/solid_generator/test/integration/golden_test.dart
+++ b/packages/solid_generator/test/integration/golden_test.dart
@@ -21,6 +21,7 @@ const List<String> _goldenNames = <String>[
   'm1_03_nullable_int_field',
   'm1_04_custom_name_parameter',
   'm1_05_counter_stateless_full',
+  'm1_06_plain_class_no_widget',
 ];
 
 /// Resolves the golden directory relative to the package root, regardless of


### PR DESCRIPTION
## Summary

- Add `rewritePlainClass()` to handle plain Dart classes (no widget supertype) with `@SolidState` fields
- Extract shared signal-emission logic into `signal_emitter.dart` for reuse across class-kind rewriters (`StatelessWidget`, plain class, and future `State<X>`)
- Synthesize `dispose()` method in reverse declaration order, omitting `@override` and `super.dispose()` since plain classes inherit only from `Object`
- Enforce M1-06 scope: plain classes must contain only `@SolidState`-annotated fields; deferred unsupported cases throw `CodeGenerationError`
- Update dispatcher in `builder.dart` to route `ClassKind.plainClass` to the new rewriter
- Add golden test case `m1_06_plain_class_no_widget` covering basic signal transformation and dispose synthesis

## Testing

- Golden test `m1_06_plain_class_no_widget` verifies signal field transformation and dispose method generation
- `dart test --name=m1_06` passes
- Golden analysis reports clean output