### PR TITLE
Implement M2-03: Computed read inside build() golden

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -956,7 +956,7 @@ late final summary = Computed<String>(() {
 
 **Dependencies:** M2-01, M1-05.
 
-**Status:** TODO
+**Status:** DONE
 
 ---
 

--- a/packages/solid_generator/test/golden/inputs/m2_03_computed_read_in_build.dart
+++ b/packages/solid_generator/test/golden/inputs/m2_03_computed_read_in_build.dart
@@ -1,0 +1,17 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+
+class Counter extends StatelessWidget {
+  Counter({super.key});
+
+  @SolidState()
+  int counter = 0;
+
+  @SolidState()
+  int get doubleCounter => counter * 2;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(child: Text('$doubleCounter'));
+  }
+}

--- a/packages/solid_generator/test/golden/outputs/m2_03_computed_read_in_build.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m2_03_computed_read_in_build.g.dart
@@ -1,0 +1,36 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class Counter extends StatefulWidget {
+  Counter({super.key});
+
+  @override
+  State<Counter> createState() => _CounterState();
+}
+
+class _CounterState extends State<Counter> {
+  final counter = Signal<int>(0, name: 'counter');
+  late final doubleCounter = Computed<int>(
+    () => counter.value * 2,
+    name: 'doubleCounter',
+  );
+
+  @override
+  void dispose() {
+    doubleCounter.dispose();
+    counter.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: SignalBuilder(
+        builder: (context, child) {
+          return Text('${doubleCounter.value}');
+        },
+      ),
+    );
+  }
+}

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -28,6 +28,7 @@ const List<String> goldenNames = <String>[
   'm1_13_multiple_constructors',
   'm2_01_simple_computed_with_deps',
   'm2_01b_block_body_computed',
+  'm2_03_computed_read_in_build',
 ];
 
 /// Memoized golden directory resolution. Resolved relative to the package


### PR DESCRIPTION
## Summary

- Adds paired golden fixture (`inputs/m2_03_computed_read_in_build.dart` + `outputs/m2_03_computed_read_in_build.g.dart`) asserting a bare `@SolidState` getter read inside `build()` is rewritten to `<name>.value` and the smallest enclosing widget is wrapped in `SignalBuilder`.
- Verifies SPEC §5.1's type-driven identifier rewrite rule applies identically to `Computed<T>` as to `Signal<T>` — **no generator code change**: `stateless_rewriter.dart` already builds `reactiveNames` as the union of Signal fields + Computed getters and feeds that single set into `rewriteBuildMethod`.
- Registers the new case in `golden_helpers.dart` and flips `TODOS.md` M2-03 to `Status: DONE`.

## Design

The input reads only `doubleCounter` (the Computed) inside `build()`, never `counter` directly — following the project's narrow-isolated-case convention so a regression breaking the Computed-read path would surface as a single-case failure. A `Center(child: Text('$doubleCounter'))` wrapper makes the smallest-subtree rule (SPEC §7.2) falsifiable: an over-wrap regression that wrapped the whole return would produce a different output than the golden. The Signal `counter` exists only to give the Computed a reactive dep (avoiding M2-02's zero-deps rejection); it is not read in `build()`.

The generated output encodes:
- `${doubleCounter.value}` interpolation (SPEC §5.1)
- `SignalBuilder` wraps `Text` only, NOT `Center` (SPEC §7.2)
- `late final doubleCounter = Computed<int>(() => counter.value * 2, name: 'doubleCounter')` (SPEC §4.5)
- Reverse-declaration dispose: `doubleCounter.dispose()` before `counter.dispose()` (SPEC §10)
- `flutter_solidart` import added (Signal, Computed, SignalBuilder all appear)

## Test plan

- [x] `dart pub get` clean
- [x] `UPDATE_GOLDENS=1 dart test --name=m2_03_computed_read_in_build` regenerates output; hand-verified against SPEC §4.5 + §5.1 + §7.2 + §10
- [x] `dart test --name=m2_03_computed_read_in_build` passes (golden equality)
- [x] `dart test --name=golden` — all 13 goldens pass (regression check confirms no-codegen-change claim)
- [x] `dart test` — full suite (38 tests: golden + rejections + idempotency) green
- [x] `dart format --set-exit-if-changed lib test` — zero diff
- [x] `dart analyze --fatal-infos lib test` — zero issues
- [x] `example/`: `dart run build_runner build --delete-conflicting-outputs` exits 0

Reviewer rubric (`plans/features/reviewer-rubric.md`): paired golden committed (#2), no regex (#3, no code edited), no `dynamic` casts (#4, no code edited), toolchain green (#5), output cited against SPEC §4.5 + §5.1 + §7.2 + §10 (#7).