### PR TITLE
Add M3-02 golden test: @SolidState field in untracked context (onPressed)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1028,7 +1028,7 @@ late final summary = Computed<String>(() {
 
 **Dependencies:** M1-05.
 
-**Status:** TODO
+**Status:** DONE
 
 ---
 

--- a/packages/solid_generator/test/golden/inputs/m3_02_onpressed_untracked.dart
+++ b/packages/solid_generator/test/golden/inputs/m3_02_onpressed_untracked.dart
@@ -1,0 +1,17 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/material.dart';
+
+class CounterButton extends StatelessWidget {
+  CounterButton({super.key});
+
+  @SolidState()
+  int counter = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return FloatingActionButton(
+      onPressed: () => counter++,
+      child: const Icon(Icons.add),
+    );
+  }
+}

--- a/packages/solid_generator/test/golden/outputs/m3_02_onpressed_untracked.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m3_02_onpressed_untracked.g.dart
@@ -1,0 +1,28 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class CounterButton extends StatefulWidget {
+  CounterButton({super.key});
+
+  @override
+  State<CounterButton> createState() => _CounterButtonState();
+}
+
+class _CounterButtonState extends State<CounterButton> {
+  final counter = Signal<int>(0, name: 'counter');
+
+  @override
+  void dispose() {
+    counter.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FloatingActionButton(
+      onPressed: () => counter.value++,
+      child: const Icon(Icons.add),
+    );
+  }
+}

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -31,6 +31,7 @@ const List<String> goldenNames = <String>[
   'm2_03_computed_read_in_build',
   'm2_04_dispose_order',
   'm3_01_text_arg_gets_value',
+  'm3_02_onpressed_untracked',
 ];
 
 /// Memoized golden directory resolution. Resolved relative to the package


### PR DESCRIPTION
## Summary

- Add golden test for M3-02 verifying code generation of `@SolidState` fields used in untracked contexts (e.g., event callbacks)
- Test case: `CounterButton` with a `counter` field incremented in `onPressed` callback
- Validates that generator converts the field to a `Signal`, converts component to `StatefulWidget`, and adds proper disposal
- Mark M3-02 as DONE in TODOS.md

## Testing

- Golden test comparison: input matches expected generated output
- Test runs as part of `golden_helpers.dart` integration test suite