### PR TITLE
Implement M3-12: .untracked extension getter

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -385,24 +385,32 @@ FloatingActionButton(
 // NOT wrapped in SignalBuilder
 ```
 
-### 6.4 Explicit opt-out via `untracked`
+### 6.4 Explicit opt-out via the `.untracked` extension getter
 
-`flutter_solidart` exports a top-level function `untracked<T>(T Function() fn)` that reads signals without creating a subscription. Solid exposes this function as-is and recognizes it during transformation: reads inside an `untracked(() => ...)` callback are untracked.
+To read a reactive field's current value without subscribing the enclosing widget subtree, append `.untracked` to the field reference at the call site.
+
+`solid_annotations` exports `extension UntrackedExtension<T> on T { T get untracked => this; }`, so the source typechecks before generation: `counter.untracked` has the same type as `counter` (an identity at runtime).
 
 Source:
 
 ```dart
-Text('Static snapshot: ${untracked(() => counter)}')
+Container(key: ValueKey(counter.untracked), child: const Text('hi'))
 ```
 
 Output:
 
 ```dart
-Text('Static snapshot: ${untracked(() => counter.value)}')
+Container(key: ValueKey(counter.untrackedValue), child: const Text('hi'))
 // NOT wrapped in SignalBuilder
 ```
 
-The generator recognizes `untracked` by resolved identifier (the top-level function from `package:flutter_solidart/flutter_solidart.dart`), not by name alone. A user-defined local `untracked` variable would not apply this rule.
+Rules:
+
+- The generator detects `<reactiveField>.untracked` as a `PrefixedIdentifier`, replaces the whole expression with `<reactiveField>.untrackedValue` (the runtime primitive on `ReadableSignal<T>`), and excludes the offset from the tracked-read set. No `SignalBuilder` wrap occurs at this position, regardless of structural context — even if the read sits inside an existing `SignalBuilder` from a sibling tracked read, `untrackedValue` bypasses `reactiveSystem.setCurrentSub` and never subscribes.
+- Inside string interpolations, only the long form `'${counter.untracked}'` expresses the untracked intent. The short form `'$counter.untracked'` parses as `${counter}` followed by a literal `.untracked` string suffix and rewrites as a normal tracked read of `counter`.
+- Detection is name-based on the prefix (the M3-05 type-resolution deferral); the existing shadowing guard (Section 5.5) suppresses the rewrite when a local variable shadows the field.
+
+**Migration from the v1 function-call form:** `untracked(() => ...)` is no longer supported. Writing it in source produces a build-time `CodeGenerationError` directing the user to the extension form. Replace each occurrence: `untracked(() => counter)` → `counter.untracked`.
 
 ### 6.5 Everything else is tracked
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -1273,4 +1273,4 @@ Widget build(BuildContext context) {
 **Dependencies:** M1-05.
 **Supersedes:** M3-07.
 
-**Status:** TODO
+**Status:** DONE

--- a/packages/solid_annotations/lib/src/annotations.dart
+++ b/packages/solid_annotations/lib/src/annotations.dart
@@ -41,3 +41,16 @@ class SolidEnvironment {
   /// {@macro SolidAnnotations.SolidEnvironment}
   const SolidEnvironment();
 }
+
+/// {@template SolidAnnotations.UntrackedExtension}
+/// Marks a reactive field read as untracked at the call site (SPEC §6.4).
+///
+/// When `solid_generator` sees `<field>.untracked` for a `@SolidState` field,
+/// it rewrites the expression to `<field>.untrackedValue` and excludes the
+/// read from `SignalBuilder` placement. The extension is identity at runtime;
+/// applied to a non-reactive expression it is a no-op.
+/// {@endtemplate}
+extension UntrackedExtension<T> on T {
+  /// {@macro SolidAnnotations.UntrackedExtension}
+  T get untracked => this;
+}

--- a/packages/solid_generator/lib/src/import_rewriter.dart
+++ b/packages/solid_generator/lib/src/import_rewriter.dart
@@ -2,7 +2,7 @@
 ///
 /// See SPEC Section 9 — added to the output whenever any reactive primitive
 /// (`Signal`, `Computed`, `Effect`, `Resource`, `SignalBuilder`,
-/// `SolidartConfig`, `untracked`) appears in the generated code.
+/// `SolidartConfig`) appears in the generated code.
 const String flutterSolidartUri =
     'package:flutter_solidart/flutter_solidart.dart';
 
@@ -19,7 +19,6 @@ const Set<String> solidartNames = {
   'Resource',
   'SignalBuilder',
   'SolidartConfig',
-  'untracked',
 };
 
 /// One annotated class's contribution to the generated output.

--- a/packages/solid_generator/lib/src/value_rewriter.dart
+++ b/packages/solid_generator/lib/src/value_rewriter.dart
@@ -1,5 +1,6 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:solid_generator/src/transformation_error.dart';
 
 /// A single value-level edit emitted by [collectValueEdits].
 ///
@@ -24,8 +25,8 @@ class ValueEdit {
 ///
 /// A tracked read is one that must cause its enclosing widget subtree to
 /// subscribe (Section 6.5). Writes (Section 6.0) never appear here; reads
-/// inside user-interaction callbacks or `untracked(...)` calls
-/// (Section 6.2 / 6.4) are excluded.
+/// inside user-interaction callbacks (Section 6.2) or `<field>.untracked`
+/// reads (Section 6.4) are excluded.
 class ValueRewriteResult {
   /// Creates a result holding [edits] and their [trackedReadOffsets].
   const ValueRewriteResult(this.edits, this.trackedReadOffsets);
@@ -95,6 +96,16 @@ String applyEditsToRange(String text, List<ValueEdit> edits, int baseOffset) {
   return result;
 }
 
+/// Name of the marker getter exposed by `UntrackedExtension` in
+/// `solid_annotations` (SPEC §6.4). Must stay in sync with the extension
+/// declaration in `packages/solid_annotations/lib/src/annotations.dart`.
+const String _untrackedGetterName = 'untracked';
+
+/// Name of the runtime opt-out getter on `ReadableSignal<T>` from
+/// `flutter_solidart`. Reading via this getter never subscribes the
+/// surrounding reactive context.
+const String _untrackedValueGetterName = 'untrackedValue';
+
 /// AST visitor that accumulates [ValueEdit]s for reactive-field identifiers.
 ///
 /// Scope tracking is intentionally minimal in M1-05: a local variable whose
@@ -112,11 +123,16 @@ class _ValueRewriteVisitor extends RecursiveAstVisitor<void> {
   final List<Set<String>> _scopeStack = [<String>{}];
 
   /// Depth of untracked contexts; >0 means every read visited here is
-  /// treated as untracked.
+  /// treated as untracked. Nested `on*` callbacks (Section 6.2) accumulate.
   int _untrackedDepth = 0;
 
   bool _isShadowed(String name) =>
       _scopeStack.any((frame) => frame.contains(name));
+
+  /// True if [name] is a reactive field reference that the rewriter should
+  /// rewrite at this site — known reactive name AND not shadowed by a local.
+  bool _isTrackedField(String name) =>
+      _reactiveFields.contains(name) && !_isShadowed(name);
 
   @override
   void visitBlock(Block node) {
@@ -148,21 +164,49 @@ class _ValueRewriteVisitor extends RecursiveAstVisitor<void> {
 
   @override
   void visitMethodInvocation(MethodInvocation node) {
-    final isUntrackedFn =
-        node.target == null && node.methodName.name == 'untracked';
-    if (isUntrackedFn) _untrackedDepth++;
+    // SPEC §6.4: the v1 `untracked(() => ...)` function-call form is no
+    // longer supported. The canonical opt-out marker is `<field>.untracked`
+    // (handled in [visitPrefixedIdentifier]).
+    if (node.target == null && node.methodName.name == _untrackedGetterName) {
+      throw const CodeGenerationError(
+        'untracked(() => ...) is no longer supported (SPEC §6.4). '
+            'Use the extension getter at the call site instead, e.g. '
+            '`counter.untracked`.',
+        null,
+        'untracked() function-call form',
+      );
+    }
     super.visitMethodInvocation(node);
-    if (isUntrackedFn) _untrackedDepth--;
+  }
+
+  @override
+  void visitPrefixedIdentifier(PrefixedIdentifier node) {
+    // SPEC §6.4: rewrite `<reactiveField>.untracked` to
+    // `<field>.untrackedValue` (the runtime primitive on `ReadableSignal<T>`).
+    // The offset is intentionally NOT added to trackedReadOffsets and
+    // `_untrackedDepth` is intentionally not consulted — an `.untracked` read
+    // must never subscribe, regardless of surrounding context.
+    if (node.identifier.name == _untrackedGetterName &&
+        _isTrackedField(node.prefix.name)) {
+      edits.add(
+        ValueEdit(
+          node.offset,
+          node.end,
+          '${node.prefix.name}.$_untrackedValueGetterName',
+        ),
+      );
+      // Skip super: descending would let visitSimpleIdentifier append `.value`
+      // to the prefix, corrupting the replacement just emitted.
+      return;
+    }
+    super.visitPrefixedIdentifier(node);
   }
 
   @override
   void visitInterpolationExpression(InterpolationExpression node) {
     final expr = node.expression;
     final isShortForm = node.leftBracket.lexeme == r'$';
-    if (isShortForm &&
-        expr is SimpleIdentifier &&
-        _reactiveFields.contains(expr.name) &&
-        !_isShadowed(expr.name)) {
+    if (isShortForm && expr is SimpleIdentifier && _isTrackedField(expr.name)) {
       // Expand `$name` → `${name.value}` as a single edit. Do not descend
       // — the inner SimpleIdentifier is already handled by this rewrite.
       edits.add(
@@ -181,8 +225,7 @@ class _ValueRewriteVisitor extends RecursiveAstVisitor<void> {
   @override
   void visitSimpleIdentifier(SimpleIdentifier node) {
     final name = node.name;
-    if (!_reactiveFields.contains(name)) return;
-    if (_isShadowed(name)) return;
+    if (!_isTrackedField(name)) return;
     if (_isAccessedValueProperty(node)) return;
     if (!_isBareReferenceToField(node)) return;
 

--- a/packages/solid_generator/test/golden/inputs/m3_12_untracked_extension.dart
+++ b/packages/solid_generator/test/golden/inputs/m3_12_untracked_extension.dart
@@ -1,0 +1,17 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/material.dart';
+
+class KeyedContainerUntracked extends StatelessWidget {
+  KeyedContainerUntracked({super.key});
+
+  @SolidState()
+  int counter = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      key: ValueKey(counter.untracked),
+      child: const Text('hi'),
+    );
+  }
+}

--- a/packages/solid_generator/test/golden/inputs/m3_12_untracked_function_call_rejected.dart
+++ b/packages/solid_generator/test/golden/inputs/m3_12_untracked_function_call_rejected.dart
@@ -1,0 +1,15 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class LegacyUsage extends StatelessWidget {
+  LegacyUsage({super.key});
+
+  @SolidState()
+  int counter = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text('Static: ${untracked(() => counter)}');
+  }
+}

--- a/packages/solid_generator/test/golden/outputs/m3_12_untracked_extension.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m3_12_untracked_extension.g.dart
@@ -1,0 +1,29 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class KeyedContainerUntracked extends StatefulWidget {
+  KeyedContainerUntracked({super.key});
+
+  @override
+  State<KeyedContainerUntracked> createState() =>
+      _KeyedContainerUntrackedState();
+}
+
+class _KeyedContainerUntrackedState extends State<KeyedContainerUntracked> {
+  final counter = Signal<int>(0, name: 'counter');
+
+  @override
+  void dispose() {
+    counter.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      key: ValueKey(counter.untrackedValue),
+      child: const Text('hi'),
+    );
+  }
+}

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -40,6 +40,7 @@ const List<String> goldenNames = <String>[
   'm3_09_shadowing',
   'm3_10_existing_signalbuilder',
   'm3_11_nested_tracked_reads',
+  'm3_12_untracked_extension',
 ];
 
 /// Memoized golden directory resolution. Resolved relative to the package

--- a/packages/solid_generator/test/rejections/m3_12_untracked_function_call_rejected_test.dart
+++ b/packages/solid_generator/test/rejections/m3_12_untracked_function_call_rejected_test.dart
@@ -1,0 +1,16 @@
+// Rejection suite for M3-12: the v1 untracked() function-call form (SPEC §6.4).
+// Writing `untracked(() => ...)` produces a CodeGenerationError directing
+// the user to the extension getter at the call site.
+
+import '../integration/golden_helpers.dart';
+
+const List<({String name, String errorContains})> _cases = [
+  (
+    name: 'm3_12_untracked_function_call_rejected',
+    errorContains: 'untracked(() => ...) is no longer supported (SPEC §6.4)',
+  ),
+];
+
+void main() {
+  runRejectionCases('m3_12 untracked() function-call rejection', _cases);
+}


### PR DESCRIPTION
## Summary

- Replace the v1 `untracked(() => ...)` function-call form with a `.untracked` extension getter on reactive fields (SPEC §6.4)
- Add `UntrackedExtension<T>` to `solid_annotations` exposing an identity getter that typechecks before generation
- Update `value_rewriter.dart` to detect `<field>.untracked` as a `PrefixedIdentifier`, rewrite to `<field>.untrackedValue`, and exclude from `SignalBuilder` wrapping
- Reject the old function form with a `CodeGenerationError` directing users to the extension getter pattern
- Add golden test for valid `.untracked` extension usage in a container key
- Add rejection test confirming old `untracked(() => ...)` syntax produces a helpful error
- Mark M3-12 as DONE in TODOS.md

## Testing

- Golden test: `m3_12_untracked_extension` verifies the extension getter is rewritten to `untrackedValue` at runtime
- Rejection test: `m3_12_untracked_function_call_rejected` confirms the old function-call form is rejected with migration guidance
- SPEC updated and golden helpers registered for new test case