### PR TITLE
Add M4 SPEC and implementation plan for @SolidEffect

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -288,15 +288,15 @@ Output:
 
 ```dart
 final counter = Signal<int>(0, name: 'counter');
-late final logCounter = Effect((_) {
+late final logCounter = Effect(() {
   print('Counter changed: ${counter.value}');
 }, name: 'logCounter');
 ```
 
 Rules:
 
-- The method's body — expression body or block body — is wrapped in a `(_) { … }` function expression. Section 5.1 type-driven `.value` rewriting is applied verbatim inside the body, identical to a `Computed` body (Sections 4.5–4.6).
-- The `Effect` callback receives one positional parameter (the upstream `flutter_solidart` `Effect` API surfaces a `DisposeEffect` callback at this position). The generator names the parameter `_` because the v2 generator does not surface self-disposal to user code; users who want self-disposal write the `Effect` by hand.
+- The method's body — expression body or block body — is wrapped in a `() { … }` function expression with no parameters. Section 5.1 type-driven `.value` rewriting is applied verbatim inside the body, identical to a `Computed` body (Sections 4.5–4.6).
+- The `Effect` callback takes zero parameters per the upstream `flutter_solidart` API: `Effect(() { … })`. Users who want self-disposal capture the value returned by `Effect(...)` (a disposer) by hand outside the annotation flow; the generator does not surface that surface area.
 - The resulting field is always declared `late final`, parallel to `Computed` (Section 4.5): the initializer reads other reactive instance fields, so its evaluation must defer until `this` is in scope.
 - Method-name → `name:` argument, unless `@SolidEffect(name: '…')` overrides — symmetric with the `@SolidState` rule (Sections 4.1, 4.4).
 - The cross-cutting rules in Sections 5.1, 5.2, 5.4, 5.5, 6.0, 6.2, 6.4, and 9 apply uniformly inside `Effect` bodies. The body is reactive code in the same sense as a `Computed` or a `build` body, so the type-driven `.value` rewrite, string-interpolation rewrite, no-double-append guard, shadowing handling, untracked-context detection, `.untracked` opt-out, and import-rewrite rules are reused without amendment. No new SPEC rule is required for `Effect` bodies.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,7 +1,7 @@
 # Solid — Product Specification (v2)
 
 **Status:** DRAFT — under review
-**Scope of this SPEC:** defines the user-facing contract for `@SolidState` (the first implementation milestone, M1). The other annotations shipped before v2 release — `@SolidEffect`, `@SolidQuery`, `@SolidEnvironment` — are reserved names only; their full contract lives in a future SPEC revision.
+**Scope of this SPEC:** defines the user-facing contract for `@SolidState` and `@SolidEffect` (M1 and M4 milestones). The remaining annotations shipped before v2 release — `@SolidQuery`, `@SolidEnvironment` — are reserved names only; their full contract lives in a future SPEC revision.
 
 This document is the single source of truth for what Solid does. Reviewer agents cite this document by section number when judging an implementation. It contains no file names, no class names, no AST details — only what the developer sees and the guarantees they get.
 
@@ -30,7 +30,7 @@ Rules:
 
 - **Input path**: any `.dart` file under `source/` at any depth.
 - **Output path**: same relative path under `lib/`. No suffix change. `source/foo/bar.dart` becomes `lib/foo/bar.dart`.
-- **Transformation vs verbatim copy.** Solid reads every `.dart` file under `source/`. If a file contains at least one `@Solid*` annotation (`@SolidState` today; `@SolidEffect`, `@SolidQuery`, `@SolidEnvironment` in later milestones), Solid transforms it. Otherwise the file is copied verbatim to the mirrored path under `lib/`. Non-`.dart` files (assets, configs, etc.) are always copied verbatim. The key is annotation presence, not file extension.
+- **Transformation vs verbatim copy.** Solid reads every `.dart` file under `source/`. If a file contains at least one `@Solid*` annotation (`@SolidState` and `@SolidEffect` today; `@SolidQuery`, `@SolidEnvironment` in later milestones), Solid transforms it. Otherwise the file is copied verbatim to the mirrored path under `lib/`. Non-`.dart` files (assets, configs, etc.) are always copied verbatim. The key is annotation presence, not file extension.
 - **Both are committed to git.** Source is the review artifact for intent. Lib is the review artifact for correctness — every PR that changes `source/` must include the regenerated `lib/` diff so reviewers catch generator regressions.
 - **Solid emits no `.g.dart` files of its own.** Third-party generators (freezed, json_serializable, drift) may emit `.g.dart` or `.freezed.dart` files under `source/`; Solid copies those verbatim to the mirrored path under `lib/`.
 - **The example app's `main.dart`** lives in `lib/` (or `source/` if itself annotated) and imports from `lib/` using normal Flutter imports (`import 'counter.dart';`).
@@ -41,7 +41,7 @@ Rules:
 
 ## 3. Annotations
 
-> **Milestones vs v2.** The v2 public release ships the full annotation set: `@SolidState`, `@SolidEffect`, `@SolidQuery`, `@SolidEnvironment`. Implementation is split into internal milestones. M1 implements `@SolidState` only. Later milestones add the remaining annotations before v2 ships. The user-facing API of every annotation is fixed in this SPEC; no source-code change is required when a later milestone lands.
+> **Milestones vs v2.** The v2 public release ships the full annotation set: `@SolidState`, `@SolidEffect`, `@SolidQuery`, `@SolidEnvironment`. Implementation is split into internal milestones. M1 implements `@SolidState`; M4 adds `@SolidEffect`. Later milestones add `@SolidQuery` and `@SolidEnvironment` before v2 ships. The user-facing API of every annotation is fixed in this SPEC; no source-code change is required when a later milestone lands.
 
 ### 3.1 M1 scope: `@SolidState`
 
@@ -78,9 +78,8 @@ int counter = 0;
 
 ### 3.2 Later milestones (shipped before v2 release)
 
