### PR TITLE
Add M3-09 golden test: variable shadowing in closures

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1191,7 +1191,7 @@ Widget build(BuildContext context) {
 
 **Dependencies:** M3-05, M3-08.
 
-**Status:** TODO
+**Status:** DONE
 
 ---
 

--- a/packages/solid_generator/test/golden/inputs/m3_09_shadowing.dart
+++ b/packages/solid_generator/test/golden/inputs/m3_09_shadowing.dart
@@ -1,0 +1,19 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+
+class ShadowProbe extends StatelessWidget {
+  ShadowProbe({super.key});
+
+  @SolidState()
+  int counter = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Builder(
+      builder: (context) {
+        final counter = 'local';
+        return Text(counter);
+      },
+    );
+  }
+}

--- a/packages/solid_generator/test/golden/outputs/m3_09_shadowing.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m3_09_shadowing.g.dart
@@ -1,0 +1,30 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class ShadowProbe extends StatefulWidget {
+  ShadowProbe({super.key});
+
+  @override
+  State<ShadowProbe> createState() => _ShadowProbeState();
+}
+
+class _ShadowProbeState extends State<ShadowProbe> {
+  final counter = Signal<int>(0, name: 'counter');
+
+  @override
+  void dispose() {
+    counter.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Builder(
+      builder: (context) {
+        final counter = 'local';
+        return Text(counter);
+      },
+    );
+  }
+}

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -37,6 +37,7 @@ const List<String> goldenNames = <String>[
   'm3_06_string_interpolation_bare',
   'm3_08_builder_closure_tracked',
   'm3_08b_block_body_builder_closure_tracked',
+  'm3_09_shadowing',
 ];
 
 /// Memoized golden directory resolution. Resolved relative to the package


### PR DESCRIPTION
## Summary

- Adds golden test for M3-09 requirement: code generator must preserve local variable shadowing in closures
- Test case demonstrates a `Builder` closure where a local `counter` variable shadows the `@SolidState()` counter field
- Generator correctly maintains variable scope isolation—the local `counter` remains a String, state `counter` becomes a Signal
- Updates TODOS.md to mark M3-09 as DONE
- Registers new test in golden_helpers test registry

## Testing

- Run golden test suite: `dart test --tags=golden` should pass
- Verify generated output file matches expected output (shadowing preserved, no scope collision)
- Check integration test discovers and validates m3_09_shadowing golden pair