### PR TITLE
Implement M4-08: @SolidEffect support for plain and State classes

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -656,6 +656,8 @@ class Counter {
 
 If the developer has already declared a `dispose()` method, the generator merges: the generated disposal calls are prepended to the existing body, then `super.dispose()` is emitted if and only if the class's supertype chain contains a `dispose()` method (e.g., `State<T>`, `ChangeNotifier`). The generator determines this via the analyzer's type resolution, not by name matching. For a plain class with no `dispose()` in the supertype chain, `super.dispose()` is omitted.
 
+When the plain class has one or more `@SolidEffect` methods, the generator synthesizes a no-arg constructor whose body reads each Effect field by bare identifier in declaration order — analogue of the State class's `initState()` materialization (§4.7). The synthesized constructor takes the place a widget lifecycle would otherwise serve, activating each `late final` Effect at construction time so its autorun fires once with the initial Signal values and subscribes to subsequent changes. Plain classes with a user-defined constructor and `@SolidEffect` are not supported in this milestone — the generator rejects with a `CodeGenerationError`.
+
 ### 8.4 StatelessWidget with zero `@SolidState` annotations
 
 Passes through unchanged to `lib/`.
@@ -751,7 +753,7 @@ These were open questions during SPEC drafting and have been answered by the dev
 1. **Plain (non-Widget) classes with `@SolidState` fields** — supported per Section 8.3.
 2. **Compound-assignment operator list in Section 5.3** — complete.
 3. **`@SolidState` on `final` fields** — rejected with a clear error (wrapping a never-reassigned value in a `Signal` is pointless).
-4. **Custom `initState` / `didUpdateWidget` overrides in an existing State class (Section 8.2)** — preserved untouched. If an existing `dispose()` is present, reactive disposals are merged into its body.
+4. **Custom `initState` / `didUpdateWidget` overrides in an existing State class (Section 8.2)** — preserved untouched, with one carve-out: when one or more `@SolidEffect` methods exist on the class, Effect-materialization reads (`<effectName>;`) are spliced into the existing `initState` body immediately after the `super.initState();` call (or after the opening brace if no super call is detected as the first statement). If an existing `dispose()` is present, reactive disposals are merged into its body.
 5. **User-facing packages** — two packages. `package:solid_annotations` (runtime dep) hosts the annotation classes (`@SolidState` and `@SolidEffect` today; `@SolidQuery`/`@SolidEnvironment` in later milestones). `package:solid_generator` (dev_dep) hosts the build_runner builder. There is no `package:solid` umbrella. Consumers add `solid_annotations` + `flutter_solidart` as runtime deps and `solid_generator` + `build_runner` as dev_deps, then import annotations and `flutter_solidart` primitives directly.
 6. **Shadowing rule (Section 5.5)** — handled by type resolution. Because Section 5.1 is type-driven, a shadowed local of a non-`SignalBase` type is never rewritten. A dedicated shadowing test case is required in M1.
 7. **`const` on the public widget constructor (Section 8.1)** — not added by the generator. Constructors round-trip verbatim from source. After the class split removes mutable `@SolidState` fields from the widget, the rewritten widget is usually const-eligible by Dart's own rules; `dart fix --apply` is the trusted lint pass that adds `const` (and removes unused imports — Section 9). The generator never emits `const` on its own.

--- a/TODOS.md
+++ b/TODOS.md
@@ -1543,6 +1543,12 @@ class _CounterState extends State<Counter> {
 
 **Dependencies:** M4-01, M1-07.
 
-**Status:** TODO
+**Implementation note:** Three pieces beyond the simple guard removal:
+
+1. New `emitConstructor(className, effectNames)` helper in `signal_emitter.dart` — the plain-class analogue of `emitInitState`. A plain class has no widget lifecycle, so the synthesized constructor body materializes Effects via bare-id reads at construction time; SPEC §8.3 was extended with a sentence describing this. The helper is only invoked when `effectNames` is non-empty, preserving byte-equality with the M1-06 Signal-only plain-class golden.
+2. New `_mergeInitState` in `state_class_rewriter.dart`, mirroring `_mergeDispose` — when Effects exist on a `State<X>` subclass that also declares `initState`, materialization reads (`<effectName>;`) are spliced in immediately after the `super.initState();` call (or after the opening brace if the user's body lacks the super call). SPEC §14 item 4 was extended with this carve-out. When no `initState` exists and Effects are present, a fresh one is synthesized via `emitInitState`.
+3. Both in-place rewriters now extend their `solidartNames` set with `'Effect'` when at least one Effect is present, so the import-rewriter adds `package:flutter_solidart/flutter_solidart.dart` for the Effect symbol used in the body. The walk in `state_class_rewriter` was refactored to build `disposeNames` incrementally during the member walk so Signal field names and Effect method names interleave by source-declaration order — required for SPEC §10's reverse-disposal correctness when Signals and Effects coexist. User-defined constructors on plain classes remain rejected: the synthesized constructor and a user constructor are mutually exclusive in this milestone.
+
+**Status:** DONE
 
 ---

--- a/packages/solid_generator/lib/src/plain_class_rewriter.dart
+++ b/packages/solid_generator/lib/src/plain_class_rewriter.dart
@@ -7,16 +7,23 @@ import 'package:solid_generator/src/signal_emitter.dart';
 import 'package:solid_generator/src/transformation_error.dart';
 
 /// Rewrites a plain Dart class (no widget supertype) containing `@SolidState`
-/// fields by replacing each annotated field with a `Signal<T>(…)` and
-/// synthesizing a fresh `dispose()` method.
+/// fields and/or `@SolidEffect` methods by replacing each annotated field
+/// with a `Signal<T>(…)`, each annotated method with a `late final … =
+/// Effect(…)`, and synthesizing a fresh `dispose()` method (plus, when
+/// Effects exist, a fresh no-arg constructor whose body materializes them
+/// — the plain-class analogue of the State class's `initState()`
+/// materialization, SPEC §4.7).
 ///
-/// See SPEC §8.3 and §10. The synthesized `dispose()` has neither `@override`
-/// nor `super.dispose()` because the supertype chain is `Object` only.
+/// See SPEC §8.3 (plain class lowering) and §10 (dispose contract). The
+/// synthesized `dispose()` has neither `@override` nor `super.dispose()`
+/// because the supertype chain is `Object` only.
 ///
 /// Currently only classes whose every member is an `@SolidState`-annotated
-/// field are supported. Any other member (existing `dispose()`, constructors,
-/// non-annotated fields, methods, …) throws [CodeGenerationError] —
-/// dispose-merge and in-place patching are scheduled for later milestones.
+/// field or `@SolidEffect`-annotated method are supported. Any other member
+/// (existing `dispose()`, user-defined constructors, non-annotated fields,
+/// non-Effect methods, …) throws [CodeGenerationError] — dispose-merge,
+/// constructor-merge, and in-place patching are scheduled for later
+/// milestones.
 ///
 /// The emitted string is syntactically valid Dart but is not guaranteed to be
 /// pretty-printed — run through `DartFormatter` before writing.
@@ -35,43 +42,70 @@ RewriteResult rewritePlainClass(
   // M2-01 ships getter→Computed for `StatelessWidget` only; reject here so
   // M1-14's valid-target pass isn't silently undone.
   rejectIfGettersNotYetSupported(solidGetters, 'plain class', className);
-  // M4-01 ships method→Effect for `StatelessWidget` only; M4-08 lifts this
-  // guard for plain-class lowering. Reject here so the M4-04 valid-target
-  // pass isn't silently undone.
-  rejectIfEffectsNotYetSupported(solidEffects, 'plain class', className);
-  _checkUnsupportedMembers(classDecl, solidFields, className);
+  // Source-ordered emission so Signal fields and Effect fields interleave by
+  // declaration order — required by SPEC §10's reverse-disposal rule (an
+  // Effect must be declared after the Signals it reads, so reverse order
+  // disposes the Effect before its dependencies).
+  final fieldByName = {for (final f in solidFields) f.fieldName: f};
+  final effectByName = {for (final e in solidEffects) e.methodName: e};
+  _checkUnsupportedMembers(classDecl, fieldByName, effectByName, className);
 
-  final signalFields = solidFields.map(emitSignalField).join('\n');
-  final dispose = emitDispose(
-    solidFields.map((f) => f.fieldName).toList(),
-    inheritsDispose: false,
-  );
+  final pieces = <String>[];
+  final disposeNames = <String>[];
+  final effectNames = <String>[];
+
+  for (final member in classDecl.members) {
+    if (member is FieldDeclaration) {
+      // Non-annotated fields are rejected by `_checkUnsupportedMembers`
+      // above, so the lookup always hits.
+      final f = fieldByName[member.fields.variables.first.name.lexeme]!;
+      pieces.add(emitSignalField(f));
+      disposeNames.add(f.fieldName);
+      continue;
+    }
+    if (member is MethodDeclaration) {
+      // Non-Effect methods are rejected by `_checkUnsupportedMembers`
+      // above, so the lookup always hits.
+      final e = effectByName[member.name.lexeme]!;
+      pieces.add(emitEffectField(e));
+      disposeNames.add(e.methodName);
+      effectNames.add(e.methodName);
+    }
+  }
+
+  final fields = pieces.join('\n');
+  // No-arg constructor only when Effects need materialization — keeps the
+  // Signal-only output byte-identical to the M1-06 plain-class golden,
+  // which has no synthesized constructor.
+  final ctor = effectNames.isEmpty
+      ? ''
+      : '\n\n${emitConstructor(className, effectNames)}';
+  final dispose = emitDispose(disposeNames, inheritsDispose: false);
 
   return (
-    text:
-        '''
-class $className {
-$signalFields
-
-$dispose
-}''',
-    solidartNames: const <String>{'Signal'},
+    text: 'class $className {\n$fields$ctor\n\n$dispose\n}',
+    solidartNames: <String>{
+      'Signal',
+      if (effectNames.isNotEmpty) 'Effect',
+    },
   );
 }
 
 /// Throws [CodeGenerationError] if [classDecl] contains any member other than
-/// an `@SolidState` field. Surfacing these explicitly avoids silently dropping
-/// user code while the rewriter is incomplete.
+/// an `@SolidState`-annotated field (key in [fieldByName]) or an
+/// `@SolidEffect`-annotated method (key in [effectByName]). Surfacing these
+/// explicitly avoids silently dropping user code while the rewriter is
+/// incomplete.
 void _checkUnsupportedMembers(
   ClassDeclaration classDecl,
-  List<FieldModel> solidFields,
+  Map<String, FieldModel> fieldByName,
+  Map<String, EffectModel> effectByName,
   String className,
 ) {
-  final annotatedNames = solidFields.map((f) => f.fieldName).toSet();
   for (final member in classDecl.members) {
     if (member is FieldDeclaration) {
       final varName = member.fields.variables.first.name.lexeme;
-      if (!annotatedNames.contains(varName)) {
+      if (!fieldByName.containsKey(varName)) {
         throw CodeGenerationError(
           'plain class with non-annotated field "$varName" is not yet '
           'supported',
@@ -79,6 +113,10 @@ void _checkUnsupportedMembers(
           className,
         );
       }
+      continue;
+    }
+    if (member is MethodDeclaration &&
+        effectByName.containsKey(member.name.lexeme)) {
       continue;
     }
     throw CodeGenerationError(

--- a/packages/solid_generator/lib/src/signal_emitter.dart
+++ b/packages/solid_generator/lib/src/signal_emitter.dart
@@ -134,3 +134,31 @@ String emitInitState(List<String> effectNamesInDeclarationOrder) {
   buffer.write('  }');
   return buffer.toString();
 }
+
+/// Emits a no-arg constructor whose body materializes every `late final`
+/// Effect field by reading it as a bare-identifier statement
+/// (`<effectName>;`), in source-declaration order.
+///
+/// SPEC §4.7 + §8.3: a plain Dart class has no `initState` lifecycle hook,
+/// but the same `late final` Effect-materialization rule applies — without a
+/// synthesized read, the Effect's factory constructor never runs and the
+/// autorun never registers dependencies. Reading each Effect inside the
+/// generated constructor body is the plain-class analogue of
+/// [emitInitState] for State classes: the Effects activate at construction
+/// time, so a `Counter()` instantiation is enough to start the autoruns.
+///
+/// Caller is responsible for only invoking this when
+/// [effectNamesInDeclarationOrder] is non-empty — otherwise an empty
+/// constructor is emitted, which is just noise relative to Dart's implicit
+/// default constructor for a Signal-only class (see `rewritePlainClass`).
+String emitConstructor(
+  String className,
+  List<String> effectNamesInDeclarationOrder,
+) {
+  final buffer = StringBuffer()..writeln('  $className() {');
+  for (final name in effectNamesInDeclarationOrder) {
+    buffer.writeln('    $name;');
+  }
+  buffer.write('  }');
+  return buffer.toString();
+}

--- a/packages/solid_generator/lib/src/state_class_rewriter.dart
+++ b/packages/solid_generator/lib/src/state_class_rewriter.dart
@@ -8,16 +8,21 @@ import 'package:solid_generator/src/signal_emitter.dart';
 import 'package:solid_generator/src/transformation_error.dart';
 
 /// Rewrites an existing `State<X>` subclass containing `@SolidState` fields
-/// **in place** — without splitting the class. Replaces every `@SolidState`
-/// field with a `Signal<T>(…)` declaration, routes `build()` through the
-/// reactive-read pipeline, and merges reactive disposals into any existing
-/// `dispose()` body.
+/// and/or `@SolidEffect` methods **in place** — without splitting the class.
+/// Replaces every `@SolidState` field with a `Signal<T>(…)` declaration,
+/// every `@SolidEffect` method with a `late final … = Effect(…)` field,
+/// routes `build()` through the reactive-read pipeline, and merges reactive
+/// disposals into any existing `dispose()` body. When Effects exist, Effect
+/// materialization reads (`<effectName>;`) are also merged into any existing
+/// `initState()` body, or a fresh `initState()` is synthesized if none was
+/// declared.
 ///
-/// See SPEC §8.2 and §10. This is the fix for issue #3 — a `StatefulWidget`
-/// whose `State<X>` subclass declared `@SolidState` fields was silently passed
-/// through unchanged in v1.
+/// See SPEC §8.2 (in-place State lowering), §10 (dispose merging), and §4.7
+/// (Effect materialization). The Signal-only path is the fix for issue #3 —
+/// a `StatefulWidget` whose `State<X>` subclass declared `@SolidState` fields
+/// was silently passed through unchanged in v1.
 ///
-/// Member ordering and non-annotated members (other fields, `initState`,
+/// Member ordering and non-annotated members (other fields,
 /// `didUpdateWidget`, user methods, constructors, …) are emitted verbatim
 /// from [source] so that lifecycle bodies round-trip byte-identical.
 ///
@@ -40,22 +45,27 @@ RewriteResult rewriteStateClass(
     'existing State<X> subclass',
     className,
   );
-  // M4-01 ships method→Effect for `StatelessWidget` only; M4-08 lifts this
-  // guard for in-place State<X> lowering. Reject here so the M4-04 valid-
-  // target pass isn't silently undone.
-  rejectIfEffectsNotYetSupported(
-    solidEffects,
-    'existing State<X> subclass',
-    className,
-  );
-  // Index annotated fields by name for O(1) lookup during the member walk.
-  // The builder already parsed `@SolidState` once when computing [solidFields];
-  // re-parsing here would double the annotation-reader cost per file.
+  // Index annotated fields and methods by name for O(1) lookup during the
+  // member walk. The builder already parsed `@SolidState`/`@SolidEffect`
+  // once when computing [solidFields] / [solidEffects]; re-parsing here would
+  // double the annotation-reader cost per file.
   final modelByName = {for (final f in solidFields) f.fieldName: f};
+  final effectByName = {for (final e in solidEffects) e.methodName: e};
   final reactiveNames = modelByName.keys.toSet();
-  final disposeNames = solidFields.map((f) => f.fieldName).toList();
+  // Built incrementally during the walk so Signal field names and Effect
+  // method names interleave in source-declaration order — the contract
+  // `emitDispose` relies on for reverse-disposal correctness (SPEC §10).
+  final disposeNames = <String>[];
+  final effectNames = <String>[];
   final pieces = <String>[];
-  var sawDispose = false;
+  // `initState`/`dispose` emission is deferred until after the walk so the
+  // merge sees the fully-populated `effectNames` / `disposeNames` lists.
+  // The slot index reserves the member's source-order position in `pieces`
+  // so it round-trips byte-identical when the user declared one.
+  MethodDeclaration? initStateMethod;
+  MethodDeclaration? disposeMethod;
+  var initStateSlot = -1;
+  var disposeSlot = -1;
 
   for (final member in classDecl.members) {
     if (member is FieldDeclaration) {
@@ -63,6 +73,7 @@ RewriteResult rewriteStateClass(
       final model = modelByName[varName];
       if (model != null) {
         pieces.add(emitSignalField(model));
+        disposeNames.add(model.fieldName);
       } else {
         pieces.add(source.substring(member.offset, member.end));
       }
@@ -72,9 +83,19 @@ RewriteResult rewriteStateClass(
       final name = member.name.lexeme;
       if (name == 'build') {
         pieces.add(rewriteBuildMethod(member, reactiveNames, source));
+      } else if (name == 'initState') {
+        initStateMethod = member;
+        initStateSlot = pieces.length;
+        pieces.add('');
       } else if (name == 'dispose') {
-        pieces.add(_mergeDispose(member, disposeNames, source, className));
-        sawDispose = true;
+        disposeMethod = member;
+        disposeSlot = pieces.length;
+        pieces.add('');
+      } else if (effectByName.containsKey(name)) {
+        final effect = effectByName[name]!;
+        pieces.add(emitEffectField(effect));
+        disposeNames.add(effect.methodName);
+        effectNames.add(effect.methodName);
       } else {
         pieces.add(source.substring(member.offset, member.end));
       }
@@ -83,7 +104,27 @@ RewriteResult rewriteStateClass(
     pieces.add(source.substring(member.offset, member.end));
   }
 
-  if (!sawDispose) {
+  // Custom `initState` is preserved untouched when no Effects exist (SPEC
+  // §14 item 4); when Effects are present, materialization reads are
+  // spliced after the existing `super.initState();` call (§14 item 4
+  // carve-out + §4.7). When no `initState` was declared, synthesize one
+  // iff at least one Effect needs materialization — otherwise skip, so the
+  // M1-07 Signal-only golden round-trips byte-identical.
+  if (initStateMethod != null) {
+    pieces[initStateSlot] = effectNames.isEmpty
+        ? source.substring(initStateMethod.offset, initStateMethod.end)
+        : _mergeInitState(initStateMethod, effectNames, source, className);
+  } else if (effectNames.isNotEmpty) {
+    pieces.add(emitInitState(effectNames));
+  }
+  if (disposeMethod != null) {
+    pieces[disposeSlot] = _mergeDispose(
+      disposeMethod,
+      disposeNames,
+      source,
+      className,
+    );
+  } else {
     pieces.add(emitDispose(disposeNames, inheritsDispose: true));
   }
 
@@ -93,7 +134,10 @@ RewriteResult rewriteStateClass(
   );
   return (
     text: '$header{\n${pieces.join('\n\n')}\n}',
-    solidartNames: const <String>{'Signal'},
+    solidartNames: <String>{
+      'Signal',
+      if (effectNames.isNotEmpty) 'Effect',
+    },
   );
 }
 
@@ -102,8 +146,9 @@ RewriteResult rewriteStateClass(
 /// untouched (SPEC §10).
 ///
 /// [disposeNamesInDeclarationOrder] is the unified, source-ordered list of
-/// reactive declarations (Signal field + Computed getter). Reverse-iterating
-/// it puts dependents ahead of their dependencies in the dispose body.
+/// reactive declarations (Signal field + Effect method). Reverse-iterating
+/// it puts dependents (Effects) ahead of their dependencies (Signals) in the
+/// dispose body.
 ///
 /// Throws [CodeGenerationError] if the existing `dispose()` uses an
 /// expression body (`=> …`) — the merge is only well-defined for a block.
@@ -133,4 +178,57 @@ String _mergeDispose(
   return '${source.substring(method.offset, lbrace + 1)}'
       '\n$disposals'
       '${source.substring(lbrace + 1, method.end)}';
+}
+
+/// Splices Effect-materialization reads (`<effectName>;`, in declaration
+/// order) into an existing `initState()` body immediately after the
+/// `super.initState();` call, so Effects subscribe to signals before any
+/// user code in `initState` runs (SPEC §4.7 + §14 item 4 carve-out).
+///
+/// Splice point: the end of the first statement when it is recognised as
+/// `super.initState();`; otherwise immediately after the opening brace. The
+/// SPEC mandates `super.initState()` first, so the fallback only fires for
+/// non-conforming user code — keeping the merge adjacent to where the super
+/// call would have been.
+///
+/// Throws [CodeGenerationError] if the existing `initState()` uses an
+/// expression body (`=> …`) — the merge is only well-defined for a block.
+String _mergeInitState(
+  MethodDeclaration method,
+  List<String> effectNamesInDeclarationOrder,
+  String source,
+  String className,
+) {
+  final body = method.body;
+  if (body is! BlockFunctionBody) {
+    throw CodeGenerationError(
+      'existing initState() must have a block body for Effect merge',
+      null,
+      className,
+    );
+  }
+  final stmts = body.block.statements;
+  final int insertAt;
+  if (stmts.isNotEmpty && _isSuperInitStateCall(stmts.first)) {
+    insertAt = stmts.first.end;
+  } else {
+    insertAt = body.block.leftBracket.offset + 1;
+  }
+  final reads = effectNamesInDeclarationOrder
+      .map((name) => '    $name;')
+      .join('\n');
+  return '${source.substring(method.offset, insertAt)}'
+      '\n$reads'
+      '${source.substring(insertAt, method.end)}';
+}
+
+/// Returns `true` when [stmt] is exactly the expression statement
+/// `super.initState();`. Used by [_mergeInitState] to decide whether to
+/// splice Effect reads after the user's super call (the SPEC-conforming
+/// case) or at the top of the body (fallback).
+bool _isSuperInitStateCall(Statement stmt) {
+  if (stmt is! ExpressionStatement) return false;
+  final expr = stmt.expression;
+  if (expr is! MethodInvocation) return false;
+  return expr.target is SuperExpression && expr.methodName.name == 'initState';
 }

--- a/packages/solid_generator/test/golden/inputs/m4_08_effect_on_plain_class.dart
+++ b/packages/solid_generator/test/golden/inputs/m4_08_effect_on_plain_class.dart
@@ -1,0 +1,14 @@
+// SPEC §3.4 / §4.7 use `print` as the canonical Effect side-effect example.
+// ignore_for_file: avoid_print
+
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Counter {
+  @SolidState()
+  int value = 0;
+
+  @SolidEffect()
+  void log() {
+    print('value: $value');
+  }
+}

--- a/packages/solid_generator/test/golden/inputs/m4_08_effect_on_state_class.dart
+++ b/packages/solid_generator/test/golden/inputs/m4_08_effect_on_state_class.dart
@@ -1,0 +1,49 @@
+// SPEC §3.4 / §4.7 use `print` as the canonical Effect side-effect example.
+// ignore_for_file: avoid_print
+
+import 'dart:async';
+
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+
+class Counter extends StatefulWidget {
+  const Counter({super.key});
+
+  @override
+  State<Counter> createState() => _CounterState();
+}
+
+class _CounterState extends State<Counter> {
+  @SolidState()
+  int counter = 0;
+
+  final StreamSubscription<void> _subscription = Stream<void>.periodic(
+    const Duration(seconds: 1),
+  ).listen((_) {});
+
+  @SolidEffect()
+  void logCounter() {
+    print('Counter: $counter');
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    debugPrint('init');
+  }
+
+  @override
+  void didUpdateWidget(covariant Counter oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    debugPrint('update');
+  }
+
+  @override
+  void dispose() {
+    unawaited(_subscription.cancel());
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/golden/outputs/m4_08_effect_on_plain_class.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m4_08_effect_on_plain_class.g.dart
@@ -1,0 +1,18 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class Counter {
+  final value = Signal<int>(0, name: 'value');
+  late final log = Effect(() {
+    print('value: ${value.value}');
+  }, name: 'log');
+
+  Counter() {
+    log;
+  }
+
+  void dispose() {
+    log.dispose();
+    value.dispose();
+  }
+}

--- a/packages/solid_generator/test/golden/outputs/m4_08_effect_on_state_class.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m4_08_effect_on_state_class.g.dart
@@ -1,0 +1,47 @@
+import 'dart:async';
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class Counter extends StatefulWidget {
+  const Counter({super.key});
+
+  @override
+  State<Counter> createState() => _CounterState();
+}
+
+class _CounterState extends State<Counter> {
+  final counter = Signal<int>(0, name: 'counter');
+
+  final StreamSubscription<void> _subscription = Stream<void>.periodic(
+    const Duration(seconds: 1),
+  ).listen((_) {});
+
+  late final logCounter = Effect(() {
+    print('Counter: ${counter.value}');
+  }, name: 'logCounter');
+
+  @override
+  void initState() {
+    super.initState();
+    logCounter;
+    debugPrint('init');
+  }
+
+  @override
+  void didUpdateWidget(covariant Counter oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    debugPrint('update');
+  }
+
+  @override
+  void dispose() {
+    logCounter.dispose();
+    counter.dispose();
+    unawaited(_subscription.cancel());
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -44,6 +44,8 @@ const List<String> goldenNames = <String>[
   'm4_01_simple_effect_with_deps',
   'm4_02_effect_with_signal_and_computed',
   'm4_03_effect_block_body_shadowing',
+  'm4_08_effect_on_state_class',
+  'm4_08_effect_on_plain_class',
 ];
 
 /// Memoized golden directory resolution. Resolved relative to the package


### PR DESCRIPTION
## Summary

- Extends `@SolidEffect` support from `StatelessWidget` to plain Dart classes and existing `State<X>` subclasses
- For plain classes: synthesizes a no-arg constructor that materializes `late final` Effect fields via bare-identifier reads, activating autoruns at construction time
- For State classes: merges Effect materialization reads into existing `initState()` body (after `super.initState();`) or synthesizes `initState()` if none exists
- Updates dispose merging to interleave Signal and Effect names in source-declaration order, ensuring reverse-disposal correctness (Effects disposed before their Signal dependencies)
- Adds `Effect` to the import set when Effects are present; preserves byte-equality for Signal-only cases
- Rejects plain classes with user-defined constructors (mutually exclusive with synthesized constructor in this milestone)
- Updates SPEC §8.3, §14 item 4, and §4.7 with Effect-materialization rules and carve-outs

## Testing

- [x] Golden test cases for plain class with `@SolidEffect` and Signal: `m4_08_effect_on_plain_class` (input/output pair)
- [x] Golden test cases for State class with both `initState`, `dispose`, and `@SolidEffect`: `m4_08_effect_on_state_class` (input/output pair)
- [x] Verify Effect fields are emitted as `late final <name> = Effect((...))`
- [x] Verify plain-class constructor body contains bare-identifier Effect reads in declaration order
- [x] Verify State class `initState()` merge splices Effect reads after `super.initState();`
- [x] Verify dispose order is reversed: Effects before Signals
- [x] Verify `Effect` symbol is added to solidart imports only when Effects are present
- [x] Verify existing Signal-only golden outputs remain byte-identical (M1-06 plain class, M1-07 State class)