-The following annotations are part of the v2 public release but land in milestones after M1. Until each one ships, the generator must fail with a clear error that names the annotation and says "not yet implemented; scheduled for a later v2 milestone." Their names are reserved here; the full user-facing contract (parameters, valid targets, transformation rules) will be specified in a future SPEC revision before each lands.
+The following annotations are part of the v2 public release but land in milestones after the SPEC's currently-specified set (`@SolidState` in M1, `@SolidEffect` in M4). Until each one ships, the generator must fail with a clear error that names the annotation and says "not yet implemented; scheduled for a later v2 milestone." Their names are reserved here; the full user-facing contract (parameters, valid targets, transformation rules) will be specified in a future SPEC revision before each lands.
 
-- `@SolidEffect` — reactive side effect (method)
 - `@SolidQuery` — async reactive source (method)
 - `@SolidEnvironment` — dependency injection (field)
 
@@ -92,6 +91,48 @@ Solid will never:
 - Ship its own reactive runtime.
 - Use Dart Macros, Dart augmentations, or part-file patterns.
 - Split one source file into multiple lib files. Each `source/*.dart` produces exactly one `lib/*.dart` at the mirrored path.
+
+### 3.4 M4 scope: `@SolidEffect`
+
+`@SolidEffect` declares a reactive side effect on a class. It attaches to an instance method whose body reads one or more reactive declarations and runs them as a side effect whenever those declarations change.
+
+```dart
+@SolidState()
+int counter = 0;
+
+@SolidEffect()
+void logCounter() {
+  print('Counter changed: $counter');
+}
+```
+
+Optional `name:` parameter overrides the auto-derived debug name:
+
+```dart
+@SolidEffect(name: 'counterLogger')
+void logCounter() {
+  print('Counter changed: $counter');
+}
+```
+
+#### Valid target
+
+- Instance method declared with a `void` return type, with **no parameters** and **no return value**. The body may be expression-bodied (`=> ...`) or block-bodied (`{ ... }`); both forms work uniformly with the body-rewrite pipeline (Section 4.7).
+
+#### Invalid targets (the generator must reject with a clear error)
+
+- Method with one or more parameters (the lowered `Effect` callback signature is fixed; user-supplied parameters cannot be threaded through).
+- Method with a non-`void` return type (an Effect produces side effects, not values; for a value-producing reactive expression use `@SolidState` on a getter — Section 3.1).
+- `static` method (class-level, not instance — out of scope, parallel to `@SolidState`).
+- `abstract` or `external` method (no body to lower).
+- Getter (use `@SolidState` on a getter for a `Computed`).
+- Setter.
+- Top-level function.
+- Field.
+
+#### Reactive-deps requirement
+
+The method body MUST read at least one reactive declaration — any identifier whose resolved static type is `SignalBase<T>` or a subtype. An `Effect` with zero reactive dependencies is rejected at build time: *"effect `<name>` has no reactive dependencies; use a regular method or call it once explicitly instead of `@SolidEffect`."* This mirrors Section 4.5's rejection rule for zero-dep `Computed`.
 
 ---
 
