### PR TITLE
feat: implement M1-09 — idempotency testing with golden suite

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -687,7 +687,7 @@ class _CounterState extends State<Counter> {
 
 **Dependencies:** M1-01 through M1-08.
 
-**Status:** TODO
+**Status:** DONE
 
 ---
 

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -1,0 +1,68 @@
+// Shared helpers for the integration suite. Not picked up by `dart test`
+// directly (no `_test.dart` suffix) — imported by the *_test.dart files.
+
+import 'dart:convert';
+import 'dart:io';
+import 'dart:isolate';
+
+import 'package:build/build.dart';
+import 'package:build_test/build_test.dart';
+import 'package:solid_generator/builder.dart';
+import 'package:test/test.dart';
+
+/// Names of golden cases under `test/golden/{inputs,outputs}/`.
+///
+/// M1+ TODOs append case names here. Each entry `name` requires:
+///   `test/golden/inputs/<name>.dart`   — hand-written source with @Solid* annotations
+///   `test/golden/outputs/<name>.g.dart` — expected builder output
+const List<String> goldenNames = <String>[
+  'm1_01_int_field_with_initializer',
+  'm1_02_late_string_no_initializer',
+  'm1_03_nullable_int_field',
+  'm1_04_custom_name_parameter',
+  'm1_05_counter_stateless_full',
+  'm1_06_plain_class_no_widget',
+  'm1_07_existing_state_class',
+  'm1_08_import_rewrite',
+];
+
+/// Memoized golden directory resolution. Resolved relative to the package
+/// root via `Isolate.resolvePackageUri`, so it works regardless of CWD.
+Future<String> goldenDir() => _goldenDir ??= _resolveGoldenDir();
+Future<String>? _goldenDir;
+
+Future<String> _resolveGoldenDir() async {
+  final libUri = await Isolate.resolvePackageUri(
+    Uri.parse('package:solid_generator/builder.dart'),
+  );
+  return Directory.fromUri(libUri!.resolve('../test/golden')).path;
+}
+
+/// Loads the input fixture for [name], failing the test with a clear message
+/// if the fixture file is missing.
+Future<String> loadGoldenInput(String name) async {
+  final path = '${await goldenDir()}/inputs/$name.dart';
+  final file = File(path);
+  if (!file.existsSync()) fail('missing input fixture: $path');
+  return file.readAsStringSync();
+}
+
+/// Runs the builder once on [input] keyed under `source/<name>.dart` and
+/// returns the bytes written to `lib/<name>.dart`, decoded as UTF-8.
+///
+/// Fails the test if the builder produced no output.
+Future<String> runBuilderCapture(String name, String input) async {
+  String? captured;
+  await testBuilder(
+    solidBuilder(BuilderOptions.empty),
+    {'a|source/$name.dart': input},
+    outputs: {
+      'a|lib/$name.dart': predicate<List<int>>((bytes) {
+        captured = utf8.decode(bytes);
+        return true;
+      }),
+    },
+  );
+  if (captured == null) fail('builder produced no output for $name');
+  return captured!;
+}

--- a/packages/solid_generator/test/integration/golden_test.dart
+++ b/packages/solid_generator/test/integration/golden_test.dart
@@ -1,39 +1,14 @@
 // Integration suite for the Solid builder's paired-golden tests.
 // M1+ TODOs extend [goldenNames]; the body of this file does not change.
 
-import 'dart:convert';
 import 'dart:io';
-import 'dart:isolate';
 
 import 'package:build/build.dart';
 import 'package:build_test/build_test.dart';
 import 'package:solid_generator/builder.dart';
 import 'package:test/test.dart';
 
-/// Names of golden cases under `test/golden/{inputs,outputs}/`.
-///
-/// M1+ TODOs append case names here. Each entry `name` requires:
-///   `test/golden/inputs/<name>.dart`   — hand-written source with @Solid* annotations
-///   `test/golden/outputs/<name>.g.dart` — expected builder output
-const List<String> goldenNames = <String>[
-  'm1_01_int_field_with_initializer',
-  'm1_02_late_string_no_initializer',
-  'm1_03_nullable_int_field',
-  'm1_04_custom_name_parameter',
-  'm1_05_counter_stateless_full',
-  'm1_06_plain_class_no_widget',
-  'm1_07_existing_state_class',
-  'm1_08_import_rewrite',
-];
-
-/// Resolves the golden directory relative to the package root, regardless of
-/// where `dart test` is invoked from.
-Future<String> resolveGoldenDir() async {
-  final libUri = await Isolate.resolvePackageUri(
-    Uri.parse('package:solid_generator/builder.dart'),
-  );
-  return Directory.fromUri(libUri!.resolve('../test/golden')).path;
-}
+import 'golden_helpers.dart';
 
 final bool _updateGoldens = Platform.environment['UPDATE_GOLDENS'] == '1';
 
@@ -41,35 +16,15 @@ void main() {
   group('golden', () {
     for (final name in goldenNames) {
       test(name, () async {
-        final goldenDir = await resolveGoldenDir();
-        final inputPath = '$goldenDir/inputs/$name.dart';
-        final expectedPath = '$goldenDir/outputs/$name.g.dart';
-
-        final inputFile = File(inputPath);
+        final input = await loadGoldenInput(name);
+        final expectedPath = '${await goldenDir()}/outputs/$name.g.dart';
         final expectedFile = File(expectedPath);
 
-        if (!inputFile.existsSync()) {
-          fail('missing input fixture: $inputPath');
-        }
-
-        final input = inputFile.readAsStringSync();
-
         if (_updateGoldens) {
-          String? captured;
-          await testBuilder(
-            solidBuilder(BuilderOptions.empty),
-            {'a|source/$name.dart': input},
-            outputs: {
-              'a|lib/$name.dart': predicate<List<int>>((bytes) {
-                captured = utf8.decode(bytes);
-                return true;
-              }),
-            },
-          );
-          if (captured == null) fail('builder produced no output for $name');
+          final captured = await runBuilderCapture(name, input);
           expectedFile
             ..createSync(recursive: true)
-            ..writeAsStringSync(captured!);
+            ..writeAsStringSync(captured);
           return;
         }
 

--- a/packages/solid_generator/test/integration/golden_test.dart
+++ b/packages/solid_generator/test/integration/golden_test.dart
@@ -1,5 +1,5 @@
 // Integration suite for the Solid builder's paired-golden tests.
-// M1+ TODOs extend [_goldenNames]; the body of this file does not change.
+// M1+ TODOs extend [goldenNames]; the body of this file does not change.
 
 import 'dart:convert';
 import 'dart:io';
@@ -15,7 +15,7 @@ import 'package:test/test.dart';
 /// M1+ TODOs append case names here. Each entry `name` requires:
 ///   `test/golden/inputs/<name>.dart`   — hand-written source with @Solid* annotations
 ///   `test/golden/outputs/<name>.g.dart` — expected builder output
-const List<String> _goldenNames = <String>[
+const List<String> goldenNames = <String>[
   'm1_01_int_field_with_initializer',
   'm1_02_late_string_no_initializer',
   'm1_03_nullable_int_field',
@@ -28,7 +28,7 @@ const List<String> _goldenNames = <String>[
 
 /// Resolves the golden directory relative to the package root, regardless of
 /// where `dart test` is invoked from.
-Future<String> _resolveGoldenDir() async {
+Future<String> resolveGoldenDir() async {
   final libUri = await Isolate.resolvePackageUri(
     Uri.parse('package:solid_generator/builder.dart'),
   );
@@ -39,9 +39,9 @@ final bool _updateGoldens = Platform.environment['UPDATE_GOLDENS'] == '1';
 
 void main() {
   group('golden', () {
-    for (final name in _goldenNames) {
+    for (final name in goldenNames) {
       test(name, () async {
-        final goldenDir = await _resolveGoldenDir();
+        final goldenDir = await resolveGoldenDir();
         final inputPath = '$goldenDir/inputs/$name.dart';
         final expectedPath = '$goldenDir/outputs/$name.g.dart';
 

--- a/packages/solid_generator/test/integration/idempotency_test.dart
+++ b/packages/solid_generator/test/integration/idempotency_test.dart
@@ -1,0 +1,46 @@
+// Idempotency suite: every golden runs through the builder twice and
+// the two outputs must be byte-identical. Regression fence against
+// accidental builder state — see plans/features/m1-solid-state-field.md
+// Stage D and SPEC §5.4.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:build/build.dart';
+import 'package:build_test/build_test.dart';
+import 'package:solid_generator/builder.dart';
+import 'package:test/test.dart';
+
+import 'golden_test.dart' show goldenNames, resolveGoldenDir;
+
+void main() {
+  group('idempotency', () {
+    for (final name in goldenNames) {
+      test('$name produces byte-identical output across two runs', () async {
+        final goldenDir = await resolveGoldenDir();
+        final input = File('$goldenDir/inputs/$name.dart').readAsStringSync();
+
+        final first = await _runBuilder(name, input);
+        final second = await _runBuilder(name, input);
+
+        expect(second, equals(first));
+      });
+    }
+  });
+}
+
+Future<String> _runBuilder(String name, String input) async {
+  String? captured;
+  await testBuilder(
+    solidBuilder(BuilderOptions.empty),
+    {'a|source/$name.dart': input},
+    outputs: {
+      'a|lib/$name.dart': predicate<List<int>>((bytes) {
+        captured = utf8.decode(bytes);
+        return true;
+      }),
+    },
+  );
+  if (captured == null) fail('builder produced no output for $name');
+  return captured!;
+}

--- a/packages/solid_generator/test/integration/idempotency_test.dart
+++ b/packages/solid_generator/test/integration/idempotency_test.dart
@@ -3,44 +3,21 @@
 // accidental builder state — see plans/features/m1-solid-state-field.md
 // Stage D and SPEC §5.4.
 
-import 'dart:convert';
-import 'dart:io';
-
-import 'package:build/build.dart';
-import 'package:build_test/build_test.dart';
-import 'package:solid_generator/builder.dart';
 import 'package:test/test.dart';
 
-import 'golden_test.dart' show goldenNames, resolveGoldenDir;
+import 'golden_helpers.dart';
 
 void main() {
   group('idempotency', () {
     for (final name in goldenNames) {
       test('$name produces byte-identical output across two runs', () async {
-        final goldenDir = await resolveGoldenDir();
-        final input = File('$goldenDir/inputs/$name.dart').readAsStringSync();
+        final input = await loadGoldenInput(name);
 
-        final first = await _runBuilder(name, input);
-        final second = await _runBuilder(name, input);
+        final first = await runBuilderCapture(name, input);
+        final second = await runBuilderCapture(name, input);
 
         expect(second, equals(first));
       });
     }
   });
-}
-
-Future<String> _runBuilder(String name, String input) async {
-  String? captured;
-  await testBuilder(
-    solidBuilder(BuilderOptions.empty),
-    {'a|source/$name.dart': input},
-    outputs: {
-      'a|lib/$name.dart': predicate<List<int>>((bytes) {
-        captured = utf8.decode(bytes);
-        return true;
-      }),
-    },
-  );
-  if (captured == null) fail('builder produced no output for $name');
-  return captured!;
 }


### PR DESCRIPTION
## Summary

- Implements M1-09: idempotency testing to verify the Solid builder is deterministic
- Adds new `idempotency_test.dart` suite that runs each golden case through the builder twice and asserts byte-identical outputs
- Refactors golden test helpers (`goldenNames`, `resolveGoldenDir()`) to be public and reusable by idempotency tests
- Marks M1-09 as DONE in TODOS.md

## Testing

- Idempotency test suite: runs each of the 8 golden cases twice, verifies outputs match byte-for-byte
- Existing golden test suite: still passes with refactored helpers
- Regression fence: idempotency tests prevent accidental builder state issues per SPEC §5.4