### PR TITLE
Implement M1-15: reject reserved annotations at build time

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -838,7 +838,7 @@ class Hello extends StatelessWidget {
 
 **Dependencies:** M0-02, M1-01.
 
-**Status:** TODO
+**Status:** DONE
 
 ---
 

--- a/packages/solid_generator/lib/builder.dart
+++ b/packages/solid_generator/lib/builder.dart
@@ -9,6 +9,7 @@ import 'package:solid_generator/src/class_kind.dart';
 import 'package:solid_generator/src/field_model.dart';
 import 'package:solid_generator/src/import_rewriter.dart';
 import 'package:solid_generator/src/plain_class_rewriter.dart';
+import 'package:solid_generator/src/reserved_annotation_validator.dart';
 import 'package:solid_generator/src/state_class_rewriter.dart';
 import 'package:solid_generator/src/stateless_rewriter.dart';
 import 'package:solid_generator/src/target_validator.dart';
@@ -68,15 +69,19 @@ class _SolidBuilder implements Builder {
       );
     }
 
+    // SPEC §3.2 + §13: reject reserved annotations (`@SolidEffect`,
+    // `@SolidQuery`, `@SolidEnvironment`) before any other pass so the user
+    // gets a fail-fast error instead of a silent passthrough.
+    validateReservedAnnotations(parsed.unit);
     // SPEC §3.1 invalid-target guard. Must run before
     // `_collectAnnotatedClasses`, which only walks `FieldDeclaration`s.
     validateSolidStateTargets(parsed.unit);
 
     final annotatedClasses = _collectAnnotatedClasses(parsed.unit, source);
     if (annotatedClasses.every((c) => c.fields.isEmpty)) {
-      // Hint matched, but no `@SolidState` field resolved — e.g. the user has
-      // a comment mentioning `@Solid…` or a not-yet-implemented annotation.
-      // SPEC §3.2 rejections are M1-15's scope; for M1-01 we pass through.
+      // Hint matched, but no `@SolidState` field resolved — the file likely
+      // contains a comment or string literal mentioning `@Solid…`. Reserved
+      // annotations are caught upstream.
       await buildStep.writeAsString(outputId, source);
       return;
     }

--- a/packages/solid_generator/lib/src/reserved_annotation_validator.dart
+++ b/packages/solid_generator/lib/src/reserved_annotation_validator.dart
@@ -1,0 +1,72 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:solid_generator/src/transformation_error.dart';
+
+/// Reserved annotation names from `package:solid_annotations` whose full
+/// contract is deferred to a later SPEC revision (SPEC §3.2 + §13). Detecting
+/// any use causes the build to fail before transformation. The map value is
+/// the violation code stamped onto [ValidationError.violationType].
+const Map<String, String> _reservedAnnotations = {
+  'SolidEffect': 'RESERVED_ANNOTATION_SOLID_EFFECT',
+  'SolidQuery': 'RESERVED_ANNOTATION_SOLID_QUERY',
+  'SolidEnvironment': 'RESERVED_ANNOTATION_SOLID_ENVIRONMENT',
+};
+
+/// SPEC §3.2 + §13 build-time guard: reject any `@SolidEffect`,
+/// `@SolidQuery`, or `@SolidEnvironment` use with a clear error that names
+/// the annotation and quotes the SPEC §3.2 phrase verbatim.
+///
+/// Runs before transformation so users learn at build time that they're
+/// using a not-yet-implemented annotation, instead of debugging missing
+/// reactivity from a silent passthrough.
+void validateReservedAnnotations(CompilationUnit unit) {
+  unit.accept(_ReservedAnnotationVisitor());
+}
+
+class _ReservedAnnotationVisitor extends RecursiveAstVisitor<void> {
+  @override
+  void visitAnnotation(Annotation node) {
+    final name = node.name.name;
+    final code = _reservedAnnotations[name];
+    if (code != null) {
+      throw ValidationError(
+        '@$name is not yet implemented; '
+        'scheduled for a later v2 milestone',
+        _locationFor(node),
+        code,
+      );
+    }
+    super.visitAnnotation(node);
+  }
+}
+
+/// Walks up [ann]'s parents to build a `ClassName.member` (or bare
+/// `member` / `topLevelName`) location string in a single pass — when the
+/// member declaration is found, the same walk continues upward to capture
+/// the enclosing class name without restarting from the member node.
+String? _locationFor(Annotation ann) {
+  String? memberPart;
+  // Explicit `AstNode?` because `Annotation.parent` is overridden to
+  // non-nullable `AstNode` — `var` infers a non-nullable type that the
+  // subsequent `p = p.parent` reassignment would not satisfy.
+  AstNode? p = ann.parent;
+  while (p != null) {
+    if (memberPart == null) {
+      if (p is FieldDeclaration) {
+        memberPart = p.fields.variables.first.name.lexeme;
+      } else if (p is MethodDeclaration) {
+        memberPart = p.name.lexeme;
+      } else if (p is FunctionDeclaration) {
+        return p.name.lexeme;
+      } else if (p is TopLevelVariableDeclaration) {
+        return p.variables.variables.first.name.lexeme;
+      } else if (p is ClassDeclaration) {
+        return p.name.lexeme;
+      }
+    } else if (p is ClassDeclaration) {
+      return '${p.name.lexeme}.$memberPart';
+    }
+    p = p.parent;
+  }
+  return memberPart;
+}

