### PR TITLE
Drop SPEC 6.3: ValueKey reads now tracked by default

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -385,29 +385,6 @@ FloatingActionButton(
 // NOT wrapped in SignalBuilder
 ```
 
-### 6.3 Reads inside Key constructor arguments
-
-A read is untracked when the identifier appears inside an `InstanceCreationExpression` whose constructor is `ValueKey`, `Key`, `ObjectKey`, `UniqueKey`, `GlobalKey`, `GlobalObjectKey`, or `PageStorageKey`, and that expression is passed to the `key:` parameter of a widget.
-
-Source:
-
-```dart
-Container(
-  key: ValueKey(counter),
-  child: const Text('hi'),
-)
-```
-
-Output:
-
-```dart
-Container(
-  key: ValueKey(counter.value),
-  child: const Text('hi'),
-)
-// NOT wrapped in SignalBuilder
-```
-
 ### 6.4 Explicit opt-out via `untracked`
 
 `flutter_solidart` exports a top-level function `untracked<T>(T Function() fn)` that reads signals without creating a subscription. Solid exposes this function as-is and recognizes it during transformation: reads inside an `untracked(() => ...)` callback are untracked.
@@ -429,7 +406,7 @@ The generator recognizes `untracked` by resolved identifier (the top-level funct
 
 ### 6.5 Everything else is tracked
 
-If a read is not in one of the contexts defined in Sections 6.2, 6.3, or 6.4, it is tracked. The containing widget subtree must be wrapped in `SignalBuilder` (Section 7).
+If a read is not in one of the contexts defined in Sections 6.2 or 6.4, it is tracked. The containing widget subtree must be wrapped in `SignalBuilder` (Section 7).
 
 ### 6.6 Nested cases
 
@@ -712,7 +689,7 @@ Any change that alters user-observable behavior must be covered by a golden test
 This SPEC addresses the following real user-reported issues from the v1 repo:
 
 - **#3** — `@SolidEnvironment` inside an existing `State<X>` was not transformed; the class-kind handling in Section 8.2 makes this impossible to regress.
-- **#4** — untracked reads (`ValueKey`, `onPressed`) were wrapped in `SignalBuilder`, breaking compilation; Section 6 defines the untracked-context rules.
+- **#4** — untracked reads (`onPressed`) were wrapped in `SignalBuilder`, breaking compilation; Section 6 defines the untracked-context rules.
 - **#6** — `Text(text)` did not receive `.value` because the rewriter missed bare identifier reads; Section 5.1 defines the rewrite rule exhaustively.
 - **#8** — generated `main.dart` used `SolidartConfig` without importing `flutter_solidart`; Section 9 defines the import-addition rule.
 - **#9** — hot reload required a double-save; Section 12 defines the two supported workflows: manual `r` after build_runner emits, or `dashmon` to bridge filesystem changes to Flutter's stdin automatically.

--- a/TODOS.md
+++ b/TODOS.md
@@ -1032,21 +1032,24 @@ late final summary = Computed<String>(() {
 
 ---
 
-### TODO M3-03 — Golden: ValueKey(counter) is untracked
+### TODO M3-03 — Golden: ValueKey(counter) is tracked
 
-**Goal:** A read inside `ValueKey(counter)` gets `.value` but does NOT wrap the enclosing widget in `SignalBuilder`.
+**Goal:** A read inside `ValueKey(counter)` gets `.value` AND wraps the enclosing widget in `SignalBuilder` — the new default after dropping the v1-era SPEC 6.3 auto-untracking enumeration. Users opt out per-read via the `.untracked` extension once M3-12 lands.
 
-**SPEC references:** Section 6.3.
+**SPEC references:** Section 6.5 (everything else is tracked).
 
 **Files to create:**
 
-- `packages/solid_generator/test/golden/inputs/m3_03_value_key_untracked.dart`
-- `packages/solid_generator/test/golden/outputs/m3_03_value_key_untracked.g.dart`
-- entry in `golden_test.dart`
+- `packages/solid_generator/test/golden/inputs/m3_03_value_key_tracked.dart`
+- `packages/solid_generator/test/golden/outputs/m3_03_value_key_tracked.g.dart`
+- entry in `golden_helpers.dart` `goldenNames`
 
-**Expected implementation change:** The untracked-context detector adds Key constructor names (Section 6.3) to its enumerated list. Reads inside these `InstanceCreationExpression`s get `.value` but do not trigger wrapping.
+**Expected implementation change:** Two deletions and one placement fix.
 
-**Acceptance:** `dart test --name=m3_03` passes; output `Container(key: ValueKey(counter.value), child: ...)` is NOT wrapped.
+1. Remove SPEC Section 6.3 entirely; strip `_keyConstructors`, `_isKeyUntracked`, and the `visitInstanceCreationExpression` hook from `value_rewriter.dart`.
+2. Patch `placement_visitor.dart` `_WidgetCollector` to skip constructor expressions used as the value of a `key:` named argument — Keys are not Widgets and cannot host a `SignalBuilder` wrapper. (SPEC 6.3 had been hiding this latent placement bug by untracking the read entirely. The KISS pivot makes the bug visible, so it ships its fix here.)
+
+**Acceptance:** `dart test --name=m3_03` passes; output `SignalBuilder` wraps the enclosing `Container`, with `ValueKey(counter.value)` inside as the Key.
 
 **Dependencies:** M1-05.
 
@@ -1122,23 +1125,13 @@ late final summary = Computed<String>(() {
 
 ### TODO M3-07 — Golden: explicit `untracked(() => ...)` opt-out
 
-**Goal:** `Text('snapshot: ${untracked(() => counter)}')` keeps `.value` on `counter` (per Section 5.1) but does NOT wrap the enclosing `Text` in `SignalBuilder`.
+**Superseded by M3-12** (`.untracked` extension replaces the function-call form). Keep this entry as a roadmap stub so cross-references resolve; do not ship.
 
-**SPEC references:** Section 6.4.
+**Goal (historical):** `Text('snapshot: ${untracked(() => counter)}')` keeps `.value` on `counter` (per Section 5.1) but does NOT wrap the enclosing `Text` in `SignalBuilder`.
 
-**Files to create:**
+**SPEC references:** Section 6.4 (subject to rewrite under M3-12).
 
-- `packages/solid_generator/test/golden/inputs/m3_07_untracked_opt_out.dart`
-- `packages/solid_generator/test/golden/outputs/m3_07_untracked_opt_out.g.dart`
-- entry in `golden_test.dart`
-
-**Expected implementation change:** The untracked-context detector recognizes calls to the top-level `untracked` function from `package:flutter_solidart/flutter_solidart.dart` by resolved identifier (not name alone). Reads inside the closure passed to `untracked` are untracked.
-
-**Acceptance:** `dart test --name=m3_07` passes; the golden output does NOT wrap the enclosing `Text` in `SignalBuilder`.
-
-**Dependencies:** M1-05.
-
-**Status:** TODO
+**Status:** OBSOLETE — see M3-12.
 
 ---
 
@@ -1249,5 +1242,35 @@ Widget build(BuildContext context) {
 **Acceptance:** `dart test --name=m3_11` passes; the golden has zero `SignalBuilder` wrappers around the outer Column.
 
 **Dependencies:** M1-05.
+
+**Status:** TODO
+
+---
+
+### TODO M3-12 — `.untracked` extension replaces `untracked()` opt-out
+
+**Goal:** Replace `untracked(() => counter)` with `counter.untracked` as the single, canonical opt-out marker for read tracking. Supersedes M3-07.
+
+**Why:** KISS — one mechanism, no closure boilerplate, reads naturally at the call site. `Container(key: ValueKey(counter.untracked))` is the migration story for users who actually want the v1-era SPEC 6.3 auto-untracking behavior that M3-03 dropped.
+
+**SPEC references:** Section 6.4 (full rewrite).
+
+**Files to modify / create:**
+
+- `packages/solid_annotations/lib/solid_annotations.dart` — add `extension Untracked<T> on T { T get untracked => this; }` (or scoped equivalent — design to be finalized in this TODO).
+- `packages/solid_generator/lib/src/value_rewriter.dart` — detect `.untracked` `PropertyAccess` on a reactive field; emit the untracked-read primitive (e.g., `Signal.peek()`) and exclude the offset from `trackedReadOffsets`. Remove the existing `untracked()` function-call special-case in `visitMethodInvocation`.
+- `SPEC.md` Section 6.4 — rewrite around the extension form.
+- New goldens: `m3_12_untracked_extension` input/output pair.
+
+**Open questions to resolve in this TODO:**
+
+- Exact untracked-read primitive name on `flutter_solidart`'s Signal API (`peek()`, `untracked` getter, etc.) — verify against the package source.
+- Extension scope: on `T`, on a marker mixin, or on a sentinel? Tradeoff is API-surface pollution vs source-typecheck friction.
+- Migration policy for users on `untracked(() => ...)` — silent drop of generator special-casing, or a generator warning?
+
+**Acceptance:** `dart test --name=m3_12` passes; `Text('${counter.untracked}')` produces an untracked-read output (no `SignalBuilder` wrap).
+
+**Dependencies:** M1-05.
+**Supersedes:** M3-07.
 
 **Status:** TODO

--- a/packages/solid_generator/lib/src/build_rewriter.dart
+++ b/packages/solid_generator/lib/src/build_rewriter.dart
@@ -36,7 +36,7 @@ class SourceEdit {
 ///      receive `.value` (single textual occurrence per SPEC rule).
 ///   4. SPEC Section 7.2 — tracked reads cause their smallest enclosing
 ///      widget expression to be wrapped in `SignalBuilder`. Untracked-
-///      context rules from Section 6.2 / 6.3 / 6.4 suppress tracking.
+///      context rules from Section 6.2 / 6.4 suppress tracking.
 ///
 /// [reactiveFields] is the set of field names declared `@SolidState` on the
 /// enclosing class. The match is name-based; SPEC 5.4's type-driven rule

--- a/packages/solid_generator/lib/src/placement_visitor.dart
+++ b/packages/solid_generator/lib/src/placement_visitor.dart
@@ -13,7 +13,9 @@ import 'package:analyzer/dart/ast/visitor.dart';
 ///    an UpperCamelCase identifier (the `Text(...)` style used without
 ///    `const` or `new`; the analyzer only upgrades these to
 ///    `InstanceCreationExpression` during resolution, which we defer to
-///    M3-05 per SPEC 5.4).
+///    M3-05 per SPEC 5.4). Constructor expressions used as the value of a
+///    `key:` named argument are filtered out — Keys are not Widgets and
+///    cannot host a `SignalBuilder` wrapper (see `_isAtKeyPosition`).
 /// 2. For each tracked-read offset T (from `value_rewriter`), pick the
 ///    smallest (deepest) widget expression whose source range contains T —
 ///    SPEC Section 7.2's minimum-subtree rule.
@@ -101,13 +103,15 @@ class _WidgetCollector extends RecursiveAstVisitor<void> {
   void visitInstanceCreationExpression(InstanceCreationExpression node) {
     // Post-order: descend first so deeper widgets are appended first.
     super.visitInstanceCreationExpression(node);
+    if (_isAtKeyPosition(node)) return;
     widgets.add(node);
   }
 
   @override
   void visitMethodInvocation(MethodInvocation node) {
     super.visitMethodInvocation(node);
-    if (_looksLikeWidgetCtor(node)) widgets.add(node);
+    if (!_looksLikeWidgetCtor(node) || _isAtKeyPosition(node)) return;
+    widgets.add(node);
   }
 }
 
@@ -121,4 +125,13 @@ bool _looksLikeWidgetCtor(MethodInvocation node) {
   if (name.isEmpty) return false;
   final first = name.codeUnitAt(0);
   return first >= 0x41 && first <= 0x5A; // 'A'..'Z'
+}
+
+/// Syntactic stand-in for "this expression's static type is `Widget`": skips
+/// constructor calls that sit at `key:` argument position, since `Key` is not
+/// a `Widget` and cannot host a `SignalBuilder` wrap. The general non-Widget-
+/// argument case (e.g. `EdgeInsets`) waits for the type-driven pivot in M3-05.
+bool _isAtKeyPosition(Expression expr) {
+  final parent = expr.parent;
+  return parent is NamedExpression && parent.name.label.name == 'key';
 }

--- a/packages/solid_generator/lib/src/value_rewriter.dart
+++ b/packages/solid_generator/lib/src/value_rewriter.dart
@@ -24,8 +24,8 @@ class ValueEdit {
 ///
 /// A tracked read is one that must cause its enclosing widget subtree to
 /// subscribe (Section 6.5). Writes (Section 6.0) never appear here; reads
-/// inside user-interaction callbacks, `Key`-family constructors, or
-/// `untracked(...)` calls (Section 6.2 / 6.3 / 6.4) are excluded.
+/// inside user-interaction callbacks or `untracked(...)` calls
+/// (Section 6.2 / 6.4) are excluded.
 class ValueRewriteResult {
   /// Creates a result holding [edits] and their [trackedReadOffsets].
   const ValueRewriteResult(this.edits, this.trackedReadOffsets);
@@ -53,19 +53,6 @@ bool _isOnPrefixedCallbackName(String name) {
   final third = name.codeUnitAt(2);
   return third >= 0x41 && third <= 0x5A; // 'A'..'Z'
 }
-
-/// Names of `Key`-family constructors enumerated by SPEC Section 6.3. A
-/// read inside an `InstanceCreationExpression` of one of these classes
-/// (passed as the `key:` argument to a widget) is untracked.
-const Set<String> _keyConstructors = {
-  'Key',
-  'ValueKey',
-  'ObjectKey',
-  'UniqueKey',
-  'GlobalKey',
-  'GlobalObjectKey',
-  'PageStorageKey',
-};
 
 /// Walks [node] and returns every offset-based value edit plus the
 /// tracked-read offsets that downstream placement needs.
@@ -155,14 +142,6 @@ class _ValueRewriteVisitor extends RecursiveAstVisitor<void> {
   void visitVariableDeclaration(VariableDeclaration node) {
     _scopeStack.last.add(node.name.lexeme);
     super.visitVariableDeclaration(node);
-  }
-
-  @override
-  void visitInstanceCreationExpression(InstanceCreationExpression node) {
-    final untracked = _isKeyUntracked(node);
-    if (untracked) _untrackedDepth++;
-    super.visitInstanceCreationExpression(node);
-    if (untracked) _untrackedDepth--;
   }
 
   @override
@@ -268,20 +247,4 @@ class _ValueRewriteVisitor extends RecursiveAstVisitor<void> {
     if (parent is! NamedExpression) return false;
     return _isOnPrefixedCallbackName(parent.name.label.name);
   }
-
-  /// True if [node] is a `Key`-family constructor passed as the `key:`
-  /// argument of a widget (SPEC 6.3).
-  bool _isKeyUntracked(InstanceCreationExpression node) {
-    final ctorName = node.constructorName.type.qualifiedName;
-    if (!_keyConstructors.contains(ctorName)) return false;
-    final parent = node.parent;
-    if (parent is! NamedExpression) return false;
-    return parent.name.label.name == 'key';
-  }
-}
-
-extension on NamedType {
-  /// The bare class name of a type annotation, ignoring any import prefix
-  /// (e.g. `foo.ValueKey` → `ValueKey`).
-  String get qualifiedName => name.lexeme;
 }

--- a/packages/solid_generator/test/golden/inputs/m3_03_value_key_tracked.dart
+++ b/packages/solid_generator/test/golden/inputs/m3_03_value_key_tracked.dart
@@ -1,0 +1,17 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/material.dart';
+
+class KeyedContainer extends StatelessWidget {
+  KeyedContainer({super.key});
+
+  @SolidState()
+  int counter = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      key: ValueKey(counter),
+      child: const Text('hi'),
+    );
+  }
+}

--- a/packages/solid_generator/test/golden/outputs/m3_03_value_key_tracked.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m3_03_value_key_tracked.g.dart
@@ -1,0 +1,29 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class KeyedContainer extends StatefulWidget {
+  KeyedContainer({super.key});
+
+  @override
+  State<KeyedContainer> createState() => _KeyedContainerState();
+}
+
+class _KeyedContainerState extends State<KeyedContainer> {
+  final counter = Signal<int>(0, name: 'counter');
+
+  @override
+  void dispose() {
+    counter.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SignalBuilder(
+      builder: (context, child) {
+        return Container(key: ValueKey(counter.value), child: const Text('hi'));
+      },
+    );
+  }
+}

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -32,6 +32,7 @@ const List<String> goldenNames = <String>[
   'm2_04_dispose_order',
   'm3_01_text_arg_gets_value',
   'm3_02_onpressed_untracked',
+  'm3_03_value_key_tracked',
 ];
 
 /// Memoized golden directory resolution. Resolved relative to the package

--- a/plans/features/m3-untracked-and-granularity.md
+++ b/plans/features/m3-untracked-and-granularity.md
@@ -1,7 +1,7 @@
 # M3 — Untracked reads + fine-grained `SignalBuilder` placement
 
-**TODOS.md items:** M3-01 → M3-11
-**SPEC sections:** 5.1, 5.2, 5.4, 5.5, 6.0, 6.2, 6.3, 6.4, 6.5, 6.6, 7.1–7.5, 16 (#4, #6)
+**TODOS.md items:** M3-01 → M3-12 (M3-07 superseded by M3-12)
+**SPEC sections:** 5.1, 5.2, 5.4, 5.5, 6.0, 6.2, 6.4, 6.5, 6.6, 7.1–7.5, 16 (#4, #6)
 **Reviewer rubric:** `plans/features/reviewer-rubric.md`
 
 ## Purpose
@@ -11,7 +11,7 @@ M3 hardens the rewriter against the v1 bugs that SPEC Section 16 enumerates: unt
 A developer after M3 can trust the generator in these scenarios:
 
 - `Text(counter)` rebuilds only `Text`.
-- `ValueKey(counter)` doesn't wrap the enclosing widget.
+- `ValueKey(counter)` wraps the enclosing widget like any other tracked read; users opt out per-read via the `.untracked` extension (M3-12).
 - `onPressed: () => counter++` never subscribes.
 - `controller.value` (a `TextEditingController`) is left alone.
 - `'$counter'` becomes `'${counter.value}'`.
@@ -24,23 +24,23 @@ A developer after M3 can trust the generator in these scenarios:
 
 - **M3-01** — `Text(counter)` inside `build` (fix for issue #6). Regression fence; core logic is in M1-05.
 - **M3-02** — `onPressed: () => counter++` (fix for issue #4). Regression fence; core logic is in M1-05.
-- **M3-03** — `ValueKey(counter)` untracked. Adds Section 6.3 Key-constructor list.
+- **M3-03** — `ValueKey(counter)` is tracked by default (drops the SPEC 6.3 auto-untracking enumeration that v1 carried). The opt-out story is M3-12's `.untracked` extension.
 - **M3-05** — type-aware no-double-append. Validates Section 5.4. Includes a `TextEditingController.value` case.
 - **M3-06** — string interpolation regression fence.
-- **M3-07** — explicit `untracked(() => ...)` opt-out (Section 6.4). Recognition by resolved identifier, not by name alone.
+- **M3-07** — explicit `untracked(() => ...)` opt-out (Section 6.4). **Superseded by M3-12** (extension form replaces the function form).
 - **M3-08** — Builder-style closures stay tracked (Section 6.6).
 - **M3-09** — shadowing (Section 5.5). Depends on M3-05 + M3-08 because it exercises both rules simultaneously.
 - **M3-10** — already-inside-SignalBuilder (Section 7.3). Hand-written `SignalBuilder` in source must not be double-wrapped.
 - **M3-11** — nested tracked reads (Section 7.5). Outer + inner both tracked; only inner wraps.
+- **M3-12** — `.untracked` extension replaces the `untracked()` function-call form (Section 6.4 rewrite). Single canonical opt-out marker for read tracking.
 - **M3-04** — sibling isolation widget test (Section 7.4). Ships last because it validates the whole M3 pipeline against a real widget tree.
 
 ## Cross-cutting concerns
 
-- **Untracked-context detector.** One AST visitor recognizes four contexts:
+- **Untracked-context detector.** One AST visitor recognizes three contexts:
   1. user-interaction callbacks (Section 6.2 — enumerated parameter-name list).
-  2. Key constructors (Section 6.3 — `ValueKey`, `Key`, `ObjectKey`, `UniqueKey`, `GlobalKey`, `GlobalObjectKey`, `PageStorageKey`).
-  3. closures passed to the top-level `untracked<T>` function from `flutter_solidart` (Section 6.4).
-  4. writes (Section 6.0 — the assignment's LHS is always untracked; the RHS is a normal read per Section 5.3).
+  2. closures passed to the top-level `untracked<T>` function from `flutter_solidart` (Section 6.4). Slated for replacement by the `.untracked` extension in M3-12.
+  3. writes (Section 6.0 — the assignment's LHS is always untracked; the RHS is a normal read per Section 5.3).
 - **Builder closure non-rule.** SPEC Section 6.6 is the explicit non-rule: `builder:`, `itemBuilder:`, etc. are NOT in the Section 6.2 list. The visitor must NOT treat them as untracked. M3-08 is the regression test.
 - **Sibling isolation.** M3-04 is a widget test, not a golden. Introduces a second `BuildTracker`-instrumented widget in the counter example; asserts both Text widgets each rebuild only when their respective signal changes.
 - **Type-driven rule is the single source of truth for `.value`.** The cases in M3-05, M3-06, M3-09 all reduce to SPEC Section 5.1 — if the identifier's resolved static type is `SignalBase<T>` or subtype, rewrite; otherwise leave alone. No special-case code per scenario; the test matrix validates generality.


### PR DESCRIPTION
## Summary

- Removes SPEC Section 6.3 which auto-untracked reads inside Key constructors (`ValueKey`, `GlobalKey`, etc.)
- ValueKey reads now get `.value` and trigger `SignalBuilder` wrapping like any tracked read
- Simplifies untracked-context detection: only user-interaction callbacks and `untracked()` calls remain untracked
- Fixes latent placement bug: skips wrapping constructor expressions used at `key:` positions (Keys are not Widgets)
- User opt-out via `.untracked` extension lands in M3-12; migration path documented
- Adds golden test `m3_03_value_key_tracked` verifying the new behavior

## Testing

- Golden test `m3_03_value_key_tracked` passes: `Container(key: ValueKey(counter))` → wrapped in `SignalBuilder` with `counter.value` in the key
- Existing golden tests (m3_01, m3_02) still pass
- `dart test` suite passes with no regressions
- SPEC updated to remove Section 6.3 references; Section 6.5 now sole rule for tracked reads