### PR TITLE
Add M3-08 golden test: Builder-style closures stay tracked

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1153,7 +1153,7 @@ late final summary = Computed<String>(() {
 
 **Dependencies:** M1-05.
 
-**Status:** TODO
+**Status:** DONE
 
 ---
 

--- a/packages/solid_generator/test/golden/inputs/m3_08_builder_closure_tracked.dart
+++ b/packages/solid_generator/test/golden/inputs/m3_08_builder_closure_tracked.dart
@@ -1,0 +1,14 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+
+class BuilderProbe extends StatelessWidget {
+  BuilderProbe({super.key});
+
+  @SolidState()
+  String label = '';
+
+  @override
+  Widget build(BuildContext context) {
+    return Builder(builder: (context) => Text(label));
+  }
+}

--- a/packages/solid_generator/test/golden/inputs/m3_08b_block_body_builder_closure_tracked.dart
+++ b/packages/solid_generator/test/golden/inputs/m3_08b_block_body_builder_closure_tracked.dart
@@ -1,0 +1,18 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+
+class BuilderProbe extends StatelessWidget {
+  BuilderProbe({super.key});
+
+  @SolidState()
+  String label = '';
+
+  @override
+  Widget build(BuildContext context) {
+    return Builder(
+      builder: (context) {
+        return Text(label);
+      },
+    );
+  }
+}

--- a/packages/solid_generator/test/golden/outputs/m3_08_builder_closure_tracked.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m3_08_builder_closure_tracked.g.dart
@@ -1,0 +1,31 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class BuilderProbe extends StatefulWidget {
+  BuilderProbe({super.key});
+
+  @override
+  State<BuilderProbe> createState() => _BuilderProbeState();
+}
+
+class _BuilderProbeState extends State<BuilderProbe> {
+  final label = Signal<String>('', name: 'label');
+
+  @override
+  void dispose() {
+    label.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Builder(
+      builder: (context) => SignalBuilder(
+        builder: (context, child) {
+          return Text(label.value);
+        },
+      ),
+    );
+  }
+}

--- a/packages/solid_generator/test/golden/outputs/m3_08b_block_body_builder_closure_tracked.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m3_08b_block_body_builder_closure_tracked.g.dart
@@ -1,0 +1,33 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class BuilderProbe extends StatefulWidget {
+  BuilderProbe({super.key});
+
+  @override
+  State<BuilderProbe> createState() => _BuilderProbeState();
+}
+
+class _BuilderProbeState extends State<BuilderProbe> {
+  final label = Signal<String>('', name: 'label');
+
+  @override
+  void dispose() {
+    label.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Builder(
+      builder: (context) {
+        return SignalBuilder(
+          builder: (context, child) {
+            return Text(label.value);
+          },
+        );
+      },
+    );
+  }
+}

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -36,6 +36,7 @@ const List<String> goldenNames = <String>[
   'm3_05_type_aware_no_double_append',
   'm3_06_string_interpolation_bare',
   'm3_08_builder_closure_tracked',
+  'm3_08b_block_body_builder_closure_tracked',
 ];
 
 /// Memoized golden directory resolution. Resolved relative to the package

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -35,6 +35,7 @@ const List<String> goldenNames = <String>[
   'm3_03_value_key_tracked',
   'm3_05_type_aware_no_double_append',
   'm3_06_string_interpolation_bare',
+  'm3_08_builder_closure_tracked',
 ];
 
 /// Memoized golden directory resolution. Resolved relative to the package


### PR DESCRIPTION
## Summary

Implements **TODO M3-08** (`TODOS.md` lines 1138–1156) — paired golden test that fences SPEC §6.6's *non-rule*: `Builder(builder: ...)` does NOT create an untracked context. Reads inside its closure stay tracked and trigger `SignalBuilder` wrapping per Section 7.

- New input fixture: `Builder(builder: (context) => Text(label))` over a `@SolidState() String label = ''`.
- New output fixture: the inner `Text` is wrapped in `SignalBuilder` (per the smallest-enclosing-widget rule); the outer `Builder` is preserved verbatim.
- No production code change. The existing detector at `packages/solid_generator/lib/src/value_rewriter.dart:50–55` (`_isOnPrefixedCallbackName`) already implements SPEC §6.2's `on[A-Z]\w*` regex shape, so `builder:` correctly fails the check. This PR adds the regression fence.

After M3-08, M3 status is `M3-01,02,03,04,05,06,08 DONE`. Remaining: M3-09 (shadowing — depends on M3-05 + M3-08, now unblocked), M3-10, M3-11, M3-12. M3-07 stays OBSOLETE.

## Test plan

- [x] `dart test --name=m3_08_builder_closure_tracked` — passes.
- [x] `dart test test/integration/golden_test.dart` — all 20 goldens pass (no regressions).
- [x] `dart test test/integration/idempotency_test.dart` — byte-identical across two runs for the new fixture.
- [x] `dart test test/rejections/` — all rejection suites still green.
- [x] `dart analyze test/golden/outputs/` — clean (the `outputs/**` exclude in `test/golden/analysis_options.yaml` matches the existing M3-06 pattern; per-file analyze surfaces the same two expected `dart fix --apply`-able warnings as M3-06's golden).
- [x] `dart analyze --fatal-infos packages/solid_generator` — clean.
- [x] `dart format --set-exit-if-changed` on edited files — zero diff.
- [x] `dart run build_runner build --delete-conflicting-outputs` in `example/` — exits 0.