--- a/packages/solid_generator/test/golden/inputs/m1_15_effect.dart
+++ b/packages/solid_generator/test/golden/inputs/m1_15_effect.dart
@@ -1,0 +1,6 @@
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Foo {
+  @SolidEffect()
+  void side() {}
+}

--- a/packages/solid_generator/test/golden/inputs/m1_15_environment.dart
+++ b/packages/solid_generator/test/golden/inputs/m1_15_environment.dart
@@ -1,0 +1,6 @@
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Foo {
+  @SolidEnvironment()
+  late int injected;
+}

--- a/packages/solid_generator/test/golden/inputs/m1_15_query.dart
+++ b/packages/solid_generator/test/golden/inputs/m1_15_query.dart
@@ -1,0 +1,6 @@
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Foo {
+  @SolidQuery()
+  Future<int> fetch() async => 0;
+}

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -68,3 +68,30 @@ Future<String> runBuilderCapture(String name, String input) async {
   if (captured == null) fail('builder produced no output for $name');
   return captured!;
 }
+
+/// Registers one rejection test per entry in [cases] inside a `group` named
+/// [groupName]. Each entry's `name` resolves to a fixture under
+/// `test/golden/inputs/<name>.dart`; the assertion is that the builder fails
+/// with exactly one error whose message contains `errorContains`.
+///
+/// `testBuilder` captures thrown exceptions into `result.errors`, so this
+/// inspects that list rather than relying on `throwsA`.
+void runRejectionCases(
+  String groupName,
+  List<({String name, String errorContains})> cases,
+) {
+  group(groupName, () {
+    for (final c in cases) {
+      test(c.name, () async {
+        final input = await loadGoldenInput(c.name);
+        final result = await testBuilder(
+          solidBuilder(BuilderOptions.empty),
+          {'a|source/${c.name}.dart': input},
+        );
+        expect(result.succeeded, isFalse);
+        expect(result.errors, hasLength(1));
+        expect(result.errors.single, contains(c.errorContains));
+      });
+    }
+  });
+}

--- a/packages/solid_generator/test/rejections/m1_14_invalid_targets_test.dart
+++ b/packages/solid_generator/test/rejections/m1_14_invalid_targets_test.dart
@@ -1,64 +1,44 @@
 // Rejection suite for M1-14: invalid `@SolidState` placements per SPEC §3.1.
-// `testBuilder` captures thrown exceptions into `result.errors`, so the
-// assertions check that list rather than `throwsA(...)`.
-
-import 'package:build/build.dart';
-import 'package:build_test/build_test.dart';
-import 'package:solid_generator/builder.dart';
-import 'package:test/test.dart';
 
 import '../integration/golden_helpers.dart';
 
 /// Each case pairs a fixture name with the SPEC phrase the resulting error
