### PR TITLE
Implement M4-05: reject zero-deps @SolidEffect

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1463,7 +1463,9 @@ class _CounterState extends State<Counter> {
 
 **Dependencies:** M4-01.
 
-**Status:** TODO
+**Implementation note:** The runtime detection already shipped with M4-01 — `_readReactiveBody` in `packages/solid_generator/lib/src/annotation_reader.dart` throws the SPEC §3.4 error when `collectValueEdits(...).edits.isEmpty`, and `readSolidEffectMethod` already passes the SPEC-defined `emptyDepsError` string. M4-05 added the dedicated rejection fixture + test (`test/golden/inputs/m4_05_effect_no_deps_rejected.dart` + `test/rejections/m4_05_effect_no_deps_test.dart`) to pin this behavior independent of M4-01's regress.
+
+**Status:** DONE
 
 ---
 

--- a/packages/solid_generator/test/golden/inputs/m4_05_effect_no_deps_rejected.dart
+++ b/packages/solid_generator/test/golden/inputs/m4_05_effect_no_deps_rejected.dart
@@ -1,0 +1,11 @@
+// SPEC §3.4 / §4.7 use `print` as the canonical Effect side-effect example.
+// ignore_for_file: avoid_print
+
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Foo {
+  @SolidEffect()
+  void doThing() {
+    print('no signals here');
+  }
+}

--- a/packages/solid_generator/test/rejections/m4_05_effect_no_deps_test.dart
+++ b/packages/solid_generator/test/rejections/m4_05_effect_no_deps_test.dart
@@ -1,0 +1,16 @@
+// Rejection suite for M4-05: zero-deps Effect (SPEC §3.4).
+// An `@SolidEffect` method whose body references no reactive declaration
+// must be rejected at build time with the SPEC §3.4 error message.
+
+import '../integration/golden_helpers.dart';
+
+const List<({String name, String errorContains})> _cases = [
+  (
+    name: 'm4_05_effect_no_deps_rejected',
+    errorContains: "effect 'doThing' has no reactive dependencies",
+  ),
+];
+
+void main() {
+  runRejectionCases('m4_05 zero-deps Effect rejection', _cases);
+}


### PR DESCRIPTION
## Summary

- Add rejection test for `@SolidEffect` methods with no reactive dependencies (SPEC §3.4)
- Runtime detection was already implemented in M4-01; this commit adds the dedicated test fixture to pin the behavior
- Test input: method marked `@SolidEffect()` whose body contains no signal reads
- Expected error: `effect 'methodName' has no reactive dependencies`
- Mark M4-05 as DONE in TODOS.md

## Testing

- Rejection test verifies that zero-deps Effect methods are caught at build time with the correct SPEC §3.4 error message
- Test fixture: `m4_05_effect_no_deps_rejected.dart`
- Test case: `test/rejections/m4_05_effect_no_deps_test.dart`