### PR TITLE
feat: implement M1-12 — passthrough golden for files without @Solid* annotations

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -731,7 +731,7 @@ class _CounterState extends State<Counter> {
 
 ---
 
-### TODO M1-12 — Golden: class without annotations passes through
+### DONE M1-12 — Golden: class without annotations passes through
 
 **Goal:** A `.dart` file under `source/` that contains NO `@Solid*` annotation is copied byte-for-byte to `lib/`. No transformation, no re-formatting, no import addition.
 
@@ -758,13 +758,13 @@ class Hello extends StatelessWidget {
 
 **Expected output content:** Identical to input.
 
-**Expected implementation change:** The top-level pipeline scans the parsed file for any `@Solid*` annotation before invoking the rewriter. If none, write input bytes to the output path unchanged.
+**Expected implementation change:** The top-level pipeline checks for the `@Solid` substring before invoking the parser/rewriter (SPEC §2 hot-path short-circuit, implemented at `packages/solid_generator/lib/builder.dart:53-56`). If absent, write input bytes to the output path unchanged. The post-parse fallback at lines 71-77 covers the corner case where `@Solid` appears as a substring (e.g. inside a comment) but resolves to no fields; both paths preserve byte-identity.
 
 **Acceptance:** `dart test --name=m1_12` passes; output bytes equal input bytes.
 
 **Dependencies:** M1-01.
 
-**Status:** TODO
+**Status:** DONE
 
 ---
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -758,7 +758,7 @@ class Hello extends StatelessWidget {
 
 **Expected output content:** Identical to input.
 
-**Expected implementation change:** The top-level pipeline checks for the `@Solid` substring before invoking the parser/rewriter (SPEC §2 hot-path short-circuit, implemented at `packages/solid_generator/lib/builder.dart:53-56`). If absent, write input bytes to the output path unchanged. The post-parse fallback at lines 71-77 covers the corner case where `@Solid` appears as a substring (e.g. inside a comment) but resolves to no fields; both paths preserve byte-identity.
+**Expected implementation change:** The top-level pipeline checks for the `@Solid` substring (the `_solidAnnotationHint` guard in `packages/solid_generator/lib/builder.dart`) before invoking the parser/rewriter — SPEC Section 2 hot-path short-circuit. If absent, write input bytes to the output path unchanged. The post-parse fallback in `_collectAnnotatedClasses` covers the corner case where `@Solid` appears as a substring (e.g. inside a comment) but resolves to no fields; both paths preserve byte-identity.
 
 **Acceptance:** `dart test --name=m1_12` passes; output bytes equal input bytes.
 

--- a/packages/solid_generator/test/golden/inputs/m1_12_passthrough_no_annotations.dart
+++ b/packages/solid_generator/test/golden/inputs/m1_12_passthrough_no_annotations.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/widgets.dart';
+
+class Hello extends StatelessWidget {
+  const Hello({super.key});
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/golden/outputs/m1_12_passthrough_no_annotations.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m1_12_passthrough_no_annotations.g.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/widgets.dart';
+
+class Hello extends StatelessWidget {
+  const Hello({super.key});
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -24,6 +24,7 @@ const List<String> goldenNames = <String>[
   'm1_06_plain_class_no_widget',
   'm1_07_existing_state_class',
   'm1_08_import_rewrite',
+  'm1_12_passthrough_no_annotations',
 ];
 
 /// Memoized golden directory resolution. Resolved relative to the package


### PR DESCRIPTION
## Summary

- Adds the M1-12 paired golden fixture proving SPEC §2 transformation-vs-verbatim-copy: a `.dart` file under `source/` with no `@Solid*` annotation is copied byte-for-byte to `lib/`.
- Wires the new case into both `golden_test.dart` (byte-equality) and `idempotency_test.dart` (twice-through byte-identity) via a single new entry in `goldenNames`.
- Test-only PR — no library code change. The pre-parse substring short-circuit at `packages/solid_generator/lib/builder.dart:53-56` already implements the passthrough; this PR fences that behaviour against future regressions (e.g., a refactor that pipes every file through `DartFormatter`).
- Tightens the M1-12 TODOS.md wording to describe the substring guard that ships, rather than the AST scan the original wording implied.

## Test plan

- [x] `dart test packages/solid_generator/ --name=m1_12` — both new tests (golden + idempotency) pass.
- [x] `dart test packages/solid_generator/` — full generator suite green (16 prior + 2 new = 18 tests).
- [x] `flutter test example/test/` — M1-10 widget test and M1-11 dispose contract test stay green.
- [x] `dart analyze` — zero issues.
- [x] `dart format` — zero diff on changed files.
- [x] `cmp inputs/m1_12_passthrough_no_annotations.dart outputs/m1_12_passthrough_no_annotations.g.dart` — byte-identical.