### PR TITLE
Implement M4-01: @SolidEffect method → Effect

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1359,7 +1359,9 @@ class _CounterState extends State<Counter> {
 
 **Dependencies:** M2-01 (body-rewrite pipeline + `MethodDeclaration` collection path), M2-01b (block-body precedent).
 
-**Status:** TODO
+**Implementation note:** M4-01 also pulled in M4-06's three substeps because `validateReservedAnnotations` runs before the lowering pipeline — without removing `'SolidEffect'` from `_reservedAnnotations` and migrating the `m1_15_effect` rejection case in the same PR, the M4-01 golden could never go green. The bootstrap deviation is documented inline in `reserved_annotation_validator.dart` and in the M4-06 entry below. Zero-deps Effect rejection (SPEC §3.4 / TODOS M4-05) also landed here in `_rewriteEffectBody` so M4-05 is purely a regression-test PR.
+
+**Status:** DONE
 
 ---
 
@@ -1483,7 +1485,9 @@ class _CounterState extends State<Counter> {
 
 **Dependencies:** M4-01, M4-02, M4-03, M4-04, M4-05.
 
-**Status:** TODO
+**Implementation note:** All three substeps were pulled into M4-01 because `validateReservedAnnotations` (`builder.dart`) runs before `_collectAnnotatedClasses`; without trimming the reserved list and migrating the `m1_15_effect` case in the same PR, the M4-01 golden test could never go green. The dependency arrow above is therefore retroactive — M4-06 shipped *with* M4-01.
+
+**Status:** DONE
 
 ---
 

--- a/packages/solid_annotations/lib/src/annotations.dart
+++ b/packages/solid_annotations/lib/src/annotations.dart
@@ -16,12 +16,20 @@ class SolidState {
 }
 
 /// {@template SolidAnnotations.SolidEffect}
-/// Reserved. Full contract deferred to a later SPEC revision;
-/// see SPEC Section 3.2.
+/// Marks an instance method as a reactive side effect. See SPEC Section 3.4.
+///
+/// The annotated method must declare a `void` return type and take no
+/// parameters; its body must read at least one reactive declaration. The
+/// generator lowers it to a `late final <name> = Effect(() { … }, name: '…')`
+/// field that re-runs whenever any read reactive declaration changes.
 /// {@endtemplate}
+@Target({TargetKind.method})
 class SolidEffect {
   /// {@macro SolidAnnotations.SolidEffect}
-  const SolidEffect();
+  const SolidEffect({this.name});
+
+  /// Optional debug name; defaults to the annotated method's identifier.
+  final String? name;
 }
 
 /// {@template SolidAnnotations.SolidQuery}

--- a/packages/solid_generator/lib/builder.dart
+++ b/packages/solid_generator/lib/builder.dart
@@ -6,6 +6,7 @@ import 'package:dart_style/dart_style.dart';
 
 import 'package:solid_generator/src/annotation_reader.dart';
 import 'package:solid_generator/src/class_kind.dart';
+import 'package:solid_generator/src/effect_model.dart';
 import 'package:solid_generator/src/field_model.dart';
 import 'package:solid_generator/src/getter_model.dart';
 import 'package:solid_generator/src/import_rewriter.dart';
@@ -70,9 +71,10 @@ class _SolidBuilder implements Builder {
       );
     }
 
-    // SPEC §3.2 + §13: reject reserved annotations (`@SolidEffect`,
-    // `@SolidQuery`, `@SolidEnvironment`) before any other pass so the user
-    // gets a fail-fast error instead of a silent passthrough.
+    // SPEC §3.2 + §13: reject reserved annotations (`@SolidQuery`,
+    // `@SolidEnvironment`) before any other pass so the user gets a fail-fast
+    // error instead of a silent passthrough. `@SolidEffect` shipped in M4 and
+    // is no longer reserved.
     validateReservedAnnotations(parsed.unit);
     // SPEC §3.1 invalid-target guard. Must run before
     // `_collectAnnotatedClasses`; rejected targets (final / const / static
@@ -80,10 +82,13 @@ class _SolidBuilder implements Builder {
     validateSolidStateTargets(parsed.unit);
 
     final annotatedClasses = _collectAnnotatedClasses(parsed.unit, source);
-    if (annotatedClasses.every((c) => c.fields.isEmpty && c.getters.isEmpty)) {
-      // Hint matched, but no `@SolidState` field or getter resolved — the
-      // file likely contains a comment or string literal mentioning `@Solid…`.
-      // Reserved annotations are caught upstream.
+    if (annotatedClasses.every(
+      (c) => c.fields.isEmpty && c.getters.isEmpty && c.effects.isEmpty,
+    )) {
+      // Hint matched, but no `@SolidState` field/getter or `@SolidEffect`
+      // method resolved — the file likely contains a comment or string
+      // literal mentioning `@Solid…`. Reserved annotations are caught
+      // upstream.
       await buildStep.writeAsString(outputId, source);
       return;
     }
@@ -93,27 +98,33 @@ class _SolidBuilder implements Builder {
   }
 }
 
-/// One class declaration paired with the `@SolidState` fields and getters it
-/// contains.
+/// One class declaration paired with the `@SolidState` fields and getters
+/// and `@SolidEffect` methods it contains.
 ///
-/// Both lists are empty when the class exists in the source but has no
-/// `@SolidState` annotations; such classes are passed through verbatim.
+/// All three lists are empty when the class exists in the source but has no
+/// reactive annotations; such classes are passed through verbatim.
 class _AnnotatedClass {
-  _AnnotatedClass(this.decl, this.fields, this.getters);
+  _AnnotatedClass({
+    required this.decl,
+    required this.fields,
+    required this.getters,
+    required this.effects,
+  });
   final ClassDeclaration decl;
   final List<FieldModel> fields;
   final List<GetterModel> getters;
+  final List<EffectModel> effects;
 }
 
 /// Walks [unit] once and returns every class paired with its `@SolidState`
-/// fields and getters. Replaces an earlier double-walk (presence check +
-/// collection) with a single traversal per file.
+/// fields and getters and `@SolidEffect` methods. Replaces an earlier
+/// double-walk (presence check + collection) with a single traversal per
+/// file.
 ///
-/// Fields are read first so the getter body's reactive-name set already
-/// contains every field of the same class; a getter referencing a sibling
-/// `@SolidState` field gets its `.value` rewrite applied per SPEC §5.1.
-/// Getters then enter the name set in source order so a later getter can
-/// also reference an earlier annotated getter.
+/// Fields are read first so a getter or effect body's reactive-name set
+/// already contains every field of the same class; getters then enter the
+/// name set in source order so a later getter or effect can reference an
+/// earlier annotated getter (SPEC §5.1).
 List<_AnnotatedClass> _collectAnnotatedClasses(
   CompilationUnit unit,
   String source,
@@ -123,6 +134,7 @@ List<_AnnotatedClass> _collectAnnotatedClasses(
     if (decl is! ClassDeclaration) continue;
     final fields = <FieldModel>[];
     final getters = <GetterModel>[];
+    final effects = <EffectModel>[];
     final reactiveNames = <String>{};
     for (final member in decl.members) {
       if (member is FieldDeclaration) {
@@ -134,14 +146,30 @@ List<_AnnotatedClass> _collectAnnotatedClasses(
         continue;
       }
       if (member is MethodDeclaration) {
-        final model = readSolidStateGetter(member, reactiveNames, source);
-        if (model != null) {
-          getters.add(model);
-          reactiveNames.add(model.getterName);
+        final getter = readSolidStateGetter(member, reactiveNames, source);
+        if (getter != null) {
+          getters.add(getter);
+          reactiveNames.add(getter.getterName);
+          continue;
+        }
+        // Effect names are intentionally NOT added to `reactiveNames`:
+        // `@SolidEffect` lowers to a `void`-returning `Effect` with no
+        // observable `.value`, so a sibling effect/getter referencing it
+        // must not get a `.value` rewrite.
+        final effect = readSolidEffectMethod(member, reactiveNames, source);
+        if (effect != null) {
+          effects.add(effect);
         }
       }
     }
-    result.add(_AnnotatedClass(decl, fields, getters));
+    result.add(
+      _AnnotatedClass(
+        decl: decl,
+        fields: fields,
+        getters: getters,
+        effects: effects,
+      ),
+    );
   }
   return result;
 }
@@ -158,13 +186,13 @@ String _renderOutput(
   String source,
 ) {
   final results = annotatedClasses.map((c) {
-    if (c.fields.isEmpty && c.getters.isEmpty) {
+    if (c.fields.isEmpty && c.getters.isEmpty && c.effects.isEmpty) {
       return (
         text: source.substring(c.decl.offset, c.decl.end),
         solidartNames: const <String>{},
       );
     }
-    return _rewriteClass(c.decl, c.fields, c.getters, source);
+    return _rewriteClass(c.decl, c.fields, c.getters, c.effects, source);
   }).toList();
 
   final imports = computeOutputImports(
@@ -185,16 +213,17 @@ RewriteResult _rewriteClass(
   ClassDeclaration decl,
   List<FieldModel> fields,
   List<GetterModel> getters,
+  List<EffectModel> effects,
   String source,
 ) {
   final kind = classKindOf(decl);
   switch (kind) {
     case ClassKind.statelessWidget:
-      return rewriteStatelessWidget(decl, fields, getters, source);
+      return rewriteStatelessWidget(decl, fields, getters, effects, source);
     case ClassKind.plainClass:
-      return rewritePlainClass(decl, fields, getters, source);
+      return rewritePlainClass(decl, fields, getters, effects, source);
     case ClassKind.stateClass:
-      return rewriteStateClass(decl, fields, getters, source);
+      return rewriteStateClass(decl, fields, getters, effects, source);
     case ClassKind.statefulWidget:
       throw CodeGenerationError(
         'class-kind $kind is not supported yet '

--- a/packages/solid_generator/lib/src/annotation_reader.dart
+++ b/packages/solid_generator/lib/src/annotation_reader.dart
@@ -1,10 +1,11 @@
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:solid_generator/src/effect_model.dart';
 import 'package:solid_generator/src/field_model.dart';
 import 'package:solid_generator/src/getter_model.dart';
 import 'package:solid_generator/src/transformation_error.dart';
 import 'package:solid_generator/src/value_rewriter.dart';
 
-/// Name of the annotation class this reader looks for.
+/// Name of the `@SolidState` annotation class.
 ///
 /// Matching is textual on the unresolved AST (see SPEC Section 5.4 — type
 /// resolution is required for `.value` rewriting, but annotation detection is
@@ -15,13 +16,17 @@ import 'package:solid_generator/src/value_rewriter.dart';
 /// rejections) can match the same identifier on non-field declarations.
 const String solidStateName = 'SolidState';
 
+/// Name of the `@SolidEffect` annotation class. Same matching contract as
+/// [solidStateName] (textual on unresolved AST).
+const String solidEffectName = 'SolidEffect';
+
 /// Reads a `@SolidState(...)` annotation on [decl] and returns a [FieldModel].
 ///
 /// Returns `null` if [decl] carries no `@SolidState` annotation. The raw
 /// [source] is passed in so each string member of the returned [FieldModel]
 /// can be extracted verbatim via `source.substring(offset, end)`.
 FieldModel? readSolidStateField(FieldDeclaration decl, String source) {
-  final annotation = findSolidStateAnnotation(decl.metadata);
+  final annotation = findAnnotationByName(solidStateName, decl.metadata);
   if (annotation == null) return null;
 
   final varList = decl.fields;
@@ -64,7 +69,7 @@ GetterModel? readSolidStateGetter(
   String source,
 ) {
   if (!decl.isGetter || decl.isStatic) return null;
-  final annotation = findSolidStateAnnotation(decl.metadata);
+  final annotation = findAnnotationByName(solidStateName, decl.metadata);
   if (annotation == null) return null;
 
   final returnType = decl.returnType;
@@ -74,32 +79,18 @@ GetterModel? readSolidStateGetter(
 
   final body = decl.body;
   final getterName = decl.name.lexeme;
-  final String bodyText;
-  final bool isBlockBody;
-  if (body is ExpressionFunctionBody) {
-    bodyText = _rewriteGetterBody(
-      body.expression,
-      reactiveFields,
-      source,
-      getterName,
-    );
-    isBlockBody = false;
-  } else if (body is BlockFunctionBody) {
-    bodyText = _rewriteGetterBody(
-      body.block,
-      reactiveFields,
-      source,
-      getterName,
-    );
-    isBlockBody = true;
-  } else {
-    throw CodeGenerationError(
-      '@SolidState getter must have an expression body (=> ...) or a '
-      'block body ({ ... }); abstract and native bodies are not supported',
-      null,
-      getterName,
-    );
-  }
+  final (bodyText, isBlockBody) = _readReactiveBody(
+    body,
+    reactiveFields,
+    source,
+    memberName: getterName,
+    emptyDepsError:
+        "getter '$getterName' has no reactive dependencies; "
+        'use `final` or a plain getter instead of `@SolidState`',
+    unsupportedBodyError:
+        '@SolidState getter must have an expression body (=> ...) or a '
+        'block body ({ ... }); abstract and native bodies are not supported',
+  );
 
   return GetterModel(
     getterName: getterName,
@@ -110,46 +101,104 @@ GetterModel? readSolidStateGetter(
   );
 }
 
-/// Returns the source range covered by [node], with SPEC §5.1 reactive-read
-/// rewrites applied to every identifier in [reactiveFields]. Used for both
-/// the expression-body (`Expression`) and block-body (`Block`) getter
-/// shapes; the resulting text is spliced into the `Computed<T>(() ...)`
-/// closure by the emitter. `trackedReadOffsets` are intentionally ignored —
-/// SignalBuilder placement is a `build()` concern, not a `Computed` body
-/// concern.
+/// Returns the rewritten body text and whether it came from a block body.
+/// Shared between `readSolidStateGetter` and `readSolidEffectMethod`: both
+/// readers discriminate `ExpressionFunctionBody` vs `BlockFunctionBody`, run
+/// the SPEC §5.1 `.value` rewrite, and reject zero-deps and abstract/native
+/// bodies. Only the error wording differs (SPEC §4.5 vs §3.4) — pass it in.
 ///
-/// Throws [CodeGenerationError] for SPEC §4.5: a `Computed` with zero
-/// reactive dependencies would never invalidate, so an empty edit set is
-/// surfaced as a build error instead of a useless `Computed`.
-String _rewriteGetterBody(
-  AstNode node,
+/// `trackedReadOffsets` are intentionally ignored — SignalBuilder placement
+/// is a `build()` concern, not a `Computed`/`Effect` body concern.
+(String bodyText, bool isBlockBody) _readReactiveBody(
+  FunctionBody body,
   Set<String> reactiveFields,
-  String source,
-  String getterName,
-) {
+  String source, {
+  required String memberName,
+  required String emptyDepsError,
+  required String unsupportedBodyError,
+}) {
+  final AstNode node;
+  final bool isBlockBody;
+  if (body is ExpressionFunctionBody) {
+    node = body.expression;
+    isBlockBody = false;
+  } else if (body is BlockFunctionBody) {
+    node = body.block;
+    isBlockBody = true;
+  } else {
+    throw CodeGenerationError(unsupportedBodyError, null, memberName);
+  }
   final result = collectValueEdits(node, reactiveFields, source);
   if (result.edits.isEmpty) {
-    throw CodeGenerationError(
-      "getter '$getterName' has no reactive dependencies; "
-      'use `final` or a plain getter instead of `@SolidState`',
-      null,
-      getterName,
-    );
+    throw CodeGenerationError(emptyDepsError, null, memberName);
   }
-  return applyEditsToRange(
+  final bodyText = applyEditsToRange(
     source.substring(node.offset, node.end),
     result.edits,
     node.offset,
   );
+  return (bodyText, isBlockBody);
 }
 
-/// Returns the first `@SolidState(...)` annotation in [metadata], or `null`.
+/// Reads a `@SolidEffect(...)` annotation on the method [decl] and returns an
+/// [EffectModel]. Returns `null` when [decl] is not an `@SolidEffect`-bearing
+/// instance method; getters, setters, and static methods are filtered out
+/// here defensively (the M4-04 target validator rejects them with a clearer
+/// error before this reader runs).
 ///
-/// Package-public so the target validator (SPEC §3.1 rejections) can reuse
-/// the same matcher on `MethodDeclaration` and `FunctionDeclaration` metadata.
-Annotation? findSolidStateAnnotation(NodeList<Annotation> metadata) {
+/// The method body is rewritten in place per SPEC §5.1: any reference to a
+/// name in [reactiveFields] receives `.value`. Both expression-body
+/// (`void m() => <expr>;`) and block-body (`void m() { ... }`) shapes are
+/// supported per SPEC §4.7. Other body kinds (abstract / native) are
+/// rejected with a [CodeGenerationError].
+///
+/// SPEC §3.4 reactive-deps requirement: an Effect with zero reactive
+/// dependencies is rejected with the SPEC-defined message
+/// `"effect '<name>' has no reactive dependencies"`. M4-05 pins this
+/// behavior with a dedicated rejection test.
+EffectModel? readSolidEffectMethod(
+  MethodDeclaration decl,
+  Set<String> reactiveFields,
+  String source,
+) {
+  if (decl.isGetter || decl.isSetter || decl.isStatic) return null;
+  final annotation = findAnnotationByName(solidEffectName, decl.metadata);
+  if (annotation == null) return null;
+
+  final methodName = decl.name.lexeme;
+  final (bodyText, isBlockBody) = _readReactiveBody(
+    decl.body,
+    reactiveFields,
+    source,
+    memberName: methodName,
+    emptyDepsError:
+        "effect '$methodName' has no reactive dependencies; "
+        'use a regular method or call it once explicitly instead of '
+        '`@SolidEffect`',
+    unsupportedBodyError:
+        '@SolidEffect method must have an expression body (=> ...) or a '
+        'block body ({ ... }); abstract and native bodies are not supported',
+  );
+
+  return EffectModel(
+    methodName: methodName,
+    bodyText: bodyText,
+    isBlockBody: isBlockBody,
+    annotationName: extractNameArgument(annotation),
+  );
+}
+
+/// Returns the first `@<className>(...)` annotation in [metadata], or `null`.
+///
+/// Package-public so the target validator (SPEC §3.1 / §3.4 rejections) can
+/// reuse the same matcher on every declaration kind. Use the [solidStateName]
+/// or [solidEffectName] constants for [className] rather than bare strings.
+Annotation? findAnnotationByName(
+  String className,
+  NodeList<Annotation> metadata,
+) {
   for (final ann in metadata) {
-    if (ann.name.name == solidStateName) return ann;
+    if (ann.name.name == className) return ann;
   }
   return null;
 }

--- a/packages/solid_generator/lib/src/effect_model.dart
+++ b/packages/solid_generator/lib/src/effect_model.dart
@@ -1,0 +1,77 @@
+import 'package:meta/meta.dart';
+import 'package:solid_generator/src/transformation_error.dart';
+
+/// Parsed description of one `@SolidEffect`-annotated method.
+///
+/// Populated by `annotation_reader.dart` from unresolved AST and consumed by
+/// the rewriters (currently `stateless_rewriter.dart`). All string members are
+/// the raw source text of the corresponding AST node — except [bodyText],
+/// which is the source-substring of the method body with the SPEC §5.1
+/// `.value` rewrites already applied so the emitter can splice it directly
+/// into the `Effect(...)` closure.
+///
+/// Mirrors `GetterModel` for the parallel `@SolidState` getter → `Computed`
+/// lowering (SPEC §4.5). The two models share an identical body-rewrite
+/// contract; the only differences are (a) effects have no return type, and
+/// (b) the emitted constructor is `Effect(...)` instead of `Computed<T>(...)`.
+@immutable
+class EffectModel {
+  /// Creates an [EffectModel] describing an annotated method.
+  const EffectModel({
+    required this.methodName,
+    required this.bodyText,
+    required this.isBlockBody,
+    required this.annotationName,
+  });
+
+  /// Declared identifier of the method (e.g. `'logCounter'`).
+  final String methodName;
+
+  /// Source text of the method's body with the SPEC §5.1 reactive-read
+  /// rewrite already applied. The shape depends on [isBlockBody]:
+  ///
+  /// * **Expression body** (SPEC §4.7, [isBlockBody] is `false`): the
+  ///   rewritten expression text alone — for an input
+  ///   `void logCounter() => print(counter);` where `counter` is a sibling
+  ///   `@SolidState` field, this is the string `'print(counter.value)'`. The
+  ///   emitter wraps it in `() => <text>`.
+  /// * **Block body** (SPEC §4.7, [isBlockBody] is `true`): the rewritten
+  ///   block including its braces — for an input
+  ///   `void logCounter() { print('Counter: $counter'); }`,
+  ///   this is the string `"{ print('Counter: \${counter.value}'); }"`.
+  ///   The emitter wraps it in `() <text>`.
+  final String bodyText;
+
+  /// True when the source method has a block body (`void m() { ... }`); false
+  /// for an expression body (`void m() => <expr>;`). Determines how the
+  /// emitter shapes the closure passed to `Effect(...)`.
+  final bool isBlockBody;
+
+  /// Value of the `name:` argument on `@SolidEffect(name: '…')`, or `null` if
+  /// the annotation had no `name:` argument (SPEC §4.7).
+  final String? annotationName;
+}
+
+/// Throws [CodeGenerationError] when [solidEffects] is non-empty, naming the
+/// first offending method and the [classKindLabel] (`'plain class'`,
+/// `'existing State<X> subclass'`, …) of the rewriter that has not yet
+/// implemented method→`Effect` lowering.
+///
+/// Mirrors `rejectIfGettersNotYetSupported` in `getter_model.dart`: the
+/// message template lives in one place so two rewriters' "not yet supported"
+/// errors can never drift. The StatelessWidget path lands in M4-01; the
+/// `State<X>` and plain-class paths land in M4-08.
+void rejectIfEffectsNotYetSupported(
+  List<EffectModel> solidEffects,
+  String classKindLabel,
+  String className,
+) {
+  if (solidEffects.isEmpty) return;
+  throw CodeGenerationError(
+    '@SolidEffect on $classKindLabel is not yet supported '
+    '(will land in M4-08); '
+    'offending method: ${solidEffects.first.methodName}',
+    null,
+    className,
+  );
+}

--- a/packages/solid_generator/lib/src/plain_class_rewriter.dart
+++ b/packages/solid_generator/lib/src/plain_class_rewriter.dart
@@ -1,4 +1,5 @@
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:solid_generator/src/effect_model.dart';
 import 'package:solid_generator/src/field_model.dart';
 import 'package:solid_generator/src/getter_model.dart';
 import 'package:solid_generator/src/import_rewriter.dart';
@@ -27,12 +28,17 @@ RewriteResult rewritePlainClass(
   ClassDeclaration classDecl,
   List<FieldModel> solidFields,
   List<GetterModel> solidGetters,
+  List<EffectModel> solidEffects,
   String source,
 ) {
   final className = classDecl.name.lexeme;
   // M2-01 ships getter→Computed for `StatelessWidget` only; reject here so
   // M1-14's valid-target pass isn't silently undone.
   rejectIfGettersNotYetSupported(solidGetters, 'plain class', className);
+  // M4-01 ships method→Effect for `StatelessWidget` only; M4-08 lifts this
+  // guard for plain-class lowering. Reject here so the M4-04 valid-target
+  // pass isn't silently undone.
+  rejectIfEffectsNotYetSupported(solidEffects, 'plain class', className);
   _checkUnsupportedMembers(classDecl, solidFields, className);
 
   final signalFields = solidFields.map(emitSignalField).join('\n');

--- a/packages/solid_generator/lib/src/reserved_annotation_validator.dart
+++ b/packages/solid_generator/lib/src/reserved_annotation_validator.dart
@@ -6,15 +6,19 @@ import 'package:solid_generator/src/transformation_error.dart';
 /// contract is deferred to a later SPEC revision (SPEC §3.2 + §13). Detecting
 /// any use causes the build to fail before transformation. The map value is
 /// the violation code stamped onto [ValidationError.violationType].
+///
+/// `SolidEffect` is no longer in this list as of M4-01: the annotation now
+/// lowers to `Effect(() { … })` per SPEC §4.7. Only the still-deferred
+/// `@SolidQuery` and `@SolidEnvironment` remain reserved; both ship in
+/// later milestones before v2 release (SPEC §13).
 const Map<String, String> _reservedAnnotations = {
-  'SolidEffect': 'RESERVED_ANNOTATION_SOLID_EFFECT',
   'SolidQuery': 'RESERVED_ANNOTATION_SOLID_QUERY',
   'SolidEnvironment': 'RESERVED_ANNOTATION_SOLID_ENVIRONMENT',
 };
 
-/// SPEC §3.2 + §13 build-time guard: reject any `@SolidEffect`,
-/// `@SolidQuery`, or `@SolidEnvironment` use with a clear error that names
-/// the annotation and quotes the SPEC §3.2 phrase verbatim.
+/// SPEC §3.2 + §13 build-time guard: reject any `@SolidQuery` or
+/// `@SolidEnvironment` use with a clear error that names the annotation and
+/// quotes the SPEC §3.2 phrase verbatim.
 ///
 /// Runs before transformation so users learn at build time that they're
 /// using a not-yet-implemented annotation, instead of debugging missing

--- a/packages/solid_generator/lib/src/signal_emitter.dart
+++ b/packages/solid_generator/lib/src/signal_emitter.dart
@@ -1,3 +1,4 @@
+import 'package:solid_generator/src/effect_model.dart';
 import 'package:solid_generator/src/field_model.dart';
 import 'package:solid_generator/src/getter_model.dart';
 
@@ -54,14 +55,30 @@ String emitComputedField(GetterModel g) {
   return '  late final ${g.getterName} = $ctor;';
 }
 
+/// Emits one `late final <name> = Effect(<closure>, name: '<debug>');` line
+/// per SPEC §4.7. Mirrors [emitComputedField] (same closure shape, same
+/// `late final` rationale, same body-text contract); the only differences
+/// are the absent type parameter and the `Effect` ctor.
+///
+/// `Effect(...)` takes a zero-param `void Function()` callback per the
+/// upstream `flutter_solidart` API and returns an `Effect` object whose
+/// `.dispose()` joins the unified disposal list emitted by [emitDispose].
+String emitEffectField(EffectModel e) {
+  final debugName = e.annotationName ?? e.methodName;
+  final closure = e.isBlockBody ? '() ${e.bodyText}' : '() => ${e.bodyText}';
+  final ctor = "Effect($closure, name: '$debugName')";
+  return '  late final ${e.methodName} = $ctor;';
+}
+
 /// Emits a `dispose()` method disposing every name in
 /// [disposeNamesInDeclarationOrder] in **reverse declaration order** (SPEC
 /// §10).
 ///
 /// The list is the unified, source-ordered sequence of every reactive
-/// declaration (Signal field + Computed getter) on the owning class.
-/// Reverse-iterating it puts dependents (a `Computed` declared after the
-/// `Signal`s it reads) ahead of their dependencies in the dispose body.
+/// declaration (Signal field + Computed getter + Effect method) on the owning
+/// class. Reverse-iterating it puts dependents (an `Effect` or `Computed`
+/// declared after the `Signal`s it reads) ahead of their dependencies in the
+/// dispose body.
 ///
 /// [inheritsDispose] is `true` when the owning class's supertype chain
 /// contains a `dispose()` method (e.g. `State<T>`, `ChangeNotifier`); the

--- a/packages/solid_generator/lib/src/state_class_rewriter.dart
+++ b/packages/solid_generator/lib/src/state_class_rewriter.dart
@@ -1,5 +1,6 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:solid_generator/src/build_rewriter.dart';
+import 'package:solid_generator/src/effect_model.dart';
 import 'package:solid_generator/src/field_model.dart';
 import 'package:solid_generator/src/getter_model.dart';
 import 'package:solid_generator/src/import_rewriter.dart';
@@ -26,6 +27,7 @@ RewriteResult rewriteStateClass(
   ClassDeclaration classDecl,
   List<FieldModel> solidFields,
   List<GetterModel> solidGetters,
+  List<EffectModel> solidEffects,
   String source,
 ) {
   final className = classDecl.name.lexeme;
@@ -35,6 +37,14 @@ RewriteResult rewriteStateClass(
   // pass isn't silently undone here.
   rejectIfGettersNotYetSupported(
     solidGetters,
+    'existing State<X> subclass',
+    className,
+  );
+  // M4-01 ships method→Effect for `StatelessWidget` only; M4-08 lifts this
+  // guard for in-place State<X> lowering. Reject here so the M4-04 valid-
+  // target pass isn't silently undone.
+  rejectIfEffectsNotYetSupported(
+    solidEffects,
     'existing State<X> subclass',
     className,
   );

--- a/packages/solid_generator/lib/src/stateless_rewriter.dart
+++ b/packages/solid_generator/lib/src/stateless_rewriter.dart
@@ -1,15 +1,17 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:solid_generator/src/build_rewriter.dart';
+import 'package:solid_generator/src/effect_model.dart';
 import 'package:solid_generator/src/field_model.dart';
 import 'package:solid_generator/src/getter_model.dart';
 import 'package:solid_generator/src/import_rewriter.dart';
 import 'package:solid_generator/src/signal_emitter.dart';
 import 'package:solid_generator/src/transformation_error.dart';
 
-/// Rewrites a `StatelessWidget` class containing `@SolidState` fields and/or
-/// `@SolidState` getters as a `StatefulWidget` + `State<X>` pair. See SPEC
-/// §8.1 for the full field-partition and constructor-preservation contract;
-/// SPEC §4.5 for the getter→`Computed` lowering.
+/// Rewrites a `StatelessWidget` class containing `@SolidState` fields,
+/// `@SolidState` getters, and/or `@SolidEffect` methods as a
+/// `StatefulWidget` + `State<X>` pair. See SPEC §8.1 for the full
+/// field-partition and constructor-preservation contract; SPEC §4.5 for the
+/// getter→`Computed` lowering; SPEC §4.7 for the method→`Effect` lowering.
 ///
 /// The emitted string is syntactically valid Dart but is not guaranteed to be
 /// pretty-printed — run through `DartFormatter` before writing.
@@ -17,6 +19,7 @@ RewriteResult rewriteStatelessWidget(
   ClassDeclaration classDecl,
   List<FieldModel> solidFields,
   List<GetterModel> solidGetters,
+  List<EffectModel> solidEffects,
   String source,
 ) {
   final className = classDecl.name.lexeme;
@@ -45,6 +48,7 @@ RewriteResult rewriteStatelessWidget(
     classDecl,
     solidFields,
     solidGetters,
+    solidEffects,
   );
 
   final widgetClass = _emitWidgetClass(
@@ -64,6 +68,7 @@ RewriteResult rewriteStatelessWidget(
 
   final solidartNames = <String>{'Signal', 'SignalBuilder'};
   if (solidGetters.isNotEmpty) solidartNames.add('Computed');
+  if (solidEffects.isNotEmpty) solidartNames.add('Effect');
 
   return (
     text: '$widgetClass\n\n$stateClass\n',
@@ -72,20 +77,22 @@ RewriteResult rewriteStatelessWidget(
 }
 
 /// Returns the source-ordered emission of every reactive declaration on
-/// [classDecl] (Signal field + Computed getter) as a single 2-space-indented
-/// block, plus the declaration-order list of dispose names that pairs with
-/// it. Source order — not field-then-getter — is the contract a `Computed`
-/// depends on: it must reference fields declared before it, so the emitted
-/// `late final` Computed must appear after the `Signal`s it reads in the
-/// rewritten State class.
+/// [classDecl] (Signal field + Computed getter + Effect method) as a single
+/// 2-space-indented block, plus the declaration-order list of dispose names
+/// that pairs with it. Source order is the contract that `Computed` and
+/// `Effect` depend on: each must reference declarations defined before it,
+/// so the emitted `late final` lines must appear after the declarations they
+/// read in the rewritten State class.
 ({String fieldsText, List<String> disposeNamesInDeclarationOrder})
 _emitReactiveBlock(
   ClassDeclaration classDecl,
   List<FieldModel> solidFields,
   List<GetterModel> solidGetters,
+  List<EffectModel> solidEffects,
 ) {
   final fieldByName = {for (final f in solidFields) f.fieldName: f};
   final getterByName = {for (final g in solidGetters) g.getterName: g};
+  final effectByName = {for (final e in solidEffects) e.methodName: e};
   final lines = <String>[];
   final disposeNames = <String>[];
 
@@ -99,12 +106,20 @@ _emitReactiveBlock(
       }
       continue;
     }
-    if (member is MethodDeclaration && member.isGetter) {
+    if (member is MethodDeclaration) {
       final name = member.name.lexeme;
-      final g = getterByName[name];
-      if (g != null) {
-        lines.add(emitComputedField(g));
-        disposeNames.add(g.getterName);
+      if (member.isGetter) {
+        final g = getterByName[name];
+        if (g != null) {
+          lines.add(emitComputedField(g));
+          disposeNames.add(g.getterName);
+        }
+      } else if (!member.isSetter) {
+        final e = effectByName[name];
+        if (e != null) {
+          lines.add(emitEffectField(e));
+          disposeNames.add(e.methodName);
+        }
       }
     }
   }

--- a/packages/solid_generator/lib/src/target_validator.dart
+++ b/packages/solid_generator/lib/src/target_validator.dart
@@ -42,7 +42,7 @@ Never _reject(String kind, String location) {
 /// `static`. Instance non-final non-const non-static fields fall through
 /// silently — they are the canonical SPEC 3.1 valid target.
 void _validateField(FieldDeclaration field, String className) {
-  if (findSolidStateAnnotation(field.metadata) == null) return;
+  if (findAnnotationByName(solidStateName, field.metadata) == null) return;
   final varList = field.fields;
   final fieldName = varList.variables.first.name.lexeme;
   final location = '$className.$fieldName';
@@ -57,7 +57,7 @@ void _validateField(FieldDeclaration field, String className) {
 /// Instance getters fall through — they are valid SPEC 3.1 targets and M2
 /// will emit `Computed`.
 void _validateMethod(MethodDeclaration method, String className) {
-  if (findSolidStateAnnotation(method.metadata) == null) return;
+  if (findAnnotationByName(solidStateName, method.metadata) == null) return;
   final location = '$className.${method.name.lexeme}';
   if (method.isSetter) _reject('setter', location);
   if (method.isGetter && method.isStatic) _reject('static getter', location);
@@ -70,11 +70,11 @@ void _validateMethod(MethodDeclaration method, String className) {
 /// reusing the SETTER / METHOD codes).
 void _validateTopLevel(CompilationUnitMember decl) {
   if (decl is TopLevelVariableDeclaration &&
-      findSolidStateAnnotation(decl.metadata) != null) {
+      findAnnotationByName(solidStateName, decl.metadata) != null) {
     _reject('top-level variable', decl.variables.variables.first.name.lexeme);
   }
   if (decl is FunctionDeclaration &&
-      findSolidStateAnnotation(decl.metadata) != null) {
+      findAnnotationByName(solidStateName, decl.metadata) != null) {
     final name = decl.name.lexeme;
     if (decl.isGetter) _reject('top-level getter', name);
     if (decl.isSetter) _reject('setter', name);

--- a/packages/solid_generator/test/golden/inputs/m1_15_effect.dart
+++ b/packages/solid_generator/test/golden/inputs/m1_15_effect.dart
@@ -1,6 +1,0 @@
-import 'package:solid_annotations/solid_annotations.dart';
-
-class Foo {
-  @SolidEffect()
-  void side() {}
-}

--- a/packages/solid_generator/test/golden/inputs/m4_01_simple_effect_with_deps.dart
+++ b/packages/solid_generator/test/golden/inputs/m4_01_simple_effect_with_deps.dart
@@ -1,0 +1,20 @@
+// SPEC §3.4 / §4.7 use `print` as the canonical Effect side-effect example.
+// ignore_for_file: avoid_print
+
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+
+class Counter extends StatelessWidget {
+  Counter({super.key});
+
+  @SolidState()
+  int counter = 0;
+
+  @SolidEffect()
+  void logCounter() {
+    print('Counter changed: $counter');
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/golden/outputs/m4_01_simple_effect_with_deps.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m4_01_simple_effect_with_deps.g.dart
@@ -1,0 +1,27 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class Counter extends StatefulWidget {
+  Counter({super.key});
+
+  @override
+  State<Counter> createState() => _CounterState();
+}
+
+class _CounterState extends State<Counter> {
+  final counter = Signal<int>(0, name: 'counter');
+  late final logCounter = Effect(() {
+    print('Counter changed: ${counter.value}');
+  }, name: 'logCounter');
+
+  @override
+  void dispose() {
+    logCounter.dispose();
+    counter.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -41,6 +41,7 @@ const List<String> goldenNames = <String>[
   'm3_10_existing_signalbuilder',
   'm3_11_nested_tracked_reads',
   'm3_12_untracked_extension',
+  'm4_01_simple_effect_with_deps',
 ];
 
 /// Memoized golden directory resolution. Resolved relative to the package

--- a/packages/solid_generator/test/rejections/m1_15_non_m1_annotations_test.dart
+++ b/packages/solid_generator/test/rejections/m1_15_non_m1_annotations_test.dart
@@ -1,17 +1,12 @@
 // Rejection suite for M1-15: reserved annotations from SPEC §3.2 + §13.
-// Each case asserts that placing `@SolidEffect`, `@SolidQuery`, or
-// `@SolidEnvironment` anywhere in a source file produces a build-time error
-// quoting the SPEC §3.2 phrase verbatim.
+// Each case asserts that placing `@SolidQuery` or `@SolidEnvironment`
+// anywhere in a source file produces a build-time error quoting the SPEC
+// §3.2 phrase verbatim. `@SolidEffect` shipped in M4 and is no longer
+// reserved (M4-06 / pulled-into-M4-01).
 
 import '../integration/golden_helpers.dart';
 
 const List<({String name, String errorContains})> _cases = [
-  (
-    name: 'm1_15_effect',
-    errorContains:
-        '@SolidEffect is not yet implemented; '
-        'scheduled for a later v2 milestone',
-  ),
   (
     name: 'm1_15_query',
     errorContains:


### PR DESCRIPTION
## Summary

- Implement `@SolidEffect` annotation lowering: instance methods become `late final = Effect(() { ... }, name: '...')` fields on the synthesized `State<T>` class (SPEC §3.4, §4.7)
- Mirror the M2-01 (`@SolidState` getter → `Computed`) pipeline: new `EffectModel`, `readSolidEffectMethod` reader, `emitEffectField` emitter, and a non-getter `MethodDeclaration` branch in both `_collectAnnotatedClasses` and `_emitReactiveBlock`
- Support both expression-body (`void m() => …;`) and block-body (`void m() { … }`) shapes; SPEC §5.1 reactive-read rewrites apply uniformly inside Effect bodies
- Disposal joins the unified reverse-declaration order — Effect disposed before the Signal/Computed it reads (SPEC §10)
- Reject zero-deps Effects at build time with the SPEC §3.4 message `"effect '<name>' has no reactive dependencies"` (absorbs M4-05's reject behaviour; M4-05 becomes a pure regression-test PR)
- Pull M4-06 work into M4-01 because `validateReservedAnnotations` runs before the lowering pipeline: remove `'SolidEffect'` from `_reservedAnnotations`, drop the `m1_15_effect` rejection case, delete the orphan input fixture
- Reject `@SolidEffect` on `State<X>` subclasses and plain classes with a guard pointing to M4-08, mirroring M2-01's "not yet supported" guard for the same class kinds
- Simplify-pass cleanups: factor shared `_readReactiveBody` between getter and effect readers, unify `findSolidStateAnnotation` + `findSolidEffectAnnotation` into `findAnnotationByName`, switch `_AnnotatedClass` to named-params constructor

## Testing

- New golden `m4_01_simple_effect_with_deps` verifies Signal/Effect interleave in source order, reverse-declaration disposal (`logCounter.dispose()` before `counter.dispose()`), and `flutter_solidart` import injection
- `dart test packages/solid_generator/`: 64 tests pass (every prior golden + new M4-01 golden + new M4-01 idempotency; `m1_15_effect` rejection case removed)
- `flutter test example/`: all 3 widget tests pass
- `dart analyze --fatal-infos packages/solid_generator/`: only the pre-existing `m3_09_shadowing` info issue (unchanged from main)
- `dart analyze packages/solid_generator/test/golden/outputs/`: zero issues
- `dart format --set-exit-if-changed`: zero diff
- TODOS.md: M4-01 and M4-06 flipped to DONE, with implementation notes documenting the bootstrap deviation