### PR TITLE
Implement M1-14: validate @SolidState annotation targets

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -814,7 +814,7 @@ class Hello extends StatelessWidget {
 
 **Dependencies:** M1-01.
 
-**Status:** TODO
+**Status:** DONE
 
 ---
 

--- a/packages/solid_generator/lib/builder.dart
+++ b/packages/solid_generator/lib/builder.dart
@@ -11,6 +11,7 @@ import 'package:solid_generator/src/import_rewriter.dart';
 import 'package:solid_generator/src/plain_class_rewriter.dart';
 import 'package:solid_generator/src/state_class_rewriter.dart';
 import 'package:solid_generator/src/stateless_rewriter.dart';
+import 'package:solid_generator/src/target_validator.dart';
 import 'package:solid_generator/src/transformation_error.dart';
 
 /// Factory invoked by `build_runner` to create the Solid builder.
@@ -66,6 +67,10 @@ class _SolidBuilder implements Builder {
         '(offset ${diagnostic.offset})',
       );
     }
+
+    // SPEC §3.1 invalid-target guard. Must run before
+    // `_collectAnnotatedClasses`, which only walks `FieldDeclaration`s.
+    validateSolidStateTargets(parsed.unit);
 
     final annotatedClasses = _collectAnnotatedClasses(parsed.unit, source);
     if (annotatedClasses.every((c) => c.fields.isEmpty)) {

--- a/packages/solid_generator/lib/src/annotation_reader.dart
+++ b/packages/solid_generator/lib/src/annotation_reader.dart
@@ -7,7 +7,10 @@ import 'package:solid_generator/src/field_model.dart';
 /// resolution is required for `.value` rewriting, but annotation detection is
 /// acceptable on names because the user must import `solid_annotations` to use
 /// `@SolidState` at all).
-const String _solidStateName = 'SolidState';
+///
+/// Exposed package-publicly so the target validator (SPEC Section 3.1
+/// rejections) can match the same identifier on non-field declarations.
+const String solidStateName = 'SolidState';
 
 /// Reads a `@SolidState(...)` annotation on [decl] and returns a [FieldModel].
 ///
@@ -15,7 +18,7 @@ const String _solidStateName = 'SolidState';
 /// [source] is passed in so each string member of the returned [FieldModel]
 /// can be extracted verbatim via `source.substring(offset, end)`.
 FieldModel? readSolidStateField(FieldDeclaration decl, String source) {
-  final annotation = _findSolidStateAnnotation(decl);
+  final annotation = findSolidStateAnnotation(decl.metadata);
   if (annotation == null) return null;
 
   final varList = decl.fields;
@@ -41,10 +44,13 @@ FieldModel? readSolidStateField(FieldDeclaration decl, String source) {
   );
 }
 
-/// Returns the first `@SolidState(...)` annotation on [decl], or `null`.
-Annotation? _findSolidStateAnnotation(FieldDeclaration decl) {
-  for (final ann in decl.metadata) {
-    if (ann.name.name == _solidStateName) return ann;
+/// Returns the first `@SolidState(...)` annotation in [metadata], or `null`.
+///
+/// Package-public so the target validator (SPEC §3.1 rejections) can reuse
+/// the same matcher on `MethodDeclaration` and `FunctionDeclaration` metadata.
+Annotation? findSolidStateAnnotation(NodeList<Annotation> metadata) {
+  for (final ann in metadata) {
+    if (ann.name.name == solidStateName) return ann;
   }
   return null;
 }

--- a/packages/solid_generator/lib/src/target_validator.dart
+++ b/packages/solid_generator/lib/src/target_validator.dart
@@ -1,0 +1,83 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:solid_generator/src/annotation_reader.dart';
+import 'package:solid_generator/src/transformation_error.dart';
+
+/// Validates every `@SolidState` annotation in [unit] against the SPEC
+/// Section 3.1 valid-target list. Throws [ValidationError] on the first
+/// invalid placement; returns silently when every annotation targets a
+/// valid declaration (instance field or instance getter).
+///
+/// Runs before transformation so the pre-existing builder pipeline (which
+/// only walks `FieldDeclaration`s in `_collectAnnotatedClasses`) cannot
+/// silently drop a `@SolidState` placed on a method, setter, top-level
+/// declaration, or static/final/const field.
+void validateSolidStateTargets(CompilationUnit unit) {
+  for (final decl in unit.declarations) {
+    if (decl is ClassDeclaration) {
+      final className = decl.name.lexeme;
+      for (final member in decl.members) {
+        if (member is FieldDeclaration) _validateField(member, className);
+        if (member is MethodDeclaration) _validateMethod(member, className);
+      }
+    } else {
+      _validateTopLevel(decl);
+    }
+  }
+}
+
+/// Throws a [ValidationError] for `@SolidState` on a [kind] of declaration.
+/// The violation code is derived from [kind] so message and code never drift.
+Never _reject(String kind, String location) {
+  final code =
+      'INVALID_TARGET_'
+      '${kind.toUpperCase().replaceAll(' ', '_').replaceAll('-', '_')}';
+  throw ValidationError(
+    '@SolidState cannot be applied to a $kind',
+    location,
+    code,
+  );
+}
+
+/// Rejects `@SolidState` on a class field that is `const`, `final`, or
+/// `static`. Instance non-final non-const non-static fields fall through
+/// silently — they are the canonical SPEC 3.1 valid target.
+void _validateField(FieldDeclaration field, String className) {
+  if (findSolidStateAnnotation(field.metadata) == null) return;
+  final varList = field.fields;
+  final fieldName = varList.variables.first.name.lexeme;
+  final location = '$className.$fieldName';
+  // Order matters: `static const` reports as "const field" — the const-ness
+  // is the dominant violation per the M1-14 TODO parenthetical guidance.
+  if (varList.isConst) _reject('const field', location);
+  if (varList.isFinal) _reject('final field', location);
+  if (field.isStatic) _reject('static field', location);
+}
+
+/// Rejects `@SolidState` on a setter, static getter, or non-accessor method.
+/// Instance getters fall through — they are valid SPEC 3.1 targets and M2
+/// will emit `Computed`.
+void _validateMethod(MethodDeclaration method, String className) {
+  if (findSolidStateAnnotation(method.metadata) == null) return;
+  final location = '$className.${method.name.lexeme}';
+  if (method.isSetter) _reject('setter', location);
+  if (method.isGetter && method.isStatic) _reject('static getter', location);
+  if (!method.isGetter && !method.isSetter) _reject('method', location);
+  // Instance getter — valid SPEC 3.1 target; M2 emits Computed.
+}
+
+/// Rejects `@SolidState` on top-level variables, getters, and any other
+/// non-class declaration form (top-level setters and methods land here too,
+/// reusing the SETTER / METHOD codes).
+void _validateTopLevel(CompilationUnitMember decl) {
+  if (decl is TopLevelVariableDeclaration &&
+      findSolidStateAnnotation(decl.metadata) != null) {
+    _reject('top-level variable', decl.variables.variables.first.name.lexeme);
+  }
+  if (decl is FunctionDeclaration &&
+      findSolidStateAnnotation(decl.metadata) != null) {
+    final name = decl.name.lexeme;
+    if (decl.isGetter) _reject('top-level getter', name);
+    if (decl.isSetter) _reject('setter', name);
+    _reject('method', name);
+  }
+}

--- a/packages/solid_generator/lib/src/transformation_error.dart
+++ b/packages/solid_generator/lib/src/transformation_error.dart
@@ -71,28 +71,6 @@ class ValidationError extends TransformationError {
   /// Creates a [ValidationError] with a [violationType] code.
   const ValidationError(super.message, super.location, this.violationType);
 
-  /// Factory for invalid-annotation-target errors.
-  const ValidationError.invalidAnnotationTarget(
-    String location,
-  ) : violationType = 'INVALID_TARGET',
-      super(
-        '@SolidState can only be applied to fields and getters',
-        location,
-      );
-
-  /// Factory for missing-annotation errors.
-  const ValidationError.missingAnnotation(String elementName, String? location)
-    : violationType = 'MISSING_ANNOTATION',
-      super(
-        'Expected reactive annotation not found on $elementName',
-        location,
-      );
-
-  /// Factory for invalid-type errors.
-  const ValidationError.invalidType(String typeName, String? location)
-    : violationType = 'INVALID_TYPE',
-      super('Type $typeName is not supported for reactive state', location);
-
   /// Code identifying the type of validation violation.
   final String violationType;
 

--- a/packages/solid_generator/test/golden/analysis_options.yaml
+++ b/packages/solid_generator/test/golden/analysis_options.yaml
@@ -24,3 +24,6 @@ analyzer:
     always_put_required_named_parameters_first: ignore
     invalid_annotation_target: ignore
     lines_longer_than_80_chars: ignore
+    # M1-14 setter fixture intentionally has no corresponding getter — the
+    # whole point is that `@SolidState` on a setter must be rejected.
+    avoid_setters_without_getters: ignore

--- a/packages/solid_generator/test/golden/inputs/m1_14_const_field.dart
+++ b/packages/solid_generator/test/golden/inputs/m1_14_const_field.dart
@@ -1,0 +1,6 @@
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Counter {
+  @SolidState()
+  static const int x = 0;
+}

--- a/packages/solid_generator/test/golden/inputs/m1_14_final_field.dart
+++ b/packages/solid_generator/test/golden/inputs/m1_14_final_field.dart
@@ -1,0 +1,6 @@
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Counter {
+  @SolidState()
+  final int x = 0;
+}

--- a/packages/solid_generator/test/golden/inputs/m1_14_method.dart
+++ b/packages/solid_generator/test/golden/inputs/m1_14_method.dart
@@ -1,0 +1,6 @@
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Counter {
+  @SolidState()
+  void doThing() {}
+}

--- a/packages/solid_generator/test/golden/inputs/m1_14_setter.dart
+++ b/packages/solid_generator/test/golden/inputs/m1_14_setter.dart
@@ -1,0 +1,6 @@
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Counter {
+  @SolidState()
+  set x(int v) {}
+}

--- a/packages/solid_generator/test/golden/inputs/m1_14_static_field.dart
+++ b/packages/solid_generator/test/golden/inputs/m1_14_static_field.dart
@@ -1,0 +1,6 @@
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Counter {
+  @SolidState()
+  static int x = 0;
+}

--- a/packages/solid_generator/test/golden/inputs/m1_14_static_getter.dart
+++ b/packages/solid_generator/test/golden/inputs/m1_14_static_getter.dart
@@ -1,0 +1,6 @@
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Counter {
+  @SolidState()
+  static int get x => 0;
+}

--- a/packages/solid_generator/test/golden/inputs/m1_14_top_level.dart
+++ b/packages/solid_generator/test/golden/inputs/m1_14_top_level.dart
@@ -1,0 +1,4 @@
+import 'package:solid_annotations/solid_annotations.dart';
+
+@SolidState()
+int x = 0;

--- a/packages/solid_generator/test/golden/inputs/m1_14_top_level_getter.dart
+++ b/packages/solid_generator/test/golden/inputs/m1_14_top_level_getter.dart
@@ -1,0 +1,4 @@
+import 'package:solid_annotations/solid_annotations.dart';
+
+@SolidState()
+int get x => 0;

--- a/packages/solid_generator/test/rejections/m1_14_invalid_targets_test.dart
+++ b/packages/solid_generator/test/rejections/m1_14_invalid_targets_test.dart
@@ -1,0 +1,64 @@
+// Rejection suite for M1-14: invalid `@SolidState` placements per SPEC §3.1.
+// `testBuilder` captures thrown exceptions into `result.errors`, so the
+// assertions check that list rather than `throwsA(...)`.
+
+import 'package:build/build.dart';
+import 'package:build_test/build_test.dart';
+import 'package:solid_generator/builder.dart';
+import 'package:test/test.dart';
+
+import '../integration/golden_helpers.dart';
+
+/// Each case pairs a fixture name with the SPEC phrase the resulting error
+/// must contain. The phrase is the contains-substring used by the assertion.
+const List<({String name, String specPhrase})> _cases = [
+  (
+    name: 'm1_14_final_field',
+    specPhrase: '@SolidState cannot be applied to a final field',
+  ),
+  (
+    name: 'm1_14_const_field',
+    specPhrase: '@SolidState cannot be applied to a const field',
+  ),
+  (
+    name: 'm1_14_static_field',
+    specPhrase: '@SolidState cannot be applied to a static field',
+  ),
+  (
+    name: 'm1_14_static_getter',
+    specPhrase: '@SolidState cannot be applied to a static getter',
+  ),
+  (
+    name: 'm1_14_top_level',
+    specPhrase: '@SolidState cannot be applied to a top-level variable',
+  ),
+  (
+    name: 'm1_14_top_level_getter',
+    specPhrase: '@SolidState cannot be applied to a top-level getter',
+  ),
+  (
+    name: 'm1_14_method',
+    specPhrase: '@SolidState cannot be applied to a method',
+  ),
+  (
+    name: 'm1_14_setter',
+    specPhrase: '@SolidState cannot be applied to a setter',
+  ),
+];
+
+void main() {
+  group('m1_14 invalid @SolidState targets', () {
+    for (final c in _cases) {
+      test(c.name, () async {
+        final input = await loadGoldenInput(c.name);
+        final result = await testBuilder(
+          solidBuilder(BuilderOptions.empty),
+          {'a|source/${c.name}.dart': input},
+        );
+        expect(result.succeeded, isFalse);
+        expect(result.errors, hasLength(1));
+        expect(result.errors.single, contains(c.specPhrase));
+      });
+    }
+  });
+}


### PR DESCRIPTION
## Summary

- Validates that `@SolidState` can only target instance fields and instance getters per SPEC §3.1
- Rejects placement on: final/const/static fields, methods, setters, static getters, and top-level declarations
- Validation runs before the main transformation pipeline to catch invalid targets early
- Refactors `annotation_reader.dart` to expose annotation-matching logic (`solidStateName`, `findSolidStateAnnotation`) for reuse in the validator
- Removes unused factory constructors from `TransformationError` (now using the generic constructor)

## Testing

- Added 8 golden input fixtures covering all invalid target types:
  - const field, final field, static field
  - static getter, method, setter
  - top-level variable, top-level getter
- Rejection test suite (`m1_14_invalid_targets_test.dart`) validates that each invalid placement throws a `ValidationError` with the correct SPEC-aligned error message
- All error codes follow the pattern `INVALID_TARGET_<KIND>` for consistency