### PR TITLE
M2-01b: support block-body @SolidState getters

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -912,7 +912,7 @@ late final summary = Computed<String>(() {
 
 **Dependencies:** M2-01.
 
-**Status:** TODO
+**Status:** DONE
 
 ---
 

--- a/packages/solid_generator/lib/src/annotation_reader.dart
+++ b/packages/solid_generator/lib/src/annotation_reader.dart
@@ -53,10 +53,11 @@ FieldModel? readSolidStateField(FieldDeclaration decl, String source) {
 /// `validateSolidStateTargets`, but this reader is defensive and skips them
 /// silently as well.
 ///
-/// The getter body's expression is rewritten in place per SPEC §5.1: any
-/// reference to a name in [reactiveFields] receives `.value`. M2-01 supports
-/// expression-body getters only (`get x => <expr>;`); a block-body getter is
-/// rejected with a clear error pointing at the M2-01b TODO.
+/// The getter body is rewritten in place per SPEC §5.1: any reference to a
+/// name in [reactiveFields] receives `.value`. Both expression-body
+/// (`get x => <expr>;` — SPEC §4.5) and block-body (`get x { ... }` —
+/// SPEC §4.6) shapes are supported. Other body kinds (abstract / native) are
+/// rejected with a [CodeGenerationError].
 GetterModel? readSolidStateGetter(
   MethodDeclaration decl,
   Set<String> reactiveFields,
@@ -66,37 +67,55 @@ GetterModel? readSolidStateGetter(
   final annotation = findSolidStateAnnotation(decl.metadata);
   if (annotation == null) return null;
 
-  final body = decl.body;
-  if (body is! ExpressionFunctionBody) {
-    throw CodeGenerationError(
-      '@SolidState block-body getter is not yet supported '
-      '(scheduled for TODO M2-01b)',
-      null,
-      decl.name.lexeme,
-    );
-  }
-
   final returnType = decl.returnType;
   final typeText = returnType == null
       ? ''
       : source.substring(returnType.offset, returnType.end);
 
-  // SPEC §5.1: rewrite reactive reads inside the body. `trackedReadOffsets`
-  // are intentionally ignored — SignalBuilder placement is a `build()`
-  // concern, not a `Computed` body concern.
-  final expr = body.expression;
-  final result = collectValueEdits(expr, reactiveFields, source);
-  final bodyExpressionText = applyEditsToRange(
-    source.substring(expr.offset, expr.end),
-    result.edits,
-    expr.offset,
-  );
+  final body = decl.body;
+  final String bodyText;
+  final bool isBlockBody;
+  if (body is ExpressionFunctionBody) {
+    bodyText = _rewriteNode(body.expression, reactiveFields, source);
+    isBlockBody = false;
+  } else if (body is BlockFunctionBody) {
+    bodyText = _rewriteNode(body.block, reactiveFields, source);
+    isBlockBody = true;
+  } else {
+    throw CodeGenerationError(
+      '@SolidState getter must have an expression body (=> ...) or a '
+      'block body ({ ... }); abstract and native bodies are not supported',
+      null,
+      decl.name.lexeme,
+    );
+  }
 
   return GetterModel(
     getterName: decl.name.lexeme,
     typeText: typeText,
-    bodyExpressionText: bodyExpressionText,
+    bodyText: bodyText,
+    isBlockBody: isBlockBody,
     annotationName: extractNameArgument(annotation),
+  );
+}
+
+/// Returns the source range covered by [node], with SPEC §5.1 reactive-read
+/// rewrites applied to every identifier in [reactiveFields]. Used for both
+/// the expression-body (`Expression`) and block-body (`Block`) getter
+/// shapes; the resulting text is spliced into the `Computed<T>(() ...)`
+/// closure by the emitter. `trackedReadOffsets` are intentionally ignored —
+/// SignalBuilder placement is a `build()` concern, not a `Computed` body
+/// concern.
+String _rewriteNode(
+  AstNode node,
+  Set<String> reactiveFields,
+  String source,
+) {
+  final result = collectValueEdits(node, reactiveFields, source);
+  return applyEditsToRange(
+    source.substring(node.offset, node.end),
+    result.edits,
+    node.offset,
   );
 }
 

--- a/packages/solid_generator/lib/src/getter_model.dart
+++ b/packages/solid_generator/lib/src/getter_model.dart
@@ -5,17 +5,18 @@ import 'package:solid_generator/src/transformation_error.dart';
 ///
 /// Populated by `annotation_reader.dart` from unresolved AST and consumed by
 /// the rewriters (currently `stateless_rewriter.dart`). All string members are
-/// the raw source text of the corresponding AST node — except
-/// [bodyExpressionText], which is the source-substring of the getter body
-/// expression with the SPEC §5.1 `.value` rewrites already applied so the
-/// emitter can splice it directly into a `Computed<T>(() => …)` template.
+/// the raw source text of the corresponding AST node — except [bodyText],
+/// which is the source-substring of the getter body with the SPEC §5.1
+/// `.value` rewrites already applied so the emitter can splice it directly
+/// into the `Computed<T>(...)` closure.
 @immutable
 class GetterModel {
   /// Creates a [GetterModel] describing an annotated getter.
   const GetterModel({
     required this.getterName,
     required this.typeText,
-    required this.bodyExpressionText,
+    required this.bodyText,
+    required this.isBlockBody,
     required this.annotationName,
   });
 
@@ -27,15 +28,25 @@ class GetterModel {
   /// not expected for `@SolidState` getters per SPEC §3.1.
   final String typeText;
 
-  /// Source text of the getter's expression body with the SPEC §5.1
-  /// reactive-read rewrite already applied. For an input
-  /// `int get doubleCounter => counter * 2;` where `counter` is a sibling
-  /// `@SolidState` field, this is the string `'counter.value * 2'`.
+  /// Source text of the getter's body with the SPEC §5.1 reactive-read
+  /// rewrite already applied. The shape depends on [isBlockBody]:
   ///
-  /// M2-01 only supports expression-body getters (`get x => <expr>;`). The
-  /// block-body form (SPEC §4.6) is rejected by `readSolidStateGetter` and
-  /// scheduled for M2-01b.
-  final String bodyExpressionText;
+  /// * **Expression body** (SPEC §4.5, [isBlockBody] is `false`): the
+  ///   rewritten expression text alone — for an input
+  ///   `int get doubleCounter => counter * 2;` where `counter` is a sibling
+  ///   `@SolidState` field, this is the string `'counter.value * 2'`. The
+  ///   emitter wraps it in `() => <text>`.
+  /// * **Block body** (SPEC §4.6, [isBlockBody] is `true`): the rewritten
+  ///   block including its braces — for an input
+  ///   `String get summary { final c = counter; return 'count is $c'; }`,
+  ///   this is the string `'{ final c = counter.value; return \'count is \$c\'; }'`.
+  ///   The emitter wraps it in `() <text>`.
+  final String bodyText;
+
+  /// True when the source getter has a block body (`get x { ... }`); false
+  /// for an expression body (`get x => <expr>;`). Determines how the emitter
+  /// shapes the closure passed to `Computed<T>(...)`.
+  final bool isBlockBody;
 
   /// Value of the `name:` argument on `@SolidState(name: '…')`, or `null` if
   /// the annotation had no `name:` argument (SPEC §4.4).

--- a/packages/solid_generator/lib/src/signal_emitter.dart
+++ b/packages/solid_generator/lib/src/signal_emitter.dart
@@ -34,18 +34,23 @@ String emitSignalField(FieldModel f) {
   return '  ${lateKw}final ${f.fieldName} = $ctor;';
 }
 
-/// Emits one `late final <name> = Computed<T>(() => <body>, name: '<debug>');`
-/// line per SPEC §4.5.
+/// Emits one `late final <name> = Computed<T>(<closure>, name: '<debug>');`
+/// line per SPEC §4.5 (expression body) or §4.6 (block body).
 ///
 /// The result is always `late final` because a `Computed` references other
 /// `final` instance fields whose initialization order is not guaranteed
-/// (SPEC §4.5 last bullet). The body expression text in [g] has already had
-/// the SPEC §5.1 `.value` rewrite applied by `readSolidStateGetter`, so the
-/// emitter splices it directly into the closure template.
+/// (SPEC §4.5 last bullet). The body text in [g] has already had the
+/// SPEC §5.1 `.value` rewrite applied by `readSolidStateGetter`, so the
+/// emitter splices it directly into the closure. The closure shape depends
+/// on `g.isBlockBody`:
+///
+/// * Expression body → `() => <bodyText>`.
+/// * Block body → `() <bodyText>` (where `bodyText` already includes the
+///   surrounding `{ ... }` braces, copied verbatim from the source).
 String emitComputedField(GetterModel g) {
   final debugName = g.annotationName ?? g.getterName;
-  final body = g.bodyExpressionText;
-  final ctor = "Computed<${g.typeText}>(() => $body, name: '$debugName')";
+  final closure = g.isBlockBody ? '() ${g.bodyText}' : '() => ${g.bodyText}';
+  final ctor = "Computed<${g.typeText}>($closure, name: '$debugName')";
   return '  late final ${g.getterName} = $ctor;';
 }
 

--- a/packages/solid_generator/test/golden/inputs/m2_01b_block_body_computed.dart
+++ b/packages/solid_generator/test/golden/inputs/m2_01b_block_body_computed.dart
@@ -1,0 +1,18 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+
+class Counter extends StatelessWidget {
+  Counter({super.key});
+
+  @SolidState()
+  int counter = 0;
+
+  @SolidState()
+  String get summary {
+    final c = counter;
+    return 'count is $c';
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/golden/outputs/m2_01b_block_body_computed.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m2_01b_block_body_computed.g.dart
@@ -1,0 +1,28 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class Counter extends StatefulWidget {
+  Counter({super.key});
+
+  @override
+  State<Counter> createState() => _CounterState();
+}
+
+class _CounterState extends State<Counter> {
+  final counter = Signal<int>(0, name: 'counter');
+  late final summary = Computed<String>(() {
+    final c = counter.value;
+    return 'count is $c';
+  }, name: 'summary');
+
+  @override
+  void dispose() {
+    summary.dispose();
+    counter.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -27,6 +27,7 @@ const List<String> goldenNames = <String>[
   'm1_12_passthrough_no_annotations',
   'm1_13_multiple_constructors',
   'm2_01_simple_computed_with_deps',
+  'm2_01b_block_body_computed',
 ];
 
 /// Memoized golden directory resolution. Resolved relative to the package


### PR DESCRIPTION
## Summary

- Extend `@SolidState` computed getters to support block-body syntax (`get x { ... }`) in addition to expression-body (`get x => ...`)
- Refactor `annotation_reader.dart` to handle both body shapes uniformly via a new `_rewriteNode` helper
- Update `getter_model.dart` with `isBlockBody` boolean to distinguish body shapes and guide emission
- Modify `signal_emitter.dart` to emit correct closure syntax: `() => expr` for expression bodies, `() { ... }` for block bodies
- Add golden test case with a block-body getter that reads reactive fields and applies SPEC §5.1 `.value` rewrites

## Testing

- Golden test `m2_01b_block_body_computed` validates that a block-body getter with reactive field reads generates correct `Computed` closure
- Verify `counter.value` is correctly injected in the block body's local binding
- Run `dart test` to confirm all existing golden tests still pass and new case matches expected output
- Confirm error messages for unsupported body kinds (abstract, native) remain clear