### PR TITLE
Implement M2-01: @SolidState getter → Computed

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -878,7 +878,7 @@ void dispose() {
 
 **Dependencies:** M1-01.
 
-**Status:** TODO
+**Status:** DONE
 
 ---
 

--- a/packages/solid_generator/lib/builder.dart
+++ b/packages/solid_generator/lib/builder.dart
@@ -7,6 +7,7 @@ import 'package:dart_style/dart_style.dart';
 import 'package:solid_generator/src/annotation_reader.dart';
 import 'package:solid_generator/src/class_kind.dart';
 import 'package:solid_generator/src/field_model.dart';
+import 'package:solid_generator/src/getter_model.dart';
 import 'package:solid_generator/src/import_rewriter.dart';
 import 'package:solid_generator/src/plain_class_rewriter.dart';
 import 'package:solid_generator/src/reserved_annotation_validator.dart';
@@ -74,14 +75,15 @@ class _SolidBuilder implements Builder {
     // gets a fail-fast error instead of a silent passthrough.
     validateReservedAnnotations(parsed.unit);
     // SPEC §3.1 invalid-target guard. Must run before
-    // `_collectAnnotatedClasses`, which only walks `FieldDeclaration`s.
+    // `_collectAnnotatedClasses`; rejected targets (final / const / static
+    // fields, setters, top-level vars, methods, …) never reach the readers.
     validateSolidStateTargets(parsed.unit);
 
     final annotatedClasses = _collectAnnotatedClasses(parsed.unit, source);
-    if (annotatedClasses.every((c) => c.fields.isEmpty)) {
-      // Hint matched, but no `@SolidState` field resolved — the file likely
-      // contains a comment or string literal mentioning `@Solid…`. Reserved
-      // annotations are caught upstream.
+    if (annotatedClasses.every((c) => c.fields.isEmpty && c.getters.isEmpty)) {
+      // Hint matched, but no `@SolidState` field or getter resolved — the
+      // file likely contains a comment or string literal mentioning `@Solid…`.
+      // Reserved annotations are caught upstream.
       await buildStep.writeAsString(outputId, source);
       return;
     }
@@ -91,19 +93,27 @@ class _SolidBuilder implements Builder {
   }
 }
 
-/// One class declaration paired with the `@SolidState` fields it contains.
+/// One class declaration paired with the `@SolidState` fields and getters it
+/// contains.
 ///
-/// `fields` is empty when the class exists in the source but has no
+/// Both lists are empty when the class exists in the source but has no
 /// `@SolidState` annotations; such classes are passed through verbatim.
 class _AnnotatedClass {
-  _AnnotatedClass(this.decl, this.fields);
+  _AnnotatedClass(this.decl, this.fields, this.getters);
   final ClassDeclaration decl;
   final List<FieldModel> fields;
+  final List<GetterModel> getters;
 }
 
 /// Walks [unit] once and returns every class paired with its `@SolidState`
-/// fields. Replaces an earlier double-walk (presence check + collection) with
-/// a single traversal per file.
+/// fields and getters. Replaces an earlier double-walk (presence check +
+/// collection) with a single traversal per file.
+///
+/// Fields are read first so the getter body's reactive-name set already
+/// contains every field of the same class; a getter referencing a sibling
+/// `@SolidState` field gets its `.value` rewrite applied per SPEC §5.1.
+/// Getters then enter the name set in source order so a later getter can
+/// also reference an earlier annotated getter.
 List<_AnnotatedClass> _collectAnnotatedClasses(
   CompilationUnit unit,
   String source,
@@ -112,12 +122,26 @@ List<_AnnotatedClass> _collectAnnotatedClasses(
   for (final decl in unit.declarations) {
     if (decl is! ClassDeclaration) continue;
     final fields = <FieldModel>[];
+    final getters = <GetterModel>[];
+    final reactiveNames = <String>{};
     for (final member in decl.members) {
-      if (member is! FieldDeclaration) continue;
-      final model = readSolidStateField(member, source);
-      if (model != null) fields.add(model);
+      if (member is FieldDeclaration) {
+        final model = readSolidStateField(member, source);
+        if (model != null) {
+          fields.add(model);
+          reactiveNames.add(model.fieldName);
+        }
+        continue;
+      }
+      if (member is MethodDeclaration) {
+        final model = readSolidStateGetter(member, reactiveNames, source);
+        if (model != null) {
+          getters.add(model);
+          reactiveNames.add(model.getterName);
+        }
+      }
     }
-    result.add(_AnnotatedClass(decl, fields));
+    result.add(_AnnotatedClass(decl, fields, getters));
   }
   return result;
 }
@@ -134,13 +158,13 @@ String _renderOutput(
   String source,
 ) {
   final results = annotatedClasses.map((c) {
-    if (c.fields.isEmpty) {
+    if (c.fields.isEmpty && c.getters.isEmpty) {
       return (
         text: source.substring(c.decl.offset, c.decl.end),
         solidartNames: const <String>{},
       );
     }
-    return _rewriteClass(c.decl, c.fields, source);
+    return _rewriteClass(c.decl, c.fields, c.getters, source);
   }).toList();
 
   final imports = computeOutputImports(
@@ -160,16 +184,17 @@ String _renderOutput(
 RewriteResult _rewriteClass(
   ClassDeclaration decl,
   List<FieldModel> fields,
+  List<GetterModel> getters,
   String source,
 ) {
   final kind = classKindOf(decl);
   switch (kind) {
     case ClassKind.statelessWidget:
-      return rewriteStatelessWidget(decl, fields, source);
+      return rewriteStatelessWidget(decl, fields, getters, source);
     case ClassKind.plainClass:
-      return rewritePlainClass(decl, fields, source);
+      return rewritePlainClass(decl, fields, getters, source);
     case ClassKind.stateClass:
-      return rewriteStateClass(decl, fields, source);
+      return rewriteStateClass(decl, fields, getters, source);
     case ClassKind.statefulWidget:
       throw CodeGenerationError(
         'class-kind $kind is not supported yet '

--- a/packages/solid_generator/lib/src/annotation_reader.dart
+++ b/packages/solid_generator/lib/src/annotation_reader.dart
@@ -1,5 +1,8 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:solid_generator/src/field_model.dart';
+import 'package:solid_generator/src/getter_model.dart';
+import 'package:solid_generator/src/transformation_error.dart';
+import 'package:solid_generator/src/value_rewriter.dart';
 
 /// Name of the annotation class this reader looks for.
 ///
@@ -34,13 +37,66 @@ FieldModel? readSolidStateField(FieldDeclaration decl, String source) {
             variable.initializer!.offset,
             variable.initializer!.end,
           ),
-    annotationName: _extractNameArgument(annotation),
+    annotationName: extractNameArgument(annotation),
     isLate: varList.isLate,
     // `TypeAnnotation.question` is the `?` token at the top level of the
     // declared type. Using it (vs. a `typeText.endsWith('?')` heuristic)
     // correctly classifies nested-nullable types like `List<int?>` as
     // non-nullable at the outer level (SPEC Section 4.3).
     isNullable: type?.question != null,
+  );
+}
+
+/// Reads a `@SolidState(...)` annotation on the getter [decl] and returns a
+/// [GetterModel]. Returns `null` when the method is not an `@SolidState`
+/// getter; non-getter methods and static getters are filtered out earlier by
+/// `validateSolidStateTargets`, but this reader is defensive and skips them
+/// silently as well.
+///
+/// The getter body's expression is rewritten in place per SPEC §5.1: any
+/// reference to a name in [reactiveFields] receives `.value`. M2-01 supports
+/// expression-body getters only (`get x => <expr>;`); a block-body getter is
+/// rejected with a clear error pointing at the M2-01b TODO.
+GetterModel? readSolidStateGetter(
+  MethodDeclaration decl,
+  Set<String> reactiveFields,
+  String source,
+) {
+  if (!decl.isGetter || decl.isStatic) return null;
+  final annotation = findSolidStateAnnotation(decl.metadata);
+  if (annotation == null) return null;
+
+  final body = decl.body;
+  if (body is! ExpressionFunctionBody) {
+    throw CodeGenerationError(
+      '@SolidState block-body getter is not yet supported '
+      '(scheduled for TODO M2-01b)',
+      null,
+      decl.name.lexeme,
+    );
+  }
+
+  final returnType = decl.returnType;
+  final typeText = returnType == null
+      ? ''
+      : source.substring(returnType.offset, returnType.end);
+
+  // SPEC §5.1: rewrite reactive reads inside the body. `trackedReadOffsets`
+  // are intentionally ignored — SignalBuilder placement is a `build()`
+  // concern, not a `Computed` body concern.
+  final expr = body.expression;
+  final result = collectValueEdits(expr, reactiveFields, source);
+  final bodyExpressionText = applyEditsToRange(
+    source.substring(expr.offset, expr.end),
+    result.edits,
+    expr.offset,
+  );
+
+  return GetterModel(
+    getterName: decl.name.lexeme,
+    typeText: typeText,
+    bodyExpressionText: bodyExpressionText,
+    annotationName: extractNameArgument(annotation),
   );
 }
 
@@ -56,8 +112,10 @@ Annotation? findSolidStateAnnotation(NodeList<Annotation> metadata) {
 }
 
 /// Extracts the string value of a `name: '…'` named argument on [annotation],
-/// or `null` if the annotation has no such argument.
-String? _extractNameArgument(Annotation annotation) {
+/// or `null` if the annotation has no such argument. Shared between the field
+/// and getter readers so both reactive shapes thread the SPEC §4.4 debug name
+/// uniformly.
+String? extractNameArgument(Annotation annotation) {
   final args = annotation.arguments?.arguments ?? const [];
   for (final arg in args) {
     if (arg is NamedExpression && arg.name.label.name == 'name') {

--- a/packages/solid_generator/lib/src/build_rewriter.dart
+++ b/packages/solid_generator/lib/src/build_rewriter.dart
@@ -70,7 +70,7 @@ String rewriteBuildMethod(
     final innerValueEdits = valueResult.edits
         .where((e) => e.offset >= node.offset && e.end <= node.end)
         .toList();
-    final rewrittenInner = _applyEditsToRange(
+    final rewrittenInner = applyEditsToRange(
       innerOriginal,
       innerValueEdits,
       node.offset,
@@ -103,20 +103,6 @@ String rewriteBuildMethod(
         result.substring(0, edit.offset) +
         edit.replacement +
         result.substring(edit.end);
-  }
-  return result;
-}
-
-/// Applies [edits] (offsets relative to the full source) to the substring
-/// [text] whose original file offset begins at [baseOffset]. Returns the
-/// rewritten substring.
-String _applyEditsToRange(String text, List<ValueEdit> edits, int baseOffset) {
-  final sorted = [...edits]..sort((a, b) => b.offset.compareTo(a.offset));
-  var result = text;
-  for (final e in sorted) {
-    final start = e.offset - baseOffset;
-    final end = e.end - baseOffset;
-    result = result.substring(0, start) + e.replacement + result.substring(end);
   }
   return result;
 }

--- a/packages/solid_generator/lib/src/getter_model.dart
+++ b/packages/solid_generator/lib/src/getter_model.dart
@@ -1,0 +1,66 @@
+import 'package:meta/meta.dart';
+import 'package:solid_generator/src/transformation_error.dart';
+
+/// Parsed description of one `@SolidState`-annotated getter.
+///
+/// Populated by `annotation_reader.dart` from unresolved AST and consumed by
+/// the rewriters (currently `stateless_rewriter.dart`). All string members are
+/// the raw source text of the corresponding AST node — except
+/// [bodyExpressionText], which is the source-substring of the getter body
+/// expression with the SPEC §5.1 `.value` rewrites already applied so the
+/// emitter can splice it directly into a `Computed<T>(() => …)` template.
+@immutable
+class GetterModel {
+  /// Creates a [GetterModel] describing an annotated getter.
+  const GetterModel({
+    required this.getterName,
+    required this.typeText,
+    required this.bodyExpressionText,
+    required this.annotationName,
+  });
+
+  /// Declared identifier of the getter (e.g. `'doubleCounter'`).
+  final String getterName;
+
+  /// Raw source text of the declared return type (e.g. `'int'`,
+  /// `'List<String>'`). Empty string only if the getter has no declared type —
+  /// not expected for `@SolidState` getters per SPEC §3.1.
+  final String typeText;
+
+  /// Source text of the getter's expression body with the SPEC §5.1
+  /// reactive-read rewrite already applied. For an input
+  /// `int get doubleCounter => counter * 2;` where `counter` is a sibling
+  /// `@SolidState` field, this is the string `'counter.value * 2'`.
+  ///
+  /// M2-01 only supports expression-body getters (`get x => <expr>;`). The
+  /// block-body form (SPEC §4.6) is rejected by `readSolidStateGetter` and
+  /// scheduled for M2-01b.
+  final String bodyExpressionText;
+
+  /// Value of the `name:` argument on `@SolidState(name: '…')`, or `null` if
+  /// the annotation had no `name:` argument (SPEC §4.4).
+  final String? annotationName;
+}
+
+/// Throws [CodeGenerationError] when [solidGetters] is non-empty, naming the
+/// first offending getter and the [classKindLabel] (`'plain class'`,
+/// `'existing State<X> subclass'`, …) of the rewriter that has not yet
+/// implemented getter→`Computed` lowering.
+///
+/// Mirrors the `_reject` pattern in `target_validator.dart`: the message
+/// template lives in one place so two rewriters' "not yet supported" errors
+/// can never drift.
+void rejectIfGettersNotYetSupported(
+  List<GetterModel> solidGetters,
+  String classKindLabel,
+  String className,
+) {
+  if (solidGetters.isEmpty) return;
+  throw CodeGenerationError(
+    '@SolidState getter on $classKindLabel is not yet supported '
+    '(will land in a later M2 TODO); '
+    'offending getter: ${solidGetters.first.getterName}',
+    null,
+    className,
+  );
+}

--- a/packages/solid_generator/lib/src/plain_class_rewriter.dart
+++ b/packages/solid_generator/lib/src/plain_class_rewriter.dart
@@ -1,5 +1,6 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:solid_generator/src/field_model.dart';
+import 'package:solid_generator/src/getter_model.dart';
 import 'package:solid_generator/src/import_rewriter.dart';
 import 'package:solid_generator/src/signal_emitter.dart';
 import 'package:solid_generator/src/transformation_error.dart';
@@ -25,13 +26,20 @@ import 'package:solid_generator/src/transformation_error.dart';
 RewriteResult rewritePlainClass(
   ClassDeclaration classDecl,
   List<FieldModel> solidFields,
+  List<GetterModel> solidGetters,
   String source,
 ) {
   final className = classDecl.name.lexeme;
+  // M2-01 ships getter→Computed for `StatelessWidget` only; reject here so
+  // M1-14's valid-target pass isn't silently undone.
+  rejectIfGettersNotYetSupported(solidGetters, 'plain class', className);
   _checkUnsupportedMembers(classDecl, solidFields, className);
 
   final signalFields = solidFields.map(emitSignalField).join('\n');
-  final dispose = emitDispose(solidFields, inheritsDispose: false);
+  final dispose = emitDispose(
+    solidFields.map((f) => f.fieldName).toList(),
+    inheritsDispose: false,
+  );
 
   return (
     text:

--- a/packages/solid_generator/lib/src/signal_emitter.dart
+++ b/packages/solid_generator/lib/src/signal_emitter.dart
@@ -1,4 +1,5 @@
 import 'package:solid_generator/src/field_model.dart';
+import 'package:solid_generator/src/getter_model.dart';
 
 /// Shared signal-emission helpers used by every class-kind rewriter.
 
@@ -33,16 +34,37 @@ String emitSignalField(FieldModel f) {
   return '  ${lateKw}final ${f.fieldName} = $ctor;';
 }
 
-/// Emits a `dispose()` method disposing every signal in reverse declaration
-/// order (SPEC §10).
+/// Emits one `late final <name> = Computed<T>(() => <body>, name: '<debug>');`
+/// line per SPEC §4.5.
 ///
-/// [inheritsDispose] is `true` when the owning class's supertype chain contains
-/// a `dispose()` method (e.g. `State<T>`, `ChangeNotifier`); the emitted method
-/// is then `@override` and ends with `super.dispose();`. For a plain class
-/// whose supertype is `Object`, pass `false` — neither annotation nor
-/// super-call is emitted (SPEC §8.3).
+/// The result is always `late final` because a `Computed` references other
+/// `final` instance fields whose initialization order is not guaranteed
+/// (SPEC §4.5 last bullet). The body expression text in [g] has already had
+/// the SPEC §5.1 `.value` rewrite applied by `readSolidStateGetter`, so the
+/// emitter splices it directly into the closure template.
+String emitComputedField(GetterModel g) {
+  final debugName = g.annotationName ?? g.getterName;
+  final body = g.bodyExpressionText;
+  final ctor = "Computed<${g.typeText}>(() => $body, name: '$debugName')";
+  return '  late final ${g.getterName} = $ctor;';
+}
+
+/// Emits a `dispose()` method disposing every name in
+/// [disposeNamesInDeclarationOrder] in **reverse declaration order** (SPEC
+/// §10).
+///
+/// The list is the unified, source-ordered sequence of every reactive
+/// declaration (Signal field + Computed getter) on the owning class.
+/// Reverse-iterating it puts dependents (a `Computed` declared after the
+/// `Signal`s it reads) ahead of their dependencies in the dispose body.
+///
+/// [inheritsDispose] is `true` when the owning class's supertype chain
+/// contains a `dispose()` method (e.g. `State<T>`, `ChangeNotifier`); the
+/// emitted method is then `@override` and ends with `super.dispose();`. For
+/// a plain class whose supertype is `Object`, pass `false` — neither
+/// annotation nor super-call is emitted (SPEC §8.3).
 String emitDispose(
-  List<FieldModel> fields, {
+  List<String> disposeNamesInDeclarationOrder, {
   required bool inheritsDispose,
 }) {
   final buffer = StringBuffer();
@@ -50,8 +72,8 @@ String emitDispose(
     buffer.writeln('  @override');
   }
   buffer.writeln('  void dispose() {');
-  for (final f in fields.reversed) {
-    buffer.writeln('    ${f.fieldName}.dispose();');
+  for (final name in disposeNamesInDeclarationOrder.reversed) {
+    buffer.writeln('    $name.dispose();');
   }
   if (inheritsDispose) {
     buffer.writeln('    super.dispose();');

--- a/packages/solid_generator/lib/src/state_class_rewriter.dart
+++ b/packages/solid_generator/lib/src/state_class_rewriter.dart
@@ -1,6 +1,7 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:solid_generator/src/build_rewriter.dart';
 import 'package:solid_generator/src/field_model.dart';
+import 'package:solid_generator/src/getter_model.dart';
 import 'package:solid_generator/src/import_rewriter.dart';
 import 'package:solid_generator/src/signal_emitter.dart';
 import 'package:solid_generator/src/transformation_error.dart';
@@ -24,14 +25,25 @@ import 'package:solid_generator/src/transformation_error.dart';
 RewriteResult rewriteStateClass(
   ClassDeclaration classDecl,
   List<FieldModel> solidFields,
+  List<GetterModel> solidGetters,
   String source,
 ) {
   final className = classDecl.name.lexeme;
+  // M2-01 ships getter→Computed for `StatelessWidget` only. The in-place
+  // merge logic this rewriter is built around does not yet handle the
+  // `late final ... = Computed<T>(...)` slot; reject so M1-14's valid-target
+  // pass isn't silently undone here.
+  rejectIfGettersNotYetSupported(
+    solidGetters,
+    'existing State<X> subclass',
+    className,
+  );
   // Index annotated fields by name for O(1) lookup during the member walk.
   // The builder already parsed `@SolidState` once when computing [solidFields];
   // re-parsing here would double the annotation-reader cost per file.
   final modelByName = {for (final f in solidFields) f.fieldName: f};
   final reactiveNames = modelByName.keys.toSet();
+  final disposeNames = solidFields.map((f) => f.fieldName).toList();
   final pieces = <String>[];
   var sawDispose = false;
 
@@ -51,7 +63,7 @@ RewriteResult rewriteStateClass(
       if (name == 'build') {
         pieces.add(rewriteBuildMethod(member, reactiveNames, source));
       } else if (name == 'dispose') {
-        pieces.add(_mergeDispose(member, solidFields, source, className));
+        pieces.add(_mergeDispose(member, disposeNames, source, className));
         sawDispose = true;
       } else {
         pieces.add(source.substring(member.offset, member.end));
@@ -62,7 +74,7 @@ RewriteResult rewriteStateClass(
   }
 
   if (!sawDispose) {
-    pieces.add(emitDispose(solidFields, inheritsDispose: true));
+    pieces.add(emitDispose(disposeNames, inheritsDispose: true));
   }
 
   final header = source.substring(
@@ -75,18 +87,19 @@ RewriteResult rewriteStateClass(
   );
 }
 
-/// Prepends one `<field>.dispose();` call per reactive declaration to the
+/// Prepends one `<name>.dispose();` call per reactive declaration to the
 /// existing `dispose()` body's leading boundary, leaving the rest of the body
 /// untouched (SPEC §10).
 ///
-/// Disposal order is reverse declaration order so dependents (e.g. `Computed`)
-/// are torn down before their dependencies (the `Signal`s they read).
+/// [disposeNamesInDeclarationOrder] is the unified, source-ordered list of
+/// reactive declarations (Signal field + Computed getter). Reverse-iterating
+/// it puts dependents ahead of their dependencies in the dispose body.
 ///
 /// Throws [CodeGenerationError] if the existing `dispose()` uses an
 /// expression body (`=> …`) — the merge is only well-defined for a block.
 String _mergeDispose(
   MethodDeclaration method,
-  List<FieldModel> fields,
+  List<String> disposeNamesInDeclarationOrder,
   String source,
   String className,
 ) {
@@ -104,8 +117,8 @@ String _mergeDispose(
   // yields a single blank-line-free splice, leaving the rest of the body
   // byte-identical to the source. The `DartFormatter` pass normalises any
   // residual whitespace.
-  final disposals = fields.reversed
-      .map((f) => '    ${f.fieldName}.dispose();')
+  final disposals = disposeNamesInDeclarationOrder.reversed
+      .map((name) => '    $name.dispose();')
       .join('\n');
   return '${source.substring(method.offset, lbrace + 1)}'
       '\n$disposals'

--- a/packages/solid_generator/lib/src/stateless_rewriter.dart
+++ b/packages/solid_generator/lib/src/stateless_rewriter.dart
@@ -1,38 +1,50 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:solid_generator/src/build_rewriter.dart';
 import 'package:solid_generator/src/field_model.dart';
+import 'package:solid_generator/src/getter_model.dart';
 import 'package:solid_generator/src/import_rewriter.dart';
 import 'package:solid_generator/src/signal_emitter.dart';
 import 'package:solid_generator/src/transformation_error.dart';
 
-/// Rewrites a `StatelessWidget` class containing `@SolidState` fields as a
-/// `StatefulWidget` + `State<X>` pair. See SPEC §8.1 for the full
-/// field-partition and constructor-preservation contract.
+/// Rewrites a `StatelessWidget` class containing `@SolidState` fields and/or
+/// `@SolidState` getters as a `StatefulWidget` + `State<X>` pair. See SPEC
+/// §8.1 for the full field-partition and constructor-preservation contract;
+/// SPEC §4.5 for the getter→`Computed` lowering.
 ///
 /// The emitted string is syntactically valid Dart but is not guaranteed to be
 /// pretty-printed — run through `DartFormatter` before writing.
 RewriteResult rewriteStatelessWidget(
   ClassDeclaration classDecl,
   List<FieldModel> solidFields,
+  List<GetterModel> solidGetters,
   String source,
 ) {
   final className = classDecl.name.lexeme;
   final stateClassName = '_${className}State';
-  final reactiveFieldNames = solidFields.map((f) => f.fieldName).toSet();
+  final reactiveNames = <String>{
+    ...solidFields.map((f) => f.fieldName),
+    ...solidGetters.map((g) => g.getterName),
+  };
 
   final members = _splitMembers(classDecl);
   final widgetBoundNames = _collectWidgetBoundNames(members.ctors);
   final partition = _partitionFields(
     members.fields,
-    reactiveFieldNames,
+    reactiveNames,
     widgetBoundNames,
     source,
   );
   final ctorsBlock = _emitCtors(members.ctors, source);
   final buildMethodText = rewriteBuildMethod(
     members.buildMethod,
-    reactiveFieldNames,
+    reactiveNames,
     source,
+  );
+
+  final reactiveBlock = _emitReactiveBlock(
+    classDecl,
+    solidFields,
+    solidGetters,
   );
 
   final widgetClass = _emitWidgetClass(
@@ -44,14 +56,62 @@ RewriteResult rewriteStatelessWidget(
   final stateClass = _emitStateClass(
     className,
     stateClassName,
-    solidFields,
+    reactiveBlock.fieldsText,
+    reactiveBlock.disposeNamesInDeclarationOrder,
     partition.stateFieldsText,
     buildMethodText,
   );
 
+  final solidartNames = <String>{'Signal', 'SignalBuilder'};
+  if (solidGetters.isNotEmpty) solidartNames.add('Computed');
+
   return (
     text: '$widgetClass\n\n$stateClass\n',
-    solidartNames: const <String>{'Signal', 'SignalBuilder'},
+    solidartNames: solidartNames,
+  );
+}
+
+/// Returns the source-ordered emission of every reactive declaration on
+/// [classDecl] (Signal field + Computed getter) as a single 2-space-indented
+/// block, plus the declaration-order list of dispose names that pairs with
+/// it. Source order — not field-then-getter — is the contract a `Computed`
+/// depends on: it must reference fields declared before it, so the emitted
+/// `late final` Computed must appear after the `Signal`s it reads in the
+/// rewritten State class.
+({String fieldsText, List<String> disposeNamesInDeclarationOrder})
+_emitReactiveBlock(
+  ClassDeclaration classDecl,
+  List<FieldModel> solidFields,
+  List<GetterModel> solidGetters,
+) {
+  final fieldByName = {for (final f in solidFields) f.fieldName: f};
+  final getterByName = {for (final g in solidGetters) g.getterName: g};
+  final lines = <String>[];
+  final disposeNames = <String>[];
+
+  for (final member in classDecl.members) {
+    if (member is FieldDeclaration) {
+      final name = member.fields.variables.first.name.lexeme;
+      final f = fieldByName[name];
+      if (f != null) {
+        lines.add(emitSignalField(f));
+        disposeNames.add(f.fieldName);
+      }
+      continue;
+    }
+    if (member is MethodDeclaration && member.isGetter) {
+      final name = member.name.lexeme;
+      final g = getterByName[name];
+      if (g != null) {
+        lines.add(emitComputedField(g));
+        disposeNames.add(g.getterName);
+      }
+    }
+  }
+
+  return (
+    fieldsText: lines.join('\n'),
+    disposeNamesInDeclarationOrder: disposeNames,
   );
 }
 
@@ -184,21 +244,26 @@ String _emitWidgetClass(
 /// `dispose()` is `@override` and ends with `super.dispose();` (SPEC §10).
 /// [stateFieldsText] is the verbatim source of every non-`@SolidState`
 /// non-widget-bound field that has been moved off the widget; emitted before
-/// the synthesized signal fields so original declaration order is preserved.
+/// the synthesized reactive fields so original declaration order is preserved.
+/// [reactiveFieldsText] is the source-ordered emission of every reactive
+/// declaration (Signal field + Computed getter) on the original class.
 String _emitStateClass(
   String className,
   String stateClassName,
-  List<FieldModel> fields,
+  String reactiveFieldsText,
+  List<String> disposeNamesInDeclarationOrder,
   String stateFieldsText,
   String buildMethodText,
 ) {
-  final signalFields = fields.map(emitSignalField).join('\n');
-  final dispose = emitDispose(fields, inheritsDispose: true);
+  final dispose = emitDispose(
+    disposeNamesInDeclarationOrder,
+    inheritsDispose: true,
+  );
   final fieldsPrefix = stateFieldsText.isNotEmpty ? '$stateFieldsText\n\n' : '';
 
   return '''
 class $stateClassName extends State<$className> {
-$fieldsPrefix$signalFields
+$fieldsPrefix$reactiveFieldsText
 
 $dispose
 

--- a/packages/solid_generator/lib/src/value_rewriter.dart
+++ b/packages/solid_generator/lib/src/value_rewriter.dart
@@ -67,21 +67,43 @@ const Set<String> _keyConstructors = {
   'PageStorageKey',
 };
 
-/// Walks [buildMethod] and returns every offset-based value edit plus the
+/// Walks [node] and returns every offset-based value edit plus the
 /// tracked-read offsets that downstream placement needs.
 ///
-/// [reactiveFields] is the name-set of `@SolidState` fields declared on the
-/// enclosing class. The rewrite is name-based (see SPEC 5.4 note in the
-/// orchestrator `rewriteBuildMethod`); M3-05 upgrades to type-driven
-/// resolution.
+/// [reactiveFields] is the name-set of `@SolidState` fields and getters
+/// declared on the enclosing class. The rewrite is name-based (see SPEC 5.4
+/// note in the orchestrator `rewriteBuildMethod`); M3-05 upgrades to
+/// type-driven resolution.
+///
+/// [node] is typically the `build()` `MethodDeclaration` (the M1-05 path) or
+/// the body expression of a `@SolidState` getter (the M2-01 path). Both share
+/// the same identifier-rewrite contract; only `build()` consumes
+/// [ValueRewriteResult.trackedReadOffsets] for SignalBuilder placement.
 ValueRewriteResult collectValueEdits(
-  MethodDeclaration buildMethod,
+  AstNode node,
   Set<String> reactiveFields,
   String source,
 ) {
   final visitor = _ValueRewriteVisitor(reactiveFields);
-  buildMethod.accept(visitor);
+  node.accept(visitor);
   return ValueRewriteResult(visitor.edits, visitor.trackedReadOffsets);
+}
+
+/// Applies offset-based [edits] (with absolute file offsets) to [text] whose
+/// original file offset begins at [baseOffset]. Returns the rewritten string.
+///
+/// Edits are sorted reverse-by-offset so earlier offsets stay stable while
+/// each splice executes. Empty [edits] short-circuits without allocating.
+String applyEditsToRange(String text, List<ValueEdit> edits, int baseOffset) {
+  if (edits.isEmpty) return text;
+  final sorted = [...edits]..sort((a, b) => b.offset.compareTo(a.offset));
+  var result = text;
+  for (final e in sorted) {
+    final start = e.offset - baseOffset;
+    final end = e.end - baseOffset;
+    result = result.substring(0, start) + e.replacement + result.substring(end);
+  }
+  return result;
 }
 
 /// AST visitor that accumulates [ValueEdit]s for reactive-field identifiers.

--- a/packages/solid_generator/test/golden/inputs/m2_01_simple_computed_with_deps.dart
+++ b/packages/solid_generator/test/golden/inputs/m2_01_simple_computed_with_deps.dart
@@ -1,0 +1,15 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+
+class Counter extends StatelessWidget {
+  Counter({super.key});
+
+  @SolidState()
+  int counter = 0;
+
+  @SolidState()
+  int get doubleCounter => counter * 2;
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/golden/outputs/m2_01_simple_computed_with_deps.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m2_01_simple_computed_with_deps.g.dart
@@ -1,0 +1,28 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class Counter extends StatefulWidget {
+  Counter({super.key});
+
+  @override
+  State<Counter> createState() => _CounterState();
+}
+
+class _CounterState extends State<Counter> {
+  final counter = Signal<int>(0, name: 'counter');
+  late final doubleCounter = Computed<int>(
+    () => counter.value * 2,
+    name: 'doubleCounter',
+  );
+
+  @override
+  void dispose() {
+    doubleCounter.dispose();
+    counter.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -26,6 +26,7 @@ const List<String> goldenNames = <String>[
   'm1_08_import_rewrite',
   'm1_12_passthrough_no_annotations',
   'm1_13_multiple_constructors',
+  'm2_01_simple_computed_with_deps',
 ];
 
 /// Memoized golden directory resolution. Resolved relative to the package

--- a/plans/just-merged-implement-m1-15-robust-pearl.md
+++ b/plans/just-merged-implement-m1-15-robust-pearl.md
@@ -1,0 +1,237 @@
+# M2-01 — `@SolidState` getter → `Computed`
+
+## Context
+
+PR #32 (M1-15: reject reserved annotations at build time) just merged on `main` (commit `8a0e253`). Per the workflow in `TODOS.md` ("pick the lowest-numbered item whose Status is TODO and whose Dependencies are all DONE") and the established one-TODO-per-PR cadence (commits #18 → #32 each map to a single milestone item), the next item is **M2-01 — Golden: simple Computed with deps** (`TODOS.md` lines 847-882).
+
+M2 introduces the second `@SolidState` shape: the annotation on a class **getter** lowers to a `Computed<T>` whose body wraps the original getter's expression with the Section 5.1 reactive-read rewrite already used inside `build()`. M1-14 / M1-15 already validate that an instance getter is a valid annotation target (`target_validator.dart` line 65 explicitly comments "M2 emits Computed"), so the user-facing validation surface is already in place — the missing piece is the lowering itself.
+
+After M2-01, a developer writing
+
+```dart
+@SolidState() int counter = 0;
+@SolidState() int get doubleCounter => counter * 2;
+```
+
+on a `StatelessWidget` gets a `late final doubleCounter = Computed<int>(() => counter.value * 2, name: 'doubleCounter');` field on the synthesized State class plus a `dispose()` body that disposes `doubleCounter` before `counter` (reverse declaration order, SPEC §10).
+
+**Scope (per user direction):** This PR delivers M2-01 only — StatelessWidget split with getter handling. `rewriteStateClass` and `rewritePlainClass` are extended only to **reject** `@SolidState` getters with a clear `CodeGenerationError`; full support lands in later TODOs as needed. M2-01b (block-body getter), M2-02 (zero-deps rejection), M2-03 (Computed read in `build`), and M2-04 (explicit dispose-order golden) are separate PRs.
+
+## Approach
+
+### 1. New model type: `GetterModel`
+
+Add `packages/solid_generator/lib/src/getter_model.dart` (~30 lines, parallel to existing `field_model.dart`):
+
+```dart
+@immutable
+class GetterModel {
+  const GetterModel({
+    required this.getterName,
+    required this.typeText,
+    required this.bodyExpressionText,
+    required this.annotationName,
+  });
+  final String getterName;       // 'doubleCounter'
+  final String typeText;          // 'int'
+  final String bodyExpressionText; // 'counter * 2' — already with .value rewrites applied
+  final String? annotationName;
+}
+```
+
+`bodyExpressionText` is stored already-rewritten (Section 5.1 applied) so the emitter is purely string-template.
+
+### 2. Reading getter annotations
+
+Extend `packages/solid_generator/lib/src/annotation_reader.dart`:
+
+- Add `GetterModel? readSolidStateGetter(MethodDeclaration decl, Set<String> reactiveFieldNames, String source)`.
+- Reuse `findSolidStateAnnotation(decl.metadata)` (already exposed for the validator).
+- Reuse `_extractNameArgument(annotation)` — refactor it from `_extractNameArgument` (currently private, line 60) to a top-level `extractNameArgument` helper so both readers share it.
+- For an expression-body getter (`get x => <expr>;`), the body expression substring is `source.substring(expr.offset, expr.end)`. Apply the Section 5.1 rewriter to that range using a thin reuse of `value_rewriter.dart` (see step 4).
+- For a block-body getter, throw `CodeGenerationError('@SolidState block-body getter not yet supported (M2-01b)', ...)`. M2-01 ships expression-body only.
+
+### 3. Collecting getters
+
+Extend `_collectAnnotatedClasses` in `packages/solid_generator/lib/builder.dart` (lines 107-123) to walk `MethodDeclaration` members alongside `FieldDeclaration`s. Extend `_AnnotatedClass`:
+
+```dart
+class _AnnotatedClass {
+  _AnnotatedClass(this.decl, this.fields, this.getters);
+  final ClassDeclaration decl;
+  final List<FieldModel> fields;
+  final List<GetterModel> getters;
+}
+```
+
+Iterate members in source order, populating both lists. Reactive-name set passed to the body rewriter is the union of `fields.map((f) => f.fieldName)` plus all `getters.map((g) => g.getterName)` collected so far (a getter can read another getter declared earlier).
+
+The pass-through guard (`builder.dart` line 81) becomes `annotatedClasses.every((c) => c.fields.isEmpty && c.getters.isEmpty)`.
+
+### 4. Section 5.1 body rewrite for getter expressions
+
+`packages/solid_generator/lib/src/value_rewriter.dart`'s `collectValueEdits` currently takes `MethodDeclaration buildMethod` (line 77) but its body just calls `buildMethod.accept(visitor)`. Generalise the entry to `AstNode node` (rename the parameter; the function shape doesn't change). Two callers update:
+
+- `build_rewriter.dart` line 58 — passes the build method (no behaviour change).
+- New caller inside `annotation_reader.dart` `readSolidStateGetter` — passes the getter's expression-body `Expression` node and the same `reactiveFields` set, then applies edits to `source.substring(expr.offset, expr.end)` to produce `bodyExpressionText`.
+
+The visitor's untracked-context tracking (`_untrackedDepth`, `Key`-family, `untracked()` calls) and shadowing logic apply uniformly inside getter bodies — no code changes needed.
+
+`trackedReadOffsets` from the getter's body are **discarded**; SignalBuilder placement is a `build()`-method concern, not a `Computed` body concern (the `Computed` itself subscribes via the runtime).
+
+### 5. Computed emitter
+
+Add `emitComputedField(GetterModel g)` to `packages/solid_generator/lib/src/signal_emitter.dart`:
+
+```dart
+String emitComputedField(GetterModel g) {
+  final debugName = g.annotationName ?? g.getterName;
+  return '  late final ${g.getterName} = '
+      "Computed<${g.typeText}>(() => ${g.bodyExpressionText}, name: '$debugName');";
+}
+```
+
+Always `late final` per SPEC §4.5: "the resulting Computed field is always declared `late final`".
+
+### 6. Generalised dispose synthesis
+
+`emitDispose(List<FieldModel> fields, {required bool inheritsDispose})` (`signal_emitter.dart` line 44) currently iterates `fields.reversed`. Replace the parameter with a unified ordered list of disposable names:
+
+```dart
+String emitDispose(
+  List<String> disposeNamesInDeclarationOrder, {
+  required bool inheritsDispose,
+}) {
+  // ... iterates `.reversed`
+}
+```
+
+Callers compute the unified list themselves by interleaving fields and getters in source-declaration order. For `rewriteStatelessWidget`, the new helper `_orderedDisposeNames(fields, getters, classDecl)` reads each `ClassMember`'s offset (we already have the AST) and produces the names in source order. Reverse-declaration order then naturally puts the Computed (declared after the Signal it reads) ahead of the Signal in the dispose body.
+
+### 7. Stateless-widget rewriter (the only one that fully supports getters in this PR)
+
+`packages/solid_generator/lib/src/stateless_rewriter.dart`:
+
+- New parameter on `rewriteStatelessWidget`: `List<GetterModel> solidGetters`.
+- `_splitMembers` (line 68) drops annotated getters from the `fields` bucket (they aren't fields anyway — they're `MethodDeclaration`s). Only the `build` method goes to `buildMethod`. Annotated-getter `MethodDeclaration`s are not in any of the three buckets the rewriter cares about (we already have their `GetterModel`s) — but a non-annotated method we don't currently capture would be silently dropped. **Add a fourth bucket** `otherMethods` for completeness; M2-01's golden has none, so it's just defensive — a follow-up TODO can flesh out.
+  
+  *Decision for this PR:* keep `_splitMembers` returning only `(ctors, fields, buildMethod)` and verify the M1 cohort goldens still pass; non-annotated, non-`build` methods on a `StatelessWidget` were already dropped and are out of scope here.
+
+- `_emitStateClass` (line 188) interleaves Signal fields and Computed fields in source order. Use the `ClassMember` offset of each backing declaration. Specifically:
+  - Build a list of `(offset, emittedLine)` from `fields.map((f) => (originalFieldOffset, emitSignalField(f)))` and `getters.map((g) => (originalGetterOffset, emitComputedField(g)))`.
+  - Sort by `offset`.
+  - Join with `\n`.
+- `dispose` is computed by `emitDispose(_orderedDisposeNames(fields, getters, classDecl), inheritsDispose: true)`.
+- `solidartNames` returns `{'Signal', 'Computed', 'SignalBuilder'}` whenever `getters.isNotEmpty`; otherwise unchanged. (`Computed` is already in the canonical `solidartNames` set in `import_rewriter.dart` line 17, so the import-add rule fires correctly.)
+
+### 8. Other rewriters: explicit "not yet supported"
+
+- `rewritePlainClass` (`plain_class_rewriter.dart`): add a guard at the top — if any annotated getter exists for this class, throw `CodeGenerationError('plain class with @SolidState getter is not yet supported (will land in a later M2 TODO)', null, className)`. This keeps `target_validator` happy (instance getter is a valid target) without silently dropping.
+- `rewriteStateClass` (`state_class_rewriter.dart`): same guard.
+
+The dispatcher `_rewriteClass` in `builder.dart` (line 160) passes `getters` through to all three; the two non-stateless rewriters reject early. M1's existing goldens (which have no getters) round-trip unchanged.
+
+### 9. Golden test wiring
+
+Append to `goldenNames` in `packages/solid_generator/test/integration/golden_helpers.dart` (line 18):
+
+```dart
+'m2_01_simple_computed_with_deps',
+```
+
+The body of `golden_test.dart` does not change.
+
+### 10. Golden fixtures
+
+**`packages/solid_generator/test/golden/inputs/m2_01_simple_computed_with_deps.dart`** — `StatelessWidget` mirroring the M1-01 shape, with one Signal + one expression-body Computed getter:
+
+```dart
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+
+class Counter extends StatelessWidget {
+  Counter({super.key});
+
+  @SolidState()
+  int counter = 0;
+
+  @SolidState()
+  int get doubleCounter => counter * 2;
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}
+```
+
+**`packages/solid_generator/test/golden/outputs/m2_01_simple_computed_with_deps.g.dart`** — generated by `UPDATE_GOLDENS=1 dart test`, then hand-verified to match SPEC §4.5:
+
+```dart
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class Counter extends StatefulWidget {
+  Counter({super.key});
+
+  @override
+  State<Counter> createState() => _CounterState();
+}
+
+class _CounterState extends State<Counter> {
+  final counter = Signal<int>(0, name: 'counter');
+  late final doubleCounter = Computed<int>(
+    () => counter.value * 2,
+    name: 'doubleCounter',
+  );
+
+  @override
+  void dispose() {
+    doubleCounter.dispose();
+    counter.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}
+```
+
+Note: `dart_style` may break the long `Computed<int>(...)` line across multiple lines; the formatter pass in `_renderOutput` (`builder.dart` line 156) is the source of truth. The committed golden reflects the formatter's output verbatim.
+
+### 11. Mark TODO done
+
+Edit `TODOS.md` line 881 (the M2-01 entry's `Status`) from `TODO` to `DONE` in the same PR.
+
+## Critical files
+
+- `packages/solid_generator/lib/builder.dart` — extend `_collectAnnotatedClasses` and `_AnnotatedClass` to carry `getters` (lines 98-123); pass `getters` through `_rewriteClass` (line 160).
+- `packages/solid_generator/lib/src/annotation_reader.dart` — add `readSolidStateGetter` and refactor `_extractNameArgument` to a shared top-level helper (lines 51-69).
+- `packages/solid_generator/lib/src/getter_model.dart` — **new file**, parallel to `field_model.dart`.
+- `packages/solid_generator/lib/src/signal_emitter.dart` — add `emitComputedField`; generalise `emitDispose` to take a unified ordered name list (lines 22-61).
+- `packages/solid_generator/lib/src/value_rewriter.dart` — generalise `collectValueEdits` parameter from `MethodDeclaration buildMethod` to `AstNode node` (line 77). Body unchanged.
+- `packages/solid_generator/lib/src/stateless_rewriter.dart` — accept `solidGetters`; interleave Signal + Computed fields in source order; pass merged disposable-name list to `emitDispose` (lines 14-56, 188-207).
+- `packages/solid_generator/lib/src/state_class_rewriter.dart` — guard: reject `@SolidState` getters with `CodeGenerationError` until a future TODO.
+- `packages/solid_generator/lib/src/plain_class_rewriter.dart` — same guard.
+- `packages/solid_generator/lib/src/build_rewriter.dart` — call site for `collectValueEdits` updates the parameter name only (line 58).
+- `packages/solid_generator/test/integration/golden_helpers.dart` — append `'m2_01_simple_computed_with_deps'` to `goldenNames` (line 28).
+- `packages/solid_generator/test/golden/inputs/m2_01_simple_computed_with_deps.dart` — **new fixture**.
+- `packages/solid_generator/test/golden/outputs/m2_01_simple_computed_with_deps.g.dart` — **new fixture** (generated, hand-verified).
+- `TODOS.md` — flip M2-01 `Status: TODO` → `Status: DONE` at line 881.
+
+## Verification
+
+End-to-end run from the workspace root:
+
+1. `dart pub get` (workspace).
+2. From `packages/solid_generator/`:
+   - `dart format --set-exit-if-changed lib test` — zero diff.
+   - `dart analyze --fatal-infos lib test` — zero issues.
+   - `UPDATE_GOLDENS=1 dart test --name=m2_01_simple_computed_with_deps` — regenerates the output fixture; commit only after manual diff against the SPEC §4.5 expected shape.
+   - `dart test --name=m2_01_simple_computed_with_deps` — golden equality passes.
+   - `dart test --name=golden` — every M1 golden still passes (regression check on the rewrite path).
+   - `dart test test/rejections/` — both M1-14 and M1-15 rejection suites still pass.
+   - `dart test test/integration/idempotency_test.dart` — two-run byte equality holds with the new fixture (the M1-09 invariant).
+3. `dart analyze packages/solid_generator/test/golden/outputs/m2_01_simple_computed_with_deps.g.dart` — zero issues (rubric check #6).
+4. From `example/`: `dart run build_runner build --delete-conflicting-outputs` exits 0 and `dart analyze` reports zero issues — confirms the change does not regress the consumer-app build path.
+
+Reviewer rubric (`plans/features/reviewer-rubric.md`): paired golden committed, no regex, no `dynamic` casts, no file > 400 lines, no function > 50 lines, output cited against SPEC §4.5 + §5.1 + §10.


### PR DESCRIPTION
## Summary

- Implements M2-01 milestone: convert `@SolidState`-annotated getters on `StatelessWidget` to `Computed<T>` fields in the synthesized State class
- Adds `GetterModel` to parse and represent annotated getters alongside existing `FieldModel`
- Extends `annotation_reader.dart` with `readSolidStateGetter()` to read getter annotations, rewrite their expression bodies per SPEC §5.1, and extract the debug name
- Generalizes `collectValueEdits` in `value_rewriter.dart` to accept any `AstNode` so both `build()` methods and getter bodies share the same reactive-read rewrite logic
- Updates all rewriters to handle getters: `stateless_rewriter` fully implements getter→Computed lowering; `plain_class_rewriter` and `state_class_rewriter` reject getters with clear errors (full support scheduled for later M2 TODOs)
- Maintains source-order emission of Signal fields + Computed getters; dispose walks them in reverse order per SPEC §10
- Adds golden test case: `m2_01_simple_computed_with_deps` demonstrating a Computed getter reading a sibling Signal field
- Only expression-body getters are supported; block-body form is rejected with guidance to M2-01b TODO

## Testing

- Golden test passes: `m2_01_simple_computed_with_deps` input generates expected State class with Signal field and Computed getter
- All existing golden tests remain unchanged (passthrough guard now checks both fields and getters)
- Integration test suite confirms no regressions in field-only classes
- Block-body getter on StatelessWidget correctly throws `CodeGenerationError` naming M2-01b
- Getters on plain classes and State<X> subclasses correctly throw rejection with class-kind label
- Generated dispose() methods dispose Computed fields before Signal fields they depend on (reverse source order)