### PR TITLE
feat: implement M1-08 — conditional flutter_solidart import

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -641,7 +641,7 @@ class _CounterState extends State<Counter> {
 
 **Dependencies:** M1-01.
 
-**Status:** TODO
+**Status:** DONE
 
 ---
 
@@ -667,7 +667,7 @@ class _CounterState extends State<Counter> {
 
 **Dependencies:** M1-01.
 
-**Status:** TODO
+**Status:** DONE
 
 ---
 

--- a/packages/solid_generator/lib/builder.dart
+++ b/packages/solid_generator/lib/builder.dart
@@ -115,28 +115,39 @@ List<_AnnotatedClass> _collectAnnotatedClasses(
 /// Renders the full `lib/` output for a file that has at least one annotated
 /// class. Preserves non-annotated classes verbatim and rewrites annotated
 /// ones per their class kind.
+///
+/// `flutter_solidart` is added to the import block iff any rewriter emitted
+/// a Section 9 identifier (SPEC §9).
 String _renderOutput(
   CompilationUnit unit,
   List<_AnnotatedClass> annotatedClasses,
   String source,
 ) {
-  final classTexts = annotatedClasses.map((c) {
-    if (c.fields.isEmpty) return source.substring(c.decl.offset, c.decl.end);
+  final results = annotatedClasses.map((c) {
+    if (c.fields.isEmpty) {
+      return (
+        text: source.substring(c.decl.offset, c.decl.end),
+        solidartNames: const <String>{},
+      );
+    }
     return _rewriteClass(c.decl, c.fields, source);
-  });
+  }).toList();
 
   final imports = computeOutputImports(
     unit.directives.whereType<ImportDirective>().map(_importUri).toList(),
-    addSolidart: true,
+    addSolidart: results.any(
+      (r) => r.solidartNames.any(solidartNames.contains),
+    ),
   );
   final importBlock = imports.map((u) => "import '$u';").join('\n');
 
-  final combined = '$importBlock\n\n${classTexts.join('\n\n')}\n';
+  final combined =
+      '$importBlock\n\n${results.map((r) => r.text).join('\n\n')}\n';
   return _formatter.format(combined);
 }
 
-/// Dispatches on [decl]'s class kind and emits the rewritten form.
-String _rewriteClass(
+/// Dispatches on [decl]'s class kind to the matching rewriter.
+RewriteResult _rewriteClass(
   ClassDeclaration decl,
   List<FieldModel> fields,
   String source,

--- a/packages/solid_generator/lib/src/import_rewriter.dart
+++ b/packages/solid_generator/lib/src/import_rewriter.dart
@@ -6,6 +6,29 @@
 const String flutterSolidartUri =
     'package:flutter_solidart/flutter_solidart.dart';
 
+/// Canonical set of identifiers exported by `flutter_solidart` whose presence
+/// in generated output triggers the import-add rule (SPEC Section 9).
+///
+/// Each rewriter declares which subset of these names it statically emits;
+/// the builder unions those subsets and adds `flutter_solidart` if the union
+/// is non-empty.
+const Set<String> solidartNames = {
+  'Signal',
+  'Computed',
+  'Effect',
+  'Resource',
+  'SignalBuilder',
+  'SolidartConfig',
+  'untracked',
+};
+
+/// One annotated class's contribution to the generated output.
+///
+/// `text` is the rewritten (or verbatim) source for the class; `solidartNames`
+/// enumerates which [solidartNames] identifiers `text` references, used by the
+/// builder to decide whether to add the `flutter_solidart` import.
+typedef RewriteResult = ({String text, Set<String> solidartNames});
+
 /// Returns the import URIs that should appear at the top of the generated
 /// `lib/` file.
 ///

--- a/packages/solid_generator/lib/src/plain_class_rewriter.dart
+++ b/packages/solid_generator/lib/src/plain_class_rewriter.dart
@@ -1,5 +1,6 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:solid_generator/src/field_model.dart';
+import 'package:solid_generator/src/import_rewriter.dart';
 import 'package:solid_generator/src/signal_emitter.dart';
 import 'package:solid_generator/src/transformation_error.dart';
 
@@ -21,7 +22,7 @@ import 'package:solid_generator/src/transformation_error.dart';
 /// [source] is unused here (full reconstruction from AST); it is part of the
 /// signature so the dispatcher in `builder.dart` can pass it uniformly to
 /// every class-kind rewriter.
-String rewritePlainClass(
+RewriteResult rewritePlainClass(
   ClassDeclaration classDecl,
   List<FieldModel> solidFields,
   String source,
@@ -32,12 +33,16 @@ String rewritePlainClass(
   final signalFields = solidFields.map(emitSignalField).join('\n');
   final dispose = emitDispose(solidFields, inheritsDispose: false);
 
-  return '''
+  return (
+    text:
+        '''
 class $className {
 $signalFields
 
 $dispose
-}''';
+}''',
+    solidartNames: const <String>{'Signal'},
+  );
 }
 
 /// Throws [CodeGenerationError] if [classDecl] contains any member other than

--- a/packages/solid_generator/lib/src/state_class_rewriter.dart
+++ b/packages/solid_generator/lib/src/state_class_rewriter.dart
@@ -1,6 +1,7 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:solid_generator/src/build_rewriter.dart';
 import 'package:solid_generator/src/field_model.dart';
+import 'package:solid_generator/src/import_rewriter.dart';
 import 'package:solid_generator/src/signal_emitter.dart';
 import 'package:solid_generator/src/transformation_error.dart';
 
@@ -20,7 +21,7 @@ import 'package:solid_generator/src/transformation_error.dart';
 ///
 /// The emitted string is syntactically valid Dart but is not guaranteed to be
 /// pretty-printed — run through `DartFormatter` before writing.
-String rewriteStateClass(
+RewriteResult rewriteStateClass(
   ClassDeclaration classDecl,
   List<FieldModel> solidFields,
   String source,
@@ -68,7 +69,10 @@ String rewriteStateClass(
     classDecl.offset,
     classDecl.leftBracket.offset,
   );
-  return '$header{\n${pieces.join('\n\n')}\n}';
+  return (
+    text: '$header{\n${pieces.join('\n\n')}\n}',
+    solidartNames: const <String>{'Signal'},
+  );
 }
 
 /// Prepends one `<field>.dispose();` call per reactive declaration to the

--- a/packages/solid_generator/lib/src/stateless_rewriter.dart
+++ b/packages/solid_generator/lib/src/stateless_rewriter.dart
@@ -1,6 +1,7 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:solid_generator/src/build_rewriter.dart';
 import 'package:solid_generator/src/field_model.dart';
+import 'package:solid_generator/src/import_rewriter.dart';
 import 'package:solid_generator/src/signal_emitter.dart';
 import 'package:solid_generator/src/transformation_error.dart';
 
@@ -10,7 +11,7 @@ import 'package:solid_generator/src/transformation_error.dart';
 /// See SPEC Section 8.1. The emitted string is syntactically valid Dart but
 /// is not guaranteed to be pretty-printed — run through `DartFormatter` before
 /// writing.
-String rewriteStatelessWidget(
+RewriteResult rewriteStatelessWidget(
   ClassDeclaration classDecl,
   List<FieldModel> solidFields,
   String source,
@@ -34,7 +35,10 @@ String rewriteStatelessWidget(
     buildMethodText,
   );
 
-  return '$widgetClass\n\n$stateClass\n';
+  return (
+    text: '$widgetClass\n\n$stateClass\n',
+    solidartNames: const <String>{'Signal', 'SignalBuilder'},
+  );
 }
 
 /// Extracts the parenthesized parameter list of the class's unnamed

--- a/packages/solid_generator/test/golden/inputs/m1_07_existing_state_class.dart
+++ b/packages/solid_generator/test/golden/inputs/m1_07_existing_state_class.dart
@@ -14,8 +14,9 @@ class _CounterState extends State<Counter> {
   @SolidState()
   int counter = 0;
 
-  final StreamSubscription<void> _subscription =
-      Stream<void>.periodic(const Duration(seconds: 1)).listen((_) {});
+  final StreamSubscription<void> _subscription = Stream<void>.periodic(
+    const Duration(seconds: 1),
+  ).listen((_) {});
 
   @override
   void initState() {

--- a/packages/solid_generator/test/golden/inputs/m1_08_import_rewrite.dart
+++ b/packages/solid_generator/test/golden/inputs/m1_08_import_rewrite.dart
@@ -1,0 +1,6 @@
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Ticker {
+  @SolidState()
+  int tick = 0;
+}

--- a/packages/solid_generator/test/golden/outputs/m1_08_import_rewrite.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m1_08_import_rewrite.g.dart
@@ -1,0 +1,10 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class Ticker {
+  final tick = Signal<int>(0, name: 'tick');
+
+  void dispose() {
+    tick.dispose();
+  }
+}

--- a/packages/solid_generator/test/integration/golden_test.dart
+++ b/packages/solid_generator/test/integration/golden_test.dart
@@ -23,6 +23,7 @@ const List<String> _goldenNames = <String>[
   'm1_05_counter_stateless_full',
   'm1_06_plain_class_no_widget',
   'm1_07_existing_state_class',
+  'm1_08_import_rewrite',
 ];
 
 /// Resolves the golden directory relative to the package root, regardless of


### PR DESCRIPTION
## Summary

- Introduce `RewriteResult` typedef to track both rewritten source text and which `flutter_solidart` identifiers each class rewriter emits
- Define canonical `solidartNames` set of identifiers whose presence in output triggers the import-add rule
- Update all rewriters (plain class, state class, stateless widget) to return `RewriteResult` with their static identifier set
- Change builder logic to conditionally add `flutter_solidart` import only when rewriters actually emit identifiers from that package
- Add golden test case M1-08 validating that import is correctly added for state class rewrites

## Testing

- Golden test `m1_08_import_rewrite` verifies correct import insertion for annotated state class
- Existing golden tests (M1-05, M1-06, M1-07) continue to pass, validating backward compatibility
- Manual verification: import is added when Signal identifiers are emitted, omitted otherwise