-/// must contain. The phrase is the contains-substring used by the assertion.
-const List<({String name, String specPhrase})> _cases = [
+/// must contain.
+const List<({String name, String errorContains})> _cases = [
   (
     name: 'm1_14_final_field',
-    specPhrase: '@SolidState cannot be applied to a final field',
+    errorContains: '@SolidState cannot be applied to a final field',
   ),
   (
     name: 'm1_14_const_field',
-    specPhrase: '@SolidState cannot be applied to a const field',
+    errorContains: '@SolidState cannot be applied to a const field',
   ),
   (
     name: 'm1_14_static_field',
-    specPhrase: '@SolidState cannot be applied to a static field',
+    errorContains: '@SolidState cannot be applied to a static field',
   ),
   (
     name: 'm1_14_static_getter',
-    specPhrase: '@SolidState cannot be applied to a static getter',
+    errorContains: '@SolidState cannot be applied to a static getter',
   ),
   (
     name: 'm1_14_top_level',
-    specPhrase: '@SolidState cannot be applied to a top-level variable',
+    errorContains: '@SolidState cannot be applied to a top-level variable',
   ),
   (
     name: 'm1_14_top_level_getter',
-    specPhrase: '@SolidState cannot be applied to a top-level getter',
+    errorContains: '@SolidState cannot be applied to a top-level getter',
   ),
   (
     name: 'm1_14_method',
-    specPhrase: '@SolidState cannot be applied to a method',
+    errorContains: '@SolidState cannot be applied to a method',
   ),
   (
     name: 'm1_14_setter',
-    specPhrase: '@SolidState cannot be applied to a setter',
+    errorContains: '@SolidState cannot be applied to a setter',
   ),
 ];
 
 void main() {
-  group('m1_14 invalid @SolidState targets', () {
-    for (final c in _cases) {
-      test(c.name, () async {
-        final input = await loadGoldenInput(c.name);
-        final result = await testBuilder(
-          solidBuilder(BuilderOptions.empty),
-          {'a|source/${c.name}.dart': input},
-        );
-        expect(result.succeeded, isFalse);
-        expect(result.errors, hasLength(1));
-        expect(result.errors.single, contains(c.specPhrase));
-      });
-    }
-  });
+  runRejectionCases('m1_14 invalid @SolidState targets', _cases);
 }

--- a/packages/solid_generator/test/rejections/m1_15_non_m1_annotations_test.dart
+++ b/packages/solid_generator/test/rejections/m1_15_non_m1_annotations_test.dart
@@ -1,0 +1,31 @@
+// Rejection suite for M1-15: reserved annotations from SPEC §3.2 + §13.
+// Each case asserts that placing `@SolidEffect`, `@SolidQuery`, or
+// `@SolidEnvironment` anywhere in a source file produces a build-time error
+// quoting the SPEC §3.2 phrase verbatim.
+
+import '../integration/golden_helpers.dart';
+
+const List<({String name, String errorContains})> _cases = [
+  (
+    name: 'm1_15_effect',
+    errorContains:
+        '@SolidEffect is not yet implemented; '
+        'scheduled for a later v2 milestone',
+  ),
+  (
+    name: 'm1_15_query',
+    errorContains:
+        '@SolidQuery is not yet implemented; '
+        'scheduled for a later v2 milestone',
+  ),
+  (
+    name: 'm1_15_environment',
+    errorContains:
+        '@SolidEnvironment is not yet implemented; '
+        'scheduled for a later v2 milestone',
+  ),
+];
+
+void main() {
+  runRejectionCases('m1_15 reserved annotations rejection', _cases);
+}


### PR DESCRIPTION
## Summary

- Implements SPEC §3.2 + §13 requirement to reject `@SolidEffect`, `@SolidQuery`, and `@SolidEnvironment` at build time with a clear error message
- New `ReservedAnnotationValidator` runs before any transformation pass for fail-fast user feedback
- Extracts common rejection test pattern into `runRejectionCases` helper to reduce duplication
- Refactors M1-14 test suite to use new helper
- Adds comprehensive golden test cases for all three reserved annotations

## Testing

- M1-15 rejection tests verify each reserved annotation fails with the exact SPEC §3.2 phrase verbatim
- M1-14 test suite refactored to use shared helper without changing assertion behavior
- Golden inputs provided for `@SolidEffect`, `@SolidQuery`, and `@SolidEnvironment` placements
- Build fails with single error containing expected rejection message per test case