### PR TITLE
Add M3-11 golden test: nested tracked reads only inner wraps

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1243,7 +1243,7 @@ Widget build(BuildContext context) {
 
 **Dependencies:** M1-05.
 
-**Status:** TODO
+**Status:** DONE
 
 ---
 

--- a/packages/solid_generator/test/golden/inputs/m3_11_nested_tracked_reads.dart
+++ b/packages/solid_generator/test/golden/inputs/m3_11_nested_tracked_reads.dart
@@ -1,0 +1,22 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+
+class NestedCounter extends StatelessWidget {
+  NestedCounter({super.key});
+
+  @SolidState()
+  int counter = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Text('top: $counter'),
+        Padding(
+          padding: const EdgeInsets.all(8),
+          child: Text('nested: $counter'),
+        ),
+      ],
+    );
+  }
+}

--- a/packages/solid_generator/test/golden/outputs/m3_11_nested_tracked_reads.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m3_11_nested_tracked_reads.g.dart
@@ -1,0 +1,41 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class NestedCounter extends StatefulWidget {
+  NestedCounter({super.key});
+
+  @override
+  State<NestedCounter> createState() => _NestedCounterState();
+}
+
+class _NestedCounterState extends State<NestedCounter> {
+  final counter = Signal<int>(0, name: 'counter');
+
+  @override
+  void dispose() {
+    counter.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        SignalBuilder(
+          builder: (context, child) {
+            return Text('top: ${counter.value}');
+          },
+        ),
+        Padding(
+          padding: const EdgeInsets.all(8),
+          child: SignalBuilder(
+            builder: (context, child) {
+              return Text('nested: ${counter.value}');
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -39,6 +39,7 @@ const List<String> goldenNames = <String>[
   'm3_08b_block_body_builder_closure_tracked',
   'm3_09_shadowing',
   'm3_10_existing_signalbuilder',
+  'm3_11_nested_tracked_reads',
 ];
 
 /// Memoized golden directory resolution. Resolved relative to the package


### PR DESCRIPTION
## Summary

- New golden pair `m3_11_nested_tracked_reads` locks in the placement-visitor smallest-subtree + ancestor-pruning behavior (SPEC 7.2 + 7.5).
- Input: a `StatelessWidget` whose `build` returns a `Column` with a top-level `Text('top: $counter')` and a `Padding`-wrapped `Text('nested: $counter')`. Both reads target the same `@SolidState` field.
- Output: each leaf `Text` is wrapped in its own `SignalBuilder`; `Column` and `Padding` stay unwrapped. Both `$counter` interpolations are rewritten to `${counter.value}`.
- Pure-fixture PR; no implementation change. `computeWrapSet` in `placement_visitor.dart` already handles this correctly — the golden is a regression fence.

## Test plan

- [x] `dart test packages/solid_generator/` — all 60 tests pass (golden + idempotency).
- [x] `dart analyze packages/solid_generator/test/golden/outputs/` — zero issues.
- [x] `dart format --set-exit-if-changed .` — zero diff.
- [x] Visual: exactly 2 `SignalBuilder(` in the generated output, zero around `Column(` or `Padding(`.
- [x] Generated via `UPDATE_GOLDENS=1` rather than hand-written.
- [x] `TODOS.md` M3-11 status flipped TODO → DONE.