### PR TITLE
Implement M4-02: @SolidEffect co-exists with @SolidState field + getter

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1387,7 +1387,7 @@ class _CounterState extends State<Counter> {
 
 **Dependencies:** M4-01.
 
-**Status:** TODO
+**Status:** DONE
 
 ---
 

--- a/example/lib/counter.dart
+++ b/example/lib/counter.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_solidart/flutter_solidart.dart';
 
 class CounterPage extends StatefulWidget {
-  CounterPage({super.key});
+  const CounterPage({super.key});
 
   @override
   State<CounterPage> createState() => _CounterPageState();

--- a/packages/solid_generator/test/golden/inputs/m3_09_shadowing.dart
+++ b/packages/solid_generator/test/golden/inputs/m3_09_shadowing.dart
@@ -11,8 +11,8 @@ class ShadowProbe extends StatelessWidget {
   Widget build(BuildContext context) {
     return Builder(
       builder: (context) {
-        final counter = 'local';
-        return Text(counter);
+        const counter = 'local';
+        return const Text(counter);
       },
     );
   }

--- a/packages/solid_generator/test/golden/inputs/m4_02_effect_with_signal_and_computed.dart
+++ b/packages/solid_generator/test/golden/inputs/m4_02_effect_with_signal_and_computed.dart
@@ -1,0 +1,23 @@
+// SPEC §3.4 / §4.7 use `print` as the canonical Effect side-effect example.
+// ignore_for_file: avoid_print
+
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+
+class EffectWithDeps extends StatelessWidget {
+  EffectWithDeps({super.key});
+
+  @SolidState()
+  int counter = 0;
+
+  @SolidState()
+  int get doubleCounter => counter * 2;
+
+  @SolidEffect()
+  void logBoth() {
+    print('$counter / $doubleCounter');
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/golden/outputs/m3_09_shadowing.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m3_09_shadowing.g.dart
@@ -22,8 +22,8 @@ class _ShadowProbeState extends State<ShadowProbe> {
   Widget build(BuildContext context) {
     return Builder(
       builder: (context) {
-        final counter = 'local';
-        return Text(counter);
+        const counter = 'local';
+        return const Text(counter);
       },
     );
   }

--- a/packages/solid_generator/test/golden/outputs/m4_02_effect_with_signal_and_computed.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m4_02_effect_with_signal_and_computed.g.dart
@@ -1,0 +1,32 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class EffectWithDeps extends StatefulWidget {
+  EffectWithDeps({super.key});
+
+  @override
+  State<EffectWithDeps> createState() => _EffectWithDepsState();
+}
+
+class _EffectWithDepsState extends State<EffectWithDeps> {
+  final counter = Signal<int>(0, name: 'counter');
+  late final doubleCounter = Computed<int>(
+    () => counter.value * 2,
+    name: 'doubleCounter',
+  );
+  late final logBoth = Effect(() {
+    print('${counter.value} / ${doubleCounter.value}');
+  }, name: 'logBoth');
+
+  @override
+  void dispose() {
+    logBoth.dispose();
+    doubleCounter.dispose();
+    counter.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -42,6 +42,7 @@ const List<String> goldenNames = <String>[
   'm3_11_nested_tracked_reads',
   'm3_12_untracked_extension',
   'm4_01_simple_effect_with_deps',
+  'm4_02_effect_with_signal_and_computed',
 ];
 
 /// Memoized golden directory resolution. Resolved relative to the package


### PR DESCRIPTION
## Summary

- **M4-02 (regression-fence golden)**: paired input + output fixture exercising all three lowered shapes — `@SolidState` field (Signal), `@SolidState` getter (Computed), `@SolidEffect` method (Effect) — interleaved on one `StatelessWidget`. Locks in source-order field emission and reverse-declaration `dispose()` order across the trio. Zero generator code changes; M4-01's `_emitReactiveBlock` (`stateless_rewriter.dart` lines 86–131) already wires this up.
- **Pre-existing analyzer fixes** (separate commit): clean up `const_with_non_const` in `example/lib/main.dart`, the `prefer_const_constructors_in_immutables` info on generated consumer code, and `prefer_const_declarations` in `m3_09_shadowing.dart`. `dart analyze --fatal-infos` now reports zero issues across the workspace.

SPEC references for M4-02: §4.1 (Signal), §4.5 (Computed), §4.7 (Effect), §10 (dispose order).

## Test plan

- [x] `UPDATE_GOLDENS=1 dart test --name=m4_02_effect_with_signal_and_computed` — regenerates output; no diff against committed golden.
- [x] `dart test --name=m4_02_effect_with_signal_and_computed` — golden equality passes.
- [x] `dart test --name=golden` — all 27 goldens pass (M1, M2, M3, M4-01, M4-02).
- [x] `dart test test/integration/idempotency_test.dart` — two-run byte equality holds.
- [x] `dart test test/rejections/` — every rejection suite still passes.
- [x] `dart test packages/solid_generator/` — full suite (66 tests) green.
- [x] `dart format --set-exit-if-changed .` — zero diff.
- [x] `dart analyze --fatal-infos` — zero issues workspace-wide.
- [x] `dart analyze packages/solid_generator/test/golden/outputs/` — zero issues (rubric check #6).
- [x] `cd example && dart run build_runner build --delete-conflicting-outputs && dart analyze` — zero issues (consumer-app round-trip).

## Verification of disposal order

Per SPEC §10, the new golden's `dispose()` body emits Effect → Computed → Signal → super (reverse-declaration order):

```dart
void dispose() {
  logBoth.dispose();        // Effect — declared third
  doubleCounter.dispose();  // Computed — declared second
  counter.dispose();        // Signal — declared first
  super.dispose();
}
```