### PR TITLE
feat: implement M1-07 — existing State class rewriting

### DIFF
--- a/packages/solid_generator/lib/builder.dart
+++ b/packages/solid_generator/lib/builder.dart
@@ -9,6 +9,7 @@ import 'package:solid_generator/src/class_kind.dart';
 import 'package:solid_generator/src/field_model.dart';
 import 'package:solid_generator/src/import_rewriter.dart';
 import 'package:solid_generator/src/plain_class_rewriter.dart';
+import 'package:solid_generator/src/state_class_rewriter.dart';
 import 'package:solid_generator/src/stateless_rewriter.dart';
 import 'package:solid_generator/src/transformation_error.dart';
 
@@ -146,8 +147,9 @@ String _rewriteClass(
       return rewriteStatelessWidget(decl, fields, source);
     case ClassKind.plainClass:
       return rewritePlainClass(decl, fields, source);
-    case ClassKind.statefulWidget:
     case ClassKind.stateClass:
+      return rewriteStateClass(decl, fields, source);
+    case ClassKind.statefulWidget:
       throw CodeGenerationError(
         'class-kind $kind is not supported yet '
         '(scheduled for a later M1 TODO)',

--- a/packages/solid_generator/lib/src/state_class_rewriter.dart
+++ b/packages/solid_generator/lib/src/state_class_rewriter.dart
@@ -1,5 +1,4 @@
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:solid_generator/src/annotation_reader.dart';
 import 'package:solid_generator/src/build_rewriter.dart';
 import 'package:solid_generator/src/field_model.dart';
 import 'package:solid_generator/src/signal_emitter.dart';
@@ -27,13 +26,18 @@ String rewriteStateClass(
   String source,
 ) {
   final className = classDecl.name.lexeme;
-  final reactiveNames = solidFields.map((f) => f.fieldName).toSet();
+  // Index annotated fields by name for O(1) lookup during the member walk.
+  // The builder already parsed `@SolidState` once when computing [solidFields];
+  // re-parsing here would double the annotation-reader cost per file.
+  final modelByName = {for (final f in solidFields) f.fieldName: f};
+  final reactiveNames = modelByName.keys.toSet();
   final pieces = <String>[];
   var sawDispose = false;
 
   for (final member in classDecl.members) {
     if (member is FieldDeclaration) {
-      final model = readSolidStateField(member, source);
+      final varName = member.fields.variables.first.name.lexeme;
+      final model = modelByName[varName];
       if (model != null) {
         pieces.add(emitSignalField(model));
       } else {

--- a/packages/solid_generator/lib/src/state_class_rewriter.dart
+++ b/packages/solid_generator/lib/src/state_class_rewriter.dart
@@ -1,0 +1,105 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:solid_generator/src/annotation_reader.dart';
+import 'package:solid_generator/src/build_rewriter.dart';
+import 'package:solid_generator/src/field_model.dart';
+import 'package:solid_generator/src/signal_emitter.dart';
+import 'package:solid_generator/src/transformation_error.dart';
+
+/// Rewrites an existing `State<X>` subclass containing `@SolidState` fields
+/// **in place** — without splitting the class. Replaces every `@SolidState`
+/// field with a `Signal<T>(…)` declaration, routes `build()` through the
+/// reactive-read pipeline, and merges reactive disposals into any existing
+/// `dispose()` body.
+///
+/// See SPEC §8.2 and §10. This is the fix for issue #3 — a `StatefulWidget`
+/// whose `State<X>` subclass declared `@SolidState` fields was silently passed
+/// through unchanged in v1.
+///
+/// Member ordering and non-annotated members (other fields, `initState`,
+/// `didUpdateWidget`, user methods, constructors, …) are emitted verbatim
+/// from [source] so that lifecycle bodies round-trip byte-identical.
+///
+/// The emitted string is syntactically valid Dart but is not guaranteed to be
+/// pretty-printed — run through `DartFormatter` before writing.
+String rewriteStateClass(
+  ClassDeclaration classDecl,
+  List<FieldModel> solidFields,
+  String source,
+) {
+  final className = classDecl.name.lexeme;
+  final reactiveNames = solidFields.map((f) => f.fieldName).toSet();
+  final pieces = <String>[];
+  var sawDispose = false;
+
+  for (final member in classDecl.members) {
+    if (member is FieldDeclaration) {
+      final model = readSolidStateField(member, source);
+      if (model != null) {
+        pieces.add(emitSignalField(model));
+      } else {
+        pieces.add(source.substring(member.offset, member.end));
+      }
+      continue;
+    }
+    if (member is MethodDeclaration) {
+      final name = member.name.lexeme;
+      if (name == 'build') {
+        pieces.add(rewriteBuildMethod(member, reactiveNames, source));
+      } else if (name == 'dispose') {
+        pieces.add(_mergeDispose(member, solidFields, source, className));
+        sawDispose = true;
+      } else {
+        pieces.add(source.substring(member.offset, member.end));
+      }
+      continue;
+    }
+    pieces.add(source.substring(member.offset, member.end));
+  }
+
+  if (!sawDispose) {
+    pieces.add(emitDispose(solidFields, inheritsDispose: true));
+  }
+
+  final header = source.substring(
+    classDecl.offset,
+    classDecl.leftBracket.offset,
+  );
+  return '$header{\n${pieces.join('\n\n')}\n}';
+}
+
+/// Prepends one `<field>.dispose();` call per reactive declaration to the
+/// existing `dispose()` body's leading boundary, leaving the rest of the body
+/// untouched (SPEC §10).
+///
+/// Disposal order is reverse declaration order so dependents (e.g. `Computed`)
+/// are torn down before their dependencies (the `Signal`s they read).
+///
+/// Throws [CodeGenerationError] if the existing `dispose()` uses an
+/// expression body (`=> …`) — the merge is only well-defined for a block.
+String _mergeDispose(
+  MethodDeclaration method,
+  List<FieldModel> fields,
+  String source,
+  String className,
+) {
+  final body = method.body;
+  if (body is! BlockFunctionBody) {
+    throw CodeGenerationError(
+      'existing dispose() must have a block body for reactive merge',
+      null,
+      className,
+    );
+  }
+  final lbrace = body.block.leftBracket.offset;
+  // The original source after `{` already begins with `\n` (the body's first
+  // line break) on every reasonable formatting; prepending `\n<disposals>`
+  // yields a single blank-line-free splice, leaving the rest of the body
+  // byte-identical to the source. The `DartFormatter` pass normalises any
+  // residual whitespace.
+  final disposals = fields.reversed
+      .map((f) => '    ${f.fieldName}.dispose();')
+      .join('\n');
+  return '${source.substring(method.offset, lbrace + 1)}'
+      '\n$disposals'
+      '${source.substring(lbrace + 1, method.end)}';
+}

--- a/packages/solid_generator/test/golden/inputs/m1_07_existing_state_class.dart
+++ b/packages/solid_generator/test/golden/inputs/m1_07_existing_state_class.dart
@@ -1,0 +1,40 @@
+import 'dart:async';
+
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+
+class Counter extends StatefulWidget {
+  const Counter({super.key});
+
+  @override
+  State<Counter> createState() => _CounterState();
+}
+
+class _CounterState extends State<Counter> {
+  @SolidState()
+  int counter = 0;
+
+  final StreamSubscription<void> _subscription =
+      Stream<void>.periodic(const Duration(seconds: 1)).listen((_) {});
+
+  @override
+  void initState() {
+    super.initState();
+    debugPrint('init');
+  }
+
+  @override
+  void didUpdateWidget(covariant Counter oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    debugPrint('update');
+  }
+
+  @override
+  void dispose() {
+    unawaited(_subscription.cancel());
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/golden/outputs/m1_07_existing_state_class.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m1_07_existing_state_class.g.dart
@@ -1,0 +1,41 @@
+import 'dart:async';
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class Counter extends StatefulWidget {
+  const Counter({super.key});
+
+  @override
+  State<Counter> createState() => _CounterState();
+}
+
+class _CounterState extends State<Counter> {
+  final counter = Signal<int>(0, name: 'counter');
+
+  final StreamSubscription<void> _subscription = Stream<void>.periodic(
+    const Duration(seconds: 1),
+  ).listen((_) {});
+
+  @override
+  void initState() {
+    super.initState();
+    debugPrint('init');
+  }
+
+  @override
+  void didUpdateWidget(covariant Counter oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    debugPrint('update');
+  }
+
+  @override
+  void dispose() {
+    counter.dispose();
+    unawaited(_subscription.cancel());
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/integration/golden_test.dart
+++ b/packages/solid_generator/test/integration/golden_test.dart
@@ -22,6 +22,7 @@ const List<String> _goldenNames = <String>[
   'm1_04_custom_name_parameter',
   'm1_05_counter_stateless_full',
   'm1_06_plain_class_no_widget',
+  'm1_07_existing_state_class',
 ];
 
 /// Resolves the golden directory relative to the package root, regardless of


### PR DESCRIPTION
## Summary

- Add `StateClassRewriter` to transform `@SolidState` fields in existing `State<X>` subclasses into `Signal<T>()` declarations in place
- Rewrites `build()` method to route through reactive-read pipeline
- Merges reactive disposals into existing `dispose()` body or creates new one if absent
- Maintains member ordering and preserves non-annotated members (lifecycle methods, user methods, other fields) byte-identical from source
- Routes `ClassKind.stateClass` to new rewriter in builder; handles disposal merge validation per SPEC §10

## Testing

- Golden test added for M1-07 with existing `State<Counter>` subclass containing `@SolidState` field, stream subscription, and custom `dispose()` body
- Verified `counter` field replaced with `Signal<int>(0, name: 'counter')`
- Verified disposal call prepended to existing `dispose()` in reverse declaration order
- Golden test passes integration suite