### PR TITLE
Add M3-06 golden test: bare-identifier string interpolation

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1101,7 +1101,7 @@ late final summary = Computed<String>(() {
 
 ---
 
-### TODO M3-06 — Golden: string interpolation
+### DONE M3-06 — Golden: string interpolation
 
 **Goal:** `'$counter'` becomes `'${counter.value}'`.
 
@@ -1119,7 +1119,7 @@ late final summary = Computed<String>(() {
 
 **Dependencies:** M1-05.
 
-**Status:** TODO
+**Status:** DONE
 
 ---
 

--- a/packages/solid_generator/test/golden/inputs/m3_06_string_interpolation_bare.dart
+++ b/packages/solid_generator/test/golden/inputs/m3_06_string_interpolation_bare.dart
@@ -1,0 +1,14 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+
+class Greeting extends StatelessWidget {
+  Greeting({super.key});
+
+  @SolidState()
+  int counter = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text('counter is $counter');
+  }
+}

--- a/packages/solid_generator/test/golden/outputs/m3_06_string_interpolation_bare.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m3_06_string_interpolation_bare.g.dart
@@ -1,0 +1,29 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class Greeting extends StatefulWidget {
+  Greeting({super.key});
+
+  @override
+  State<Greeting> createState() => _GreetingState();
+}
+
+class _GreetingState extends State<Greeting> {
+  final counter = Signal<int>(0, name: 'counter');
+
+  @override
+  void dispose() {
+    counter.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SignalBuilder(
+      builder: (context, child) {
+        return Text('counter is ${counter.value}');
+      },
+    );
+  }
+}

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -34,6 +34,7 @@ const List<String> goldenNames = <String>[
   'm3_02_onpressed_untracked',
   'm3_03_value_key_tracked',
   'm3_05_type_aware_no_double_append',
+  'm3_06_string_interpolation_bare',
 ];
 
 /// Memoized golden directory resolution. Resolved relative to the package


### PR DESCRIPTION
## Summary
- Adds an isolated regression golden for SPEC §5.2: bare-identifier short-form interpolation (`'$counter'` → `'${counter.value}'`).
- M1-05 already exercises this rule at integration scale; this case narrows the input to a single `Text('counter is $counter')` so a regression shows up as a single-case failure instead of a noisy multi-line diff inside m1_05.
- Pure test addition — no generator changes. The existing `visitInterpolationExpression` in `value_rewriter.dart` already produces the expected bytes verbatim (verified via `UPDATE_GOLDENS=1`, diff was empty).
- M1-09's idempotency suite picks up the new slug automatically and confirms two-pass byte-identity, covering the no-double-append assertion called out in the TODO.

## Test plan
- [x] `UPDATE_GOLDENS=1 dart test packages/solid_generator/test/integration/golden_test.dart -N m3_06_string_interpolation_bare` — generator's actual output matches hand-written expected (empty `git diff`).
- [x] `dart test packages/solid_generator` — full suite (50 tests) passes, including `golden m3_06_string_interpolation_bare` and `idempotency m3_06_string_interpolation_bare produces byte-identical output across two runs`.
- [x] `dart analyze packages/solid_generator` — no issues found.