### PR TITLE
Implement M4-03: @SolidEffect block-body with multi-statement and shadowing

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1413,7 +1413,7 @@ class _CounterState extends State<Counter> {
 
 **Dependencies:** M4-01.
 
-**Status:** TODO
+**Status:** DONE
 
 ---
 

--- a/packages/solid_generator/test/golden/inputs/m4_03_effect_block_body_shadowing.dart
+++ b/packages/solid_generator/test/golden/inputs/m4_03_effect_block_body_shadowing.dart
@@ -1,0 +1,24 @@
+// SPEC §3.4 / §4.7 use `print` as the canonical Effect side-effect example.
+// ignore_for_file: avoid_print
+
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+
+class EffectShadowing extends StatelessWidget {
+  EffectShadowing({super.key});
+
+  @SolidState()
+  int counter = 0;
+
+  @SolidEffect()
+  void logCounter() {
+    print('outer: $counter');
+    {
+      const counter = 'shadowed';
+      print('inner: $counter');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/golden/outputs/m4_03_effect_block_body_shadowing.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m4_03_effect_block_body_shadowing.g.dart
@@ -1,0 +1,31 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class EffectShadowing extends StatefulWidget {
+  EffectShadowing({super.key});
+
+  @override
+  State<EffectShadowing> createState() => _EffectShadowingState();
+}
+
+class _EffectShadowingState extends State<EffectShadowing> {
+  final counter = Signal<int>(0, name: 'counter');
+  late final logCounter = Effect(() {
+    print('outer: ${counter.value}');
+    {
+      const counter = 'shadowed';
+      print('inner: $counter');
+    }
+  }, name: 'logCounter');
+
+  @override
+  void dispose() {
+    logCounter.dispose();
+    counter.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -43,6 +43,7 @@ const List<String> goldenNames = <String>[
   'm3_12_untracked_extension',
   'm4_01_simple_effect_with_deps',
   'm4_02_effect_with_signal_and_computed',
+  'm4_03_effect_block_body_shadowing',
 ];
 
 /// Memoized golden directory resolution. Resolved relative to the package


### PR DESCRIPTION
## Summary
- Pure regression-fence golden validating that lexical block-scoped shadowing applies uniformly inside `@SolidEffect` bodies — mirror of M3-09 for `build()` bodies.
- Outer reactive read of `counter` is rewritten to `counter.value`; nested `{ ... }` block declares a local `counter` shadow that leaves the inner read untouched.
- Zero generator changes: `_ValueRewriteVisitor.visitBlock` / `visitVariableDeclaration` / `_isShadowed` (`packages/solid_generator/lib/src/value_rewriter.dart`) already implement block-scoped shadowing, and `readSolidEffectMethod` routes the Effect body through the same `collectValueEdits` entry point used by `build()` and `@SolidState` getters.

SPEC §4.7, §5.1, §5.5. Closes the M4-03 entry in `TODOS.md`.

## Test plan
- [x] `dart test --name=m4_03_effect_block_body_shadowing` — golden equality passes.
- [x] `dart test --name=golden` — all 28 goldens (M1, M2, M3, M4-01, M4-02, M4-03) pass.
- [x] `dart test test/integration/idempotency_test.dart` — two-run byte equality holds.
- [x] `dart test test/rejections/` — every M1-14, M1-15, M2-02 rejection suite still passes.
- [x] `dart format --set-exit-if-changed lib test` — zero diff (93 files unchanged).
- [x] `dart analyze --fatal-infos lib test` — zero issues.
- [x] Hand-verified golden output: `print('outer: \${counter.value}');` (outer rewritten) and `print('inner: \$counter');` (inner preserved despite `const` shadow).
- [x] `example/`: `dart run build_runner build` exits 0, no new analyze regressions versus `origin/main`.