@@ -228,6 +269,37 @@ late final summary = Computed<String>(() {
 ```
 
 The block is copied verbatim into a function expression with reactive-read rewriting applied.
+
+### 4.7 `@SolidEffect` on method → `Effect`
+
+Input:
+
+```dart
+@SolidState()
+int counter = 0;
+
+@SolidEffect()
+void logCounter() {
+  print('Counter changed: $counter');
+}
+```
+
+Output:
+
+```dart
+final counter = Signal<int>(0, name: 'counter');
+late final logCounter = Effect((_) {
+  print('Counter changed: ${counter.value}');
+}, name: 'logCounter');
+```
+
+Rules:
+
+- The method's body — expression body or block body — is wrapped in a `(_) { … }` function expression. Section 5.1 type-driven `.value` rewriting is applied verbatim inside the body, identical to a `Computed` body (Sections 4.5–4.6).
+- The `Effect` callback receives one positional parameter (the upstream `flutter_solidart` `Effect` API surfaces a `DisposeEffect` callback at this position). The generator names the parameter `_` because the v2 generator does not surface self-disposal to user code; users who want self-disposal write the `Effect` by hand.
+- The resulting field is always declared `late final`, parallel to `Computed` (Section 4.5): the initializer reads other reactive instance fields, so its evaluation must defer until `this` is in scope.
+- Method-name → `name:` argument, unless `@SolidEffect(name: '…')` overrides — symmetric with the `@SolidState` rule (Sections 4.1, 4.4).
+- The cross-cutting rules in Sections 5.1, 5.2, 5.4, 5.5, 6.0, 6.2, 6.4, and 9 apply uniformly inside `Effect` bodies. The body is reactive code in the same sense as a `Computed` or a `build` body, so the type-driven `.value` rewrite, string-interpolation rewrite, no-double-append guard, shadowing handling, untracked-context detection, `.untracked` opt-out, and import-rewrite rules are reused without amendment. No new SPEC rule is required for `Effect` bodies.
 
 ---
 
@@ -603,11 +675,11 @@ This is the fix for issue #8.
 
 ## 10. `dispose()` Contract
 
-Every generated `Signal` and `Computed` must be disposed when its owning class is disposed. The merging algorithm below applies identically to every class kind; the per-kind sections (8.1–8.3) describe how the algorithm is triggered.
+Every generated `Signal`, `Computed`, and `Effect` must be disposed when its owning class is disposed. The merging algorithm below applies identically to every class kind; the per-kind sections (8.1–8.3) describe how the algorithm is triggered.
 
 Algorithm: if the target class already has a `dispose()` body, prepend one `xxx.dispose()` call per reactive declaration to the top of the body and leave the rest untouched; if no `dispose()` exists, synthesize one. Emit `super.dispose()` at the end if and only if the class's supertype chain contains a `dispose()` method (e.g., `State<T>`, `ChangeNotifier`); the generator determines this via the analyzer's type resolution, not by name matching. For a plain class with no `dispose()` in the supertype chain, omit `super.dispose()`.
 
-Disposal order is **reverse declaration order**: dependents are disposed before their dependencies. Because a `Computed` must always be declared after the `Signal`s it reads (those `Signal`s are the `Computed`'s dependencies), reverse declaration order guarantees the `Computed` is disposed first and a `Signal` is never disposed while a live `Computed` still holds a subscription to it.
+Disposal order is **reverse declaration order**: dependents are disposed before their dependencies. Because a `Computed` must always be declared after the `Signal`s it reads, and an `Effect` must always be declared after the `Signal`s/`Computed`s it reads (those declarations are the dependents' dependencies), reverse declaration order guarantees a dependent (`Effect` or `Computed`) is disposed first and a dependency (`Signal` or `Computed`) is never disposed while a live subscriber still holds a subscription to it.
 
 ---
 
@@ -655,11 +727,10 @@ With Option A the developer saves `source/`, waits for build_runner to emit, the
 
 ---
 
-## 13. Not in M1 (shipped before v2 release)
+## 13. Not yet shipped (deferred until later milestones, before v2 release)
 
-These features are part of the v2 public release but land in milestones after M1. An M1 build that encounters any of them in source code must fail with a clear error naming the unsupported feature and referencing this section.
+These features are part of the v2 public release but land in milestones after the SPEC's currently-specified set (`@SolidState` in M1, `@SolidEffect` in M4). A build that encounters any of them in source code must fail with a clear error naming the unsupported feature and referencing this section.
 
-- `@SolidEffect`
 - `@SolidQuery` (Future and Stream forms; `.when`, `.maybeWhen`, `.refresh`, `.isRefreshing`; debounce; useRefreshing)
 - `@SolidEnvironment`
 - `SolidProvider` / `InheritedSolidProvider` / `.environment()` widget extension / `context.read` / `context.watch`
@@ -680,7 +751,7 @@ These were open questions during SPEC drafting and have been answered by the dev
 2. **Compound-assignment operator list in Section 5.3** — complete.
 3. **`@SolidState` on `final` fields** — rejected with a clear error (wrapping a never-reassigned value in a `Signal` is pointless).
 4. **Custom `initState` / `didUpdateWidget` overrides in an existing State class (Section 8.2)** — preserved untouched. If an existing `dispose()` is present, reactive disposals are merged into its body.
-5. **User-facing packages** — two packages. `package:solid_annotations` (runtime dep) hosts the annotation classes (`@SolidState` today; `@SolidEffect`/`@SolidQuery`/`@SolidEnvironment` in later milestones). `package:solid_generator` (dev_dep) hosts the build_runner builder. There is no `package:solid` umbrella. Consumers add `solid_annotations` + `flutter_solidart` as runtime deps and `solid_generator` + `build_runner` as dev_deps, then import annotations and `flutter_solidart` primitives directly.
+5. **User-facing packages** — two packages. `package:solid_annotations` (runtime dep) hosts the annotation classes (`@SolidState` and `@SolidEffect` today; `@SolidQuery`/`@SolidEnvironment` in later milestones). `package:solid_generator` (dev_dep) hosts the build_runner builder. There is no `package:solid` umbrella. Consumers add `solid_annotations` + `flutter_solidart` as runtime deps and `solid_generator` + `build_runner` as dev_deps, then import annotations and `flutter_solidart` primitives directly.
 6. **Shadowing rule (Section 5.5)** — handled by type resolution. Because Section 5.1 is type-driven, a shadowed local of a non-`SignalBase` type is never rewritten. A dedicated shadowing test case is required in M1.
 7. **`const` on the public widget constructor (Section 8.1)** — not added by the generator. Constructors round-trip verbatim from source. After the class split removes mutable `@SolidState` fields from the widget, the rewritten widget is usually const-eligible by Dart's own rules; `dart fix --apply` is the trusted lint pass that adds `const` (and removes unused imports — Section 9). The generator never emits `const` on its own.
 
@@ -697,8 +768,8 @@ Any change that alters user-observable behavior must be covered by a golden test
 This SPEC addresses the following real user-reported issues from the v1 repo:
 
 - **#3** — `@SolidEnvironment` inside an existing `State<X>` was not transformed; the class-kind handling in Section 8.2 makes this impossible to regress.
-- **#4** — untracked reads (`onPressed`) were wrapped in `SignalBuilder`, breaking compilation; Section 6 defines the untracked-context rules.
-- **#6** — `Text(text)` did not receive `.value` because the rewriter missed bare identifier reads; Section 5.1 defines the rewrite rule exhaustively.
+- **#4** — untracked reads (`onPressed`) were wrapped in `SignalBuilder`, breaking compilation; Section 6 defines the untracked-context rules. *(resolved in M3)*
+- **#6** — `Text(text)` did not receive `.value` because the rewriter missed bare identifier reads; Section 5.1 defines the rewrite rule exhaustively. *(resolved in M3)*
 - **#8** — generated `main.dart` used `SolidartConfig` without importing `flutter_solidart`; Section 9 defines the import-addition rule.
 - **#9** — hot reload required a double-save; Section 12 defines the two supported workflows: manual `r` after build_runner emits, or `dashmon` to bridge filesystem changes to Flutter's stdin automatically.
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -1274,3 +1274,267 @@ Widget build(BuildContext context) {
 **Supersedes:** M3-07.
 
 **Status:** DONE
+
+---
+
+## M4 — `@SolidEffect`
+
+### TODO M4-01 — Golden: simple `@SolidEffect` method with one Signal dep
+
+**Goal:** `@SolidEffect() void logCounter() { print('Counter changed: $counter'); }` on a `StatelessWidget` (next to `@SolidState() int counter = 0;`) becomes `late final logCounter = Effect((_) { print('Counter changed: ${counter.value}'); }, name: 'logCounter');` on the synthesized State class. Establishes the M4 lowering pipeline: `EffectModel`, `readSolidEffectMethod`, `emitEffectField`, and the non-getter `MethodDeclaration` branch in `_collectAnnotatedClasses`.
+
+**SPEC references:** Section 3.4, Section 4.7, Section 5.1 (identifier rewrite), Section 5.2 (string interpolation), Section 9 (import — `Effect` already on canonical list), Section 10 (dispose order).
+
+**Files to create:**
+
+- `packages/solid_generator/test/golden/inputs/m4_01_simple_effect_with_deps.dart`
+- `packages/solid_generator/test/golden/outputs/m4_01_simple_effect_with_deps.g.dart`
+- entry in `packages/solid_generator/test/integration/golden_helpers.dart` `goldenNames`
+- `packages/solid_generator/lib/src/effect_model.dart` — new model file, parallel to `getter_model.dart`. Carries `methodName`, `bodyText` (already with `.value` rewrites applied), and `annotationName`.
+
+**Files to modify:**
+
+- `packages/solid_annotations/lib/src/annotations.dart` — replace the `SolidEffect` placeholder with `@Target({TargetKind.method}) class SolidEffect { const SolidEffect({this.name}); final String? name; }`.
+- `packages/solid_generator/lib/src/annotation_reader.dart` — add `EffectModel? readSolidEffectMethod(MethodDeclaration decl, Set<String> reactiveFieldNames, String source)`; reuse `findSolidStateAnnotation` + `extractNameArgument` patterns (consider factoring a shared `findSolidAnnotation(String className, …)` helper if it tightens the code).
+- `packages/solid_generator/lib/src/signal_emitter.dart` — add `String emitEffectField(EffectModel e)` returning the `late final … = Effect((_) { … }, name: '…');` line. Extend `emitDispose`'s argument-list semantics so Effects join Signals/Computeds in the unified ordered name list.
+- `packages/solid_generator/lib/builder.dart` — extend `_AnnotatedClass` to carry `final List<EffectModel> effects;`; extend `_collectAnnotatedClasses` to walk `MethodDeclaration` members where `!member.isGetter && !member.isSetter`; pass `effects` through `_rewriteClass` to all three rewriters.
+- `packages/solid_generator/lib/src/stateless_rewriter.dart` — accept `solidEffects`; interleave Signal/Computed/Effect fields in source order; pass merged disposable-name list to `emitDispose`.
+- `packages/solid_generator/lib/src/state_class_rewriter.dart`, `packages/solid_generator/lib/src/plain_class_rewriter.dart` — for now, reject `@SolidEffect` with a `CodeGenerationError("@SolidEffect on State<X>/plain class will land in M4-08")` until M4-08 ships them.
+
+**Expected input content:**
+
+```dart
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+
+class Counter extends StatelessWidget {
+  Counter({super.key});
+
+  @SolidState()
+  int counter = 0;
+
+  @SolidEffect()
+  void logCounter() {
+    print('Counter changed: $counter');
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}
+```
+
+**Expected output content:**
+
+```dart
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class Counter extends StatefulWidget {
+  Counter({super.key});
+
+  @override
+  State<Counter> createState() => _CounterState();
+}
+
+class _CounterState extends State<Counter> {
+  final counter = Signal<int>(0, name: 'counter');
+  late final logCounter = Effect((_) {
+    print('Counter changed: ${counter.value}');
+  }, name: 'logCounter');
+
+  @override
+  void dispose() {
+    logCounter.dispose();
+    counter.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}
+```
+
+**Acceptance:** `dart test --name=m4_01` passes; golden analyzes clean; dispose body calls `logCounter.dispose()` BEFORE `counter.dispose()`; the upstream `Effect` constructor signature accepted by `flutter_solidart` matches what the golden emits (verify against the package source at impl time — adjust the `(_) { … }` parameter name if the upstream API uses something else).
+
+**Dependencies:** M2-01 (body-rewrite pipeline + `MethodDeclaration` collection path), M2-01b (block-body precedent).
+
+**Status:** TODO
+
+---
+
+### TODO M4-02 — Golden: `@SolidEffect` co-exists with `@SolidState` field + getter
+
+**Goal:** A class with all three annotated shapes — `@SolidState()` field, `@SolidState()` getter, `@SolidEffect()` method — produces a State class with Signal + Computed + Effect interleaved in source order, and a `dispose()` body in reverse-declaration order. Validates the unified ordered-name list under all three lowered shapes.
+
+**SPEC references:** Section 4.1, Section 4.5, Section 4.7, Section 10.
+
+**Files to create:**
+
+- `packages/solid_generator/test/golden/inputs/m4_02_effect_with_signal_and_computed.dart`
+- `packages/solid_generator/test/golden/outputs/m4_02_effect_with_signal_and_computed.g.dart`
+- entry in `golden_helpers.dart` `goldenNames`
+
+**Expected input content:** A `StatelessWidget` with (in source order) `@SolidState() int counter = 0;`, `@SolidState() int get doubleCounter => counter * 2;`, `@SolidEffect() void logBoth() { print('$counter / $doubleCounter'); }`.
+
+**Expected output content:** State class declares `counter` (Signal), then `doubleCounter` (late final Computed), then `logBoth` (late final Effect) — all in source order. `dispose()` body calls `logBoth.dispose()`, then `doubleCounter.dispose()`, then `counter.dispose()`, then `super.dispose()` — reverse declaration order per SPEC Section 10.
+
+**Expected implementation change:** None beyond M4-01 + M2-01 — this is a regression fence on the unified ordering rule, validating that the M4-01-extended `emitDispose` argument list correctly interleaves all three shapes.
+
+**Acceptance:** `dart test --name=m4_02` passes; golden's `dispose()` body has Effect → Computed → Signal → super order verbatim.
+
+**Dependencies:** M4-01.
+
+**Status:** TODO
+
+---
+
+### TODO M4-03 — Golden: `@SolidEffect` block-body with multi-statement and shadowing
+
+**Goal:** A `@SolidEffect` method with a block body that contains multiple statements and a local variable that shadows a reactive-field name produces an Effect whose body preserves the block verbatim with reactive reads rewritten and shadowed locals untouched. Validates that Sections 5.1 and 5.5 apply uniformly inside Effect bodies.
+
+**SPEC references:** Section 4.7, Section 5.1, Section 5.5.
+
+**Files to create:**
+
+- `packages/solid_generator/test/golden/inputs/m4_03_effect_block_body_shadowing.dart`
+- `packages/solid_generator/test/golden/outputs/m4_03_effect_block_body_shadowing.g.dart`
+- entry in `golden_helpers.dart` `goldenNames`
+
+**Expected input content:** Class with `@SolidState() int counter = 0;` plus `@SolidEffect() void logCounter() { final counter = 'shadowed'; final c = counter; print(c); print('field: $counter'); }`. The local `counter` shadows the field for the first two statements but the third statement re-references the local — and there's NO outer field read inside the block (the third statement is inside the same scope).
+
+**Expected output content:** The Effect body has the local declarations preserved; the local `counter` reads stay as `counter` (no `.value`); there are no outer reactive reads at all (so the body does not subscribe to anything). This means the Effect would have ZERO reactive deps — therefore this case must instead exercise mixed shadowing: the outer scope reads `counter` (rewritten to `counter.value`) BEFORE the inner shadow scope rebinds it (stays as `counter`). Concretely: `void logCounter() { print('outer: $counter'); { final counter = 'shadowed'; print('inner: $counter'); } }`.
+
+**Expected implementation change:** None beyond M4-01 + M2-01b — this is a regression fence on the shadowing rule applied to Effect bodies.
+
+**Acceptance:** `dart test --name=m4_03` passes; golden analyzes clean; outer `$counter` becomes `${counter.value}`; inner `$counter` stays as `$counter`; the Effect has at least one reactive dep (the outer read), so M4-05's zero-dep rejection does not fire.
+
+**Dependencies:** M4-01.
+
+**Status:** TODO
+
+---
+
+### TODO M4-04 — Rejection: invalid `@SolidEffect` targets
+
+**Goal:** The generator rejects `@SolidEffect` on every invalid target enumerated in SPEC Section 3.4 with a clear, per-case error message that identifies the offending declaration. Mirror of M1-14.
+
+**SPEC references:** Section 3.4 "Invalid targets".
+
+**Files to create:**
+
+- `packages/solid_generator/test/rejections/m4_04_invalid_effect_targets_test.dart` — parametric test over the seven cases below. Each case is a minimal source snippet that places `@SolidEffect` on the invalid target; each asserts the builder raises an error whose message contains the SPEC description of the case.
+- One input file per case under `packages/solid_generator/test/golden/inputs/`:
+  - `m4_04_parameterized.dart` — `@SolidEffect() void doThing(int x) {}`
+  - `m4_04_non_void_return.dart` — `@SolidEffect() int compute() => 0;`
+  - `m4_04_static.dart` — `@SolidEffect() static void doThing() {}`
+  - `m4_04_abstract.dart` — `@SolidEffect() void doThing();` on an abstract class member.
+  - `m4_04_getter.dart` — `@SolidEffect() int get x => 0;`
+  - `m4_04_setter.dart` — `@SolidEffect() set x(int v) {}`
+  - `m4_04_top_level.dart` — top-level `@SolidEffect() void doThing() {}`
+  - `m4_04_field.dart` — `@SolidEffect() int counter = 0;` (field, not method)
+
+**Expected implementation change:** Extend `target_validator.dart` with a parallel `validateSolidEffectTargets` (or a unified validator that branches on which annotation is present). The check runs before transformation. Any invalid target produces a `ValidationError` with a SPEC-quoted message that names the target kind and the enclosing class + member identifier.
+
+**Acceptance:** The parametric test passes; every case produces a distinct error message that contains the SPEC description of the invalid-target category from Section 3.4.
+
+**Dependencies:** M4-01.
+
+**Status:** TODO
+
+---
+
+### TODO M4-05 — Rejection: zero reactive deps in Effect body
+
+**Goal:** `@SolidEffect() void doThing() { print('no signals here'); }` must be rejected at build time with the SPEC-defined error: `"effect 'doThing' has no reactive dependencies"`. An Effect with no deps is a one-shot function call; the user should call it explicitly instead. Mirror of M2-02.
+
+**SPEC references:** Section 3.4 "Reactive-deps requirement", Section 4.7.
+
+**Files to create:**
+
+- `packages/solid_generator/test/golden/inputs/m4_05_effect_no_deps_rejected.dart` — class with `@SolidEffect() void doThing() { print('hello'); }` and no `@SolidState` fields.
+- `packages/solid_generator/test/rejections/m4_05_effect_no_deps_test.dart` — asserts the builder raises an error containing `"effect 'doThing' has no reactive dependencies"`.
+
+**Expected implementation change:** After visiting an Effect body, check whether any identifier resolved to `SignalBase<T>`. If none, emit the SPEC-defined error. Reuses the same pattern as M2-02's zero-dep Computed check; the only difference is the error message wording (`"effect"` vs `"getter"`).
+
+**Acceptance:** Rejection test passes; error message text matches SPEC Section 3.4 quote exactly.
+
+**Dependencies:** M4-01.
+
+**Status:** TODO
+
+---
+
+### TODO M4-06 — Migration: remove `@SolidEffect` from reserved-annotation list
+
+**Goal:** Once M4-01 through M4-05 are green and `@SolidEffect` is fully transformed, the reserved-annotation rejection must stop firing on it. Remove `'SolidEffect'` from `_reservedAnnotations` and migrate the M1-15 `m1_15_effect` case to a golden (or delete it if M4-01 already covers the equivalent shape).
+
+**SPEC references:** Section 3.2 (reserved-annotation list, post-M4 trim — already trimmed in the M4 design seed PR), Section 13 (deferred features).
+
+**Files to modify:**
+
+- `packages/solid_generator/lib/src/reserved_annotation_validator.dart` — remove `'SolidEffect'` from the `_reservedAnnotations` map at lines 9-13.
+- `packages/solid_generator/test/rejections/m1_15_non_m1_annotations_test.dart` — delete the `m1_15_effect` case at lines 8-13 (or whatever the current line range is after M4-01 lands).
+- `packages/solid_generator/test/golden/inputs/m1_15_effect.dart` — delete (no longer a rejection input).
+
+**Expected implementation change:** A one-line trim in the validator; a small test deletion; an input-file deletion. No new code paths.
+
+**Acceptance:** `dart test packages/solid_generator/` passes; the remaining `m1_15_query` and `m1_15_environment` rejection cases still fire; M4-01 through M4-05 all still pass.
+
+**Dependencies:** M4-01, M4-02, M4-03, M4-04, M4-05.
+
+**Status:** TODO
+
+---
+
+### TODO M4-07 — Widget test: Effect fires on each tap
+
+**Goal:** With an `@SolidEffect` method that increments a separate counter (or appends to a list-typed Signal), tapping the FAB three times causes the Effect body to run three times. The test reads the recorded values and asserts the count.
+
+**SPEC references:** Section 4.7, Section 10 (Effect disposal on tear-down).
+
+**Files to create:**
+
+- `example/test/effect_widget_test.dart` — `testWidgets` test that:
+  1. Pumps a widget with `@SolidState() int counter = 0;`, `@SolidState() List<int> history = [];`, and `@SolidEffect() void recordHistory() { history.value = [...history.value, counter]; }`. (Or a simpler shape using a non-Solid `List` field that the Effect mutates and the test inspects via a `GlobalKey`.)
+  2. Taps the FAB three times.
+  3. Asserts the Effect body ran three times by checking the recorded history.
+
+**Expected implementation change:** None in the generator. The test exercises the runtime contract (Effect fires on dep change) end-to-end through the M4-01 lowered output.
+
+**Acceptance:** `flutter test example/` passes; the recorded history has exactly three entries after three taps; on Navigator pop, the Effect's `dispose()` is invoked (assert via a `signal.onDispose` hook on a wrapper Signal, parallel to M1-11).
+
+**Dependencies:** M4-01, M4-06 (Effect must no longer be reserved).
+
+**Status:** TODO
+
+---
+
+### TODO M4-08 — Golden: `@SolidEffect` on existing `State<X>` class
+
+**Goal:** A `StatefulWidget` whose existing `State<X>` subclass hosts `@SolidEffect` methods is transformed in-place, not re-wrapped. Custom `initState` / `didUpdateWidget` overrides are preserved untouched; if an existing `dispose()` body is present, Effect disposals are prepended and the rest of the body is left alone. Mirror of M1-07. Removes the `state_class_rewriter.dart` / `plain_class_rewriter.dart` guards that M4-01 added.
+
+**SPEC references:** Section 4.7, Section 8.2, Section 8.3, Section 10.
+
+**Files to create:**
+
+- `packages/solid_generator/test/golden/inputs/m4_08_effect_on_state_class.dart`
+- `packages/solid_generator/test/golden/outputs/m4_08_effect_on_state_class.g.dart`
+- `packages/solid_generator/test/golden/inputs/m4_08_effect_on_plain_class.dart`
+- `packages/solid_generator/test/golden/outputs/m4_08_effect_on_plain_class.g.dart`
+- entries in `golden_helpers.dart` `goldenNames`
+
+**Files to modify:**
+
+- `packages/solid_generator/lib/src/state_class_rewriter.dart` — remove the M4-01 reject guard; route Effects through the same in-place lowering used by Signals/Computeds.
+- `packages/solid_generator/lib/src/plain_class_rewriter.dart` — same.
+
+**Expected implementation change:** Both rewriters interleave Effect emission with Signal/Computed emission per source order, and append Effect dispose calls to the unified ordered name list. The merge-into-existing-`dispose()` logic from M1-07 already handles the prepend-then-keep-existing-body shape.
+
+**Acceptance:** `dart test --name=m4_08` passes; both goldens analyze clean; `initState` and `didUpdateWidget` bodies are byte-identical between input and output; the existing `dispose()` body has Effect/Computed/Signal disposal calls prepended in reverse-declaration order with nothing else added or removed.
+
+**Dependencies:** M4-01, M1-07.
+
+**Status:** TODO
+
+---

--- a/TODOS.md
+++ b/TODOS.md
@@ -1281,7 +1281,7 @@ Widget build(BuildContext context) {
 
 ### TODO M4-01 — Golden: simple `@SolidEffect` method with one Signal dep
 
-**Goal:** `@SolidEffect() void logCounter() { print('Counter changed: $counter'); }` on a `StatelessWidget` (next to `@SolidState() int counter = 0;`) becomes `late final logCounter = Effect((_) { print('Counter changed: ${counter.value}'); }, name: 'logCounter');` on the synthesized State class. Establishes the M4 lowering pipeline: `EffectModel`, `readSolidEffectMethod`, `emitEffectField`, and the non-getter `MethodDeclaration` branch in `_collectAnnotatedClasses`.
+**Goal:** `@SolidEffect() void logCounter() { print('Counter changed: $counter'); }` on a `StatelessWidget` (next to `@SolidState() int counter = 0;`) becomes `late final logCounter = Effect(() { print('Counter changed: ${counter.value}'); }, name: 'logCounter');` on the synthesized State class. Establishes the M4 lowering pipeline: `EffectModel`, `readSolidEffectMethod`, `emitEffectField`, and the non-getter `MethodDeclaration` branch in `_collectAnnotatedClasses`.
 
 **SPEC references:** Section 3.4, Section 4.7, Section 5.1 (identifier rewrite), Section 5.2 (string interpolation), Section 9 (import — `Effect` already on canonical list), Section 10 (dispose order).
 
@@ -1296,7 +1296,7 @@ Widget build(BuildContext context) {
 
 - `packages/solid_annotations/lib/src/annotations.dart` — replace the `SolidEffect` placeholder with `@Target({TargetKind.method}) class SolidEffect { const SolidEffect({this.name}); final String? name; }`.
 - `packages/solid_generator/lib/src/annotation_reader.dart` — add `EffectModel? readSolidEffectMethod(MethodDeclaration decl, Set<String> reactiveFieldNames, String source)`; reuse `findSolidStateAnnotation` + `extractNameArgument` patterns (consider factoring a shared `findSolidAnnotation(String className, …)` helper if it tightens the code).
-- `packages/solid_generator/lib/src/signal_emitter.dart` — add `String emitEffectField(EffectModel e)` returning the `late final … = Effect((_) { … }, name: '…');` line. Extend `emitDispose`'s argument-list semantics so Effects join Signals/Computeds in the unified ordered name list.
+- `packages/solid_generator/lib/src/signal_emitter.dart` — add `String emitEffectField(EffectModel e)` returning the `late final … = Effect(() { … }, name: '…');` line (zero-param callback per SPEC §4.7). Extend `emitDispose`'s argument-list semantics so Effects join Signals/Computeds in the unified ordered name list.
 - `packages/solid_generator/lib/builder.dart` — extend `_AnnotatedClass` to carry `final List<EffectModel> effects;`; extend `_collectAnnotatedClasses` to walk `MethodDeclaration` members where `!member.isGetter && !member.isSetter`; pass `effects` through `_rewriteClass` to all three rewriters.
 - `packages/solid_generator/lib/src/stateless_rewriter.dart` — accept `solidEffects`; interleave Signal/Computed/Effect fields in source order; pass merged disposable-name list to `emitDispose`.
 - `packages/solid_generator/lib/src/state_class_rewriter.dart`, `packages/solid_generator/lib/src/plain_class_rewriter.dart` — for now, reject `@SolidEffect` with a `CodeGenerationError("@SolidEffect on State<X>/plain class will land in M4-08")` until M4-08 ships them.
@@ -1339,7 +1339,7 @@ class Counter extends StatefulWidget {
 
 class _CounterState extends State<Counter> {
   final counter = Signal<int>(0, name: 'counter');
-  late final logCounter = Effect((_) {
+  late final logCounter = Effect(() {
     print('Counter changed: ${counter.value}');
   }, name: 'logCounter');
 
@@ -1355,7 +1355,7 @@ class _CounterState extends State<Counter> {
 }
 ```
 
-**Acceptance:** `dart test --name=m4_01` passes; golden analyzes clean; dispose body calls `logCounter.dispose()` BEFORE `counter.dispose()`; the upstream `Effect` constructor signature accepted by `flutter_solidart` matches what the golden emits (verify against the package source at impl time — adjust the `(_) { … }` parameter name if the upstream API uses something else).
+**Acceptance:** `dart test --name=m4_01` passes; golden analyzes clean; dispose body calls `logCounter.dispose()` BEFORE `counter.dispose()`; the upstream `Effect` constructor signature accepted by `flutter_solidart` matches what the golden emits (zero-param callback `() { … }` per SPEC §4.7 — verify the disposer-vs-`.dispose()` semantics against the package source at impl time and adjust the `dispose()` body if the upstream returns a function rather than an object).
 
 **Dependencies:** M2-01 (body-rewrite pipeline + `MethodDeclaration` collection path), M2-01b (block-body precedent).
 

--- a/plans/features/m4-effect.md
+++ b/plans/features/m4-effect.md
@@ -6,7 +6,7 @@
 
 ## Purpose
 
-M4 adds `@SolidEffect` on methods: a side-effecting function whose body reads one or more reactive declarations and re-runs whenever those declarations change. The method becomes a `late final Effect((_) { … }, name: '<n>')` field, with identifier rewrites applied per SPEC Section 5.1. Disposal joins the existing reverse-declaration order. This is the smallest infrastructural delta of the three reserved annotations: the body-rewrite pipeline and the `MethodDeclaration` collection path were both made future-proof in M2.
+M4 adds `@SolidEffect` on methods: a side-effecting function whose body reads one or more reactive declarations and re-runs whenever those declarations change. The method becomes a `late final Effect(() { … }, name: '<n>')` field (zero-param callback per the upstream `flutter_solidart` API), with identifier rewrites applied per SPEC Section 5.1. Disposal joins the existing reverse-declaration order. This is the smallest infrastructural delta of the three reserved annotations: the body-rewrite pipeline and the `MethodDeclaration` collection path were both made future-proof in M2.
 
 A developer after M4 can:
 
@@ -17,7 +17,7 @@ A developer after M4 can:
 
 ## TODO sequence
 
-- **M4-01** — Golden: simple `@SolidEffect` method with one Signal dep on `StatelessWidget`. Mirror of M2-01 for getters. Establishes the `EffectModel` model file, `readSolidEffectMethod` reader, `emitEffectField` emitter, the `MethodDeclaration` non-getter discrimination in `_collectAnnotatedClasses`, and the `late final ... = Effect((_) => ..., name: '<n>')` shape. Expression-body form first.
+- **M4-01** — Golden: simple `@SolidEffect` method with one Signal dep on `StatelessWidget`. Mirror of M2-01 for getters. Establishes the `EffectModel` model file, `readSolidEffectMethod` reader, `emitEffectField` emitter, the `MethodDeclaration` non-getter discrimination in `_collectAnnotatedClasses`, and the `late final ... = Effect(() { ...; }, name: '<n>')` shape (zero-param callback). Expression-body form first.
 - **M4-02** — Golden: `@SolidEffect` co-exists with `@SolidState` field + `@SolidState` getter on the same class. Validates that the unified dispose ordering across all three lowered shapes (Signal/Computed/Effect) is correct under the existing reverse-declaration rule.
 - **M4-03** — Golden: `@SolidEffect` block-body with multi-statement and shadowing. Validates that Sections 5.1 and 5.5 rules apply inside Effect bodies same as Computed bodies (parallel to M2-01b).
 - **M4-04** — Rejection: invalid `@SolidEffect` targets. Parametric test mirroring M1-14: getter, setter, static method, top-level function, parameterized method, non-void return, abstract method.

--- a/plans/features/m4-effect.md
+++ b/plans/features/m4-effect.md
@@ -1,0 +1,48 @@
+# M4 — `@SolidEffect` on methods → `Effect`
+
+**TODOS.md items:** M4-01 → M4-08
+**SPEC sections:** 3.4, 4.7, 5.1, 5.2, 5.4, 5.5, 6.0, 6.2, 6.4, 9, 10
+**Reviewer rubric:** `plans/features/reviewer-rubric.md`
+
+## Purpose
+
+M4 adds `@SolidEffect` on methods: a side-effecting function whose body reads one or more reactive declarations and re-runs whenever those declarations change. The method becomes a `late final Effect((_) { … }, name: '<n>')` field, with identifier rewrites applied per SPEC Section 5.1. Disposal joins the existing reverse-declaration order. This is the smallest infrastructural delta of the three reserved annotations: the body-rewrite pipeline and the `MethodDeclaration` collection path were both made future-proof in M2.
+
+A developer after M4 can:
+
+1. Write `@SolidEffect() void logCounter() { print('Counter changed: $counter'); }` next to an existing `@SolidState() int counter = 0;`.
+2. See the Effect re-run automatically when `counter` changes (no manual subscription, no widget rebuild).
+3. See the Effect disposed BEFORE the Signal it depends on when the widget is torn down.
+4. Get a clear build-time error if they write an Effect that reads no reactive state, or annotate an invalid target (parameterized method, non-void return, static method, getter, setter, top-level function, field).
+
+## TODO sequence
+
+- **M4-01** — Golden: simple `@SolidEffect` method with one Signal dep on `StatelessWidget`. Mirror of M2-01 for getters. Establishes the `EffectModel` model file, `readSolidEffectMethod` reader, `emitEffectField` emitter, the `MethodDeclaration` non-getter discrimination in `_collectAnnotatedClasses`, and the `late final ... = Effect((_) => ..., name: '<n>')` shape. Expression-body form first.
+- **M4-02** — Golden: `@SolidEffect` co-exists with `@SolidState` field + `@SolidState` getter on the same class. Validates that the unified dispose ordering across all three lowered shapes (Signal/Computed/Effect) is correct under the existing reverse-declaration rule.
+- **M4-03** — Golden: `@SolidEffect` block-body with multi-statement and shadowing. Validates that Sections 5.1 and 5.5 rules apply inside Effect bodies same as Computed bodies (parallel to M2-01b).
+- **M4-04** — Rejection: invalid `@SolidEffect` targets. Parametric test mirroring M1-14: getter, setter, static method, top-level function, parameterized method, non-void return, abstract method.
+- **M4-05** — Rejection: zero reactive deps in Effect body. Mirror of M2-02. Error: `"effect '<name>' has no reactive dependencies"`.
+- **M4-06** — Migration: remove `@SolidEffect` from `_reservedAnnotations` (`reserved_annotation_validator.dart:9–13`) and migrate the `m1_15_effect` rejection-test case to a golden. Trivial flip-the-bit PR — depends on M4-01 through M4-05 being green.
+- **M4-07** — Widget test: tap FAB three times, assert the Effect body fires three times. Records emitted values into a list-typed Signal that the test reads. Parallel to M1-10 / M3-04.
+- **M4-08** — Golden: `@SolidEffect` on existing `State<X>` class (lifecycle co-existence with hand-written `initState` / `dispose`). Mirror of M1-07.
+
+## Cross-cutting concerns
+
+- **Body-rewrite pipeline reuse.** `value_rewriter.dart`'s `collectValueEdits` was generalized in M2-01 to take any `AstNode`. M4-01 calls it with the Effect's body block, exactly mirroring M2-01b's block-body Computed handling. No rewriter changes needed.
+- **`MethodDeclaration` getter/non-getter discriminator.** The M2-01 path keys on `decl.isGetter` (true → Computed). The M4 path keys on `!decl.isGetter && !decl.isSetter && carriesSolidEffect` (→ Effect). Both branches share the `_collectAnnotatedClasses` member walk in `builder.dart`.
+- **Imports already future-proofed.** SPEC Section 9 (line ~596) already lists `Effect` on the canonical `flutter_solidart` import-add list as future-proofing — the M1-08 rule fires unchanged.
+- **Disposal in source-declaration order, reversed in `dispose()`.** Effects are appended to the unified ordered name list in `signal_emitter.dart:emitDispose`. Reverse-declaration order naturally puts the Effect (declared after the Signals/Computeds it reads) ahead of the Signal/Computed in the dispose body — the same algorithm Computed already exercises.
+- **Cross-cutting reactive rules apply uniformly.** Sections 5.1, 5.2, 5.4, 5.5, 6.0, 6.2, 6.4 all hold inside Effect bodies with no amendment. Effect bodies are reactive code in the same sense as `Computed` bodies and `build` bodies.
+- **Untracked-callback context inside Effect bodies.** An Effect body that itself constructs widgets with `onPressed: () => …` callbacks still applies Section 6.2 untracked-context detection inside those callbacks. Effect-body reads are tracked by default (the Effect IS the subscription); the Section 6.4 `.untracked` extension still works as a per-read opt-out.
+
+## Exit criteria
+
+- All M4-01 through M4-08 items marked DONE.
+- `dart test packages/solid_generator/` passes: every M4 golden + every prior golden + every prior rejection test.
+- `flutter test example/` passes: M4-07 widget test + every prior widget test.
+- `dart analyze --fatal-infos` and `dart analyze packages/solid_generator/test/golden/outputs/` both report zero issues.
+- `dart format --set-exit-if-changed .` reports zero diff.
+- `m1_15_effect` rejection case removed from `packages/solid_generator/test/rejections/m1_15_non_m1_annotations_test.dart` (M4-06).
+- `_reservedAnnotations` map in `reserved_annotation_validator.dart` no longer lists `'SolidEffect'` (M4-06).
+- Reviewer rubric passes on each M4 PR.
+- After M4 is green: `@SolidEffect` is the second fully-shipped annotation; SPEC Section 13 lists only `@SolidQuery` and `@SolidEnvironment` as deferred.


### PR DESCRIPTION
## Summary

- Extend SPEC Section 3.4 and 4.7 to define `@SolidEffect` annotation: declares reactive side effects on instance methods whose bodies read reactive declarations
- Add M4-01 through M4-08 TODOs in TODOS.md with detailed test requirements, file changes, expected inputs/outputs, and acceptance criteria
- Create feature plan in `plans/features/m4-effect.md` outlining the TODO sequence, cross-cutting concerns, and exit criteria
- Update SPEC Section 13 and throughout to demote `@SolidEffect` from reserved-annotation list (moves from later-milestones to M4 scope)
- Clarify that M1 + M4 fully specify the current SPEC; `@SolidQuery` and `@SolidEnvironment` remain deferred to future revisions

## Testing

- SPEC document is internally consistent across all sections that reference `@SolidEffect` (3.4, 4.7, 5, 9, 10, 13)
- TODOS.md follows the established format and contains all 8 subtasks with clear dependencies and acceptance criteria
- Implementation plan is aligned with prior milestones (M1, M2, M3) in terms of infrastructure reuse and testing patterns
- No changes to implementation code (specification and planning only)