### PR TITLE
Implement M2-02: reject zero-deps @SolidState getters

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -934,7 +934,7 @@ late final summary = Computed<String>(() {
 
 **Dependencies:** M2-01.
 
-**Status:** TODO
+**Status:** DONE
 
 ---
 

--- a/packages/solid_generator/lib/src/annotation_reader.dart
+++ b/packages/solid_generator/lib/src/annotation_reader.dart
@@ -73,25 +73,36 @@ GetterModel? readSolidStateGetter(
       : source.substring(returnType.offset, returnType.end);
 
   final body = decl.body;
+  final getterName = decl.name.lexeme;
   final String bodyText;
   final bool isBlockBody;
   if (body is ExpressionFunctionBody) {
-    bodyText = _rewriteNode(body.expression, reactiveFields, source);
+    bodyText = _rewriteGetterBody(
+      body.expression,
+      reactiveFields,
+      source,
+      getterName,
+    );
     isBlockBody = false;
   } else if (body is BlockFunctionBody) {
-    bodyText = _rewriteNode(body.block, reactiveFields, source);
+    bodyText = _rewriteGetterBody(
+      body.block,
+      reactiveFields,
+      source,
+      getterName,
+    );
     isBlockBody = true;
   } else {
     throw CodeGenerationError(
       '@SolidState getter must have an expression body (=> ...) or a '
       'block body ({ ... }); abstract and native bodies are not supported',
       null,
-      decl.name.lexeme,
+      getterName,
     );
   }
 
   return GetterModel(
-    getterName: decl.name.lexeme,
+    getterName: getterName,
     typeText: typeText,
     bodyText: bodyText,
     isBlockBody: isBlockBody,
@@ -106,12 +117,25 @@ GetterModel? readSolidStateGetter(
 /// closure by the emitter. `trackedReadOffsets` are intentionally ignored —
 /// SignalBuilder placement is a `build()` concern, not a `Computed` body
 /// concern.
-String _rewriteNode(
+///
+/// Throws [CodeGenerationError] for SPEC §4.5: a `Computed` with zero
+/// reactive dependencies would never invalidate, so an empty edit set is
+/// surfaced as a build error instead of a useless `Computed`.
+String _rewriteGetterBody(
   AstNode node,
   Set<String> reactiveFields,
   String source,
+  String getterName,
 ) {
   final result = collectValueEdits(node, reactiveFields, source);
+  if (result.edits.isEmpty) {
+    throw CodeGenerationError(
+      "getter '$getterName' has no reactive dependencies; "
+      'use `final` or a plain getter instead of `@SolidState`',
+      null,
+      getterName,
+    );
+  }
   return applyEditsToRange(
     source.substring(node.offset, node.end),
     result.edits,

--- a/packages/solid_generator/test/golden/inputs/m2_02_computed_no_deps_rejected.dart
+++ b/packages/solid_generator/test/golden/inputs/m2_02_computed_no_deps_rejected.dart
@@ -1,0 +1,6 @@
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Foo {
+  @SolidState()
+  int get constantFive => 5;
+}

--- a/packages/solid_generator/test/rejections/m2_02_zero_deps_computed_test.dart
+++ b/packages/solid_generator/test/rejections/m2_02_zero_deps_computed_test.dart
@@ -1,0 +1,16 @@
+// Rejection suite for M2-02: zero-deps Computed (SPEC §4.5).
+// A `@SolidState` getter whose body references no reactive declaration
+// must be rejected at build time with the SPEC §4.5 error message.
+
+import '../integration/golden_helpers.dart';
+
+const List<({String name, String errorContains})> _cases = [
+  (
+    name: 'm2_02_computed_no_deps_rejected',
+    errorContains: "getter 'constantFive' has no reactive dependencies",
+  ),
+];
+
+void main() {
+  runRejectionCases('m2_02 zero-deps Computed rejection', _cases);
+}


### PR DESCRIPTION
## Summary

- Implement SPEC §4.5 validation: reject `@SolidState` getters with no reactive dependencies at build time
- Refactor `_rewriteNode()` to `_rewriteGetterBody()` and add dependency validation
- Throw `CodeGenerationError` when a getter has zero reactive dependencies, with actionable error message
- Mark M2-02 task as DONE in TODOS.md

## Testing

- New rejection test: `m2_02_zero_deps_computed_test.dart` validates error detection
- Test input: `m2_02_computed_no_deps_rejected.dart` with constant getter (`=> 5`) triggers validation
- Verify error message: "getter 'constantFive' has no reactive dependencies; use `final` or a plain getter instead of `@SolidState`"
- Existing tests continue to pass with refactored `_rewriteGetterBody()` method