### PR TITLE
Implement M5-01: @SolidQuery Future-method on StatelessWidget

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1555,7 +1555,7 @@ class _CounterState extends State<Counter> {
 
 ## M5 — `@SolidQuery`
 
-### TODO M5-01 — Golden: simple `@SolidQuery` Future-method on `StatelessWidget` (no upstream signals)
+### DONE M5-01 — Golden: simple `@SolidQuery` Future-method on `StatelessWidget` (no upstream signals)
 
 **Goal:** `@SolidQuery() Future<String> fetchData() async => 'fetched';` on a `StatelessWidget` becomes a single `late final fetchData = Resource<String>(...)` field — no underscore prefix, no thin-accessor wrapper. The user's source-side `fetchData()` calls and `fetchData.refresh()` tear-offs are byte-identical in lowered output: at runtime, `fetchData()` invokes the upstream `Resource<T>.call() => state;` operator (returning `ResourceState<T>` for `.when` chains), and `fetchData.refresh()` resolves to the upstream `Resource<T>.refresh()` direct method. No body rewrite mutates the call sites. Establishes the M5 lowering pipeline: `QueryModel`, `readSolidQueryMethod`, `emitResourceField` (Future branch only, no auto-tracking), the non-getter `MethodDeclaration` branch in `_collectAnnotatedClasses` keyed on `Future<T>` return type, and a SignalBuilder-placement detection rule that records `<queryName>()` call offsets in the tracked-read set (so the enclosing widget subtree gets wrapped). Also performs the M4-06-style migration: removes `'SolidQuery'` from `_reservedAnnotations` and migrates the `m1_15_query` rejection case to a positive golden. Adds the source-time stub extensions to `solid_annotations`.
 
@@ -1644,7 +1644,7 @@ class _GreeterState extends State<Greeter> {
 
 **Implementation note:** Like M4-01, M5-01 also pulls in the M4-06-style migration (remove from `_reservedAnnotations`, migrate `m1_15_query`) because the reserved-annotation guard runs before lowering — without removing `'SolidQuery'` and migrating the rejection case in the same PR, the M5-01 golden could never go green. Document this inline in `reserved_annotation_validator.dart` similar to the M4-01 comment. The new `flutter` dep on `solid_annotations` is unavoidable: SPEC §3.5 "Source-time typechecking" requires the source-side stubs to return `Widget`. `flutter_solidart` is NOT added as a `solid_annotations` dep because the user's source layer does not name `Resource<T>`. The M0-02 "no runtime deps" rule is therefore amended in M5-01 (only `flutter`). The SignalBuilder-placement detection (visitor records `<queryName>()` offsets in `trackedReadOffsets`) is registered in M5-01 even though M5-01's golden has no call sites to exercise it (the build body is `const Placeholder()`); the detection is exercised end-to-end in M5-04's golden where SignalBuilder wraps the `fetchData().when(...)` chain.
 
-**Status:** TODO
+**Status:** DONE
 
 ---
 

--- a/packages/solid_annotations/lib/solid_annotations.dart
+++ b/packages/solid_annotations/lib/solid_annotations.dart
@@ -2,3 +2,4 @@
 library;
 
 export 'src/annotations.dart';
+export 'src/query_extensions.dart';

--- a/packages/solid_annotations/lib/src/annotations.dart
+++ b/packages/solid_annotations/lib/src/annotations.dart
@@ -33,12 +33,35 @@ class SolidEffect {
 }
 
 /// {@template SolidAnnotations.SolidQuery}
-/// Reserved. Full contract deferred to a later SPEC revision;
-/// see SPEC Section 3.2.
+/// Marks an instance method as an async reactive source. See SPEC Section 3.5.
+///
+/// The annotated method must declare a `Future<T>` return type with an `async`
+/// body, or a `Stream<T>` return type whose body either returns a pre-existing
+/// `Stream<T>` or yields with `async*`. The method must take no parameters.
+/// The generator lowers it to a `late final <name> = Resource<T>(…, name: '…')`
+/// (or `Resource<T>.stream(…)`) field whose state any reader of the call site
+/// auto-subscribes to. Source-side `<name>()`, `<name>().when(…)`,
+/// `<name>().maybeWhen(…)`, `<name>().isRefreshing`, and `<name>.refresh()`
+/// chains survive byte-identical in lowered output.
 /// {@endtemplate}
+@Target({TargetKind.method})
 class SolidQuery {
   /// {@macro SolidAnnotations.SolidQuery}
-  const SolidQuery();
+  const SolidQuery({this.name, this.debounce, this.useRefreshing = true});
+
+  /// Optional debug name; defaults to the annotated method's identifier.
+  final String? name;
+
+  /// Optional delay applied to auto-refreshes triggered by upstream reactive
+  /// changes — useful for typeahead-style queries where rapid keystrokes
+  /// should coalesce into a single fetch. Maps to the upstream
+  /// `Resource.debounceDelay:` argument when non-null.
+  final Duration? debounce;
+
+  /// When `true` (the upstream default), an auto-refresh keeps the previous
+  /// `ready` / `error` state and exposes `isRefreshing == true` while the new
+  /// value resolves. When `false`, every refresh re-enters `loading`.
+  final bool useRefreshing;
 }
 
 /// {@template SolidAnnotations.SolidEnvironment}

--- a/packages/solid_annotations/lib/src/query_extensions.dart
+++ b/packages/solid_annotations/lib/src/query_extensions.dart
@@ -1,0 +1,115 @@
+/// Source-time stub extensions for `@SolidQuery` (SPEC §3.5).
+///
+/// These extensions exist solely so that user source — written under
+/// `source/` — typechecks without referencing the codegen-internal
+/// `Resource<T>` / `ResourceState<T>` types from `flutter_solidart`. After
+/// lowering, `<queryName>` is a `Resource<T>` field in `lib/`, and the
+/// `.when` / `.maybeWhen` / `.isRefreshing` / `.refresh()` chain resolves to
+/// upstream `flutter_solidart` callable + extensions on `Resource<T>` /
+/// `ResourceState<T>` directly. Every method body throws because the bodies
+/// are never executed at runtime — the runtime artifact lives entirely in
+/// `lib/`, where these extensions are unreachable.
+///
+/// The receivers follow the SPEC §3.5 surface:
+///
+/// * `.when` / `.maybeWhen` / `.isRefreshing` chain after a method-call
+///   shape (`fetchData()` → `Future<T>` / `Stream<T>`), so they live on
+///   `Future<T>` and `Stream<T>` directly.
+/// * `.refresh()` chains after a method tear-off shape (`fetchData` — no
+///   parens), so its receiver is the function tear-off type
+///   `Future<T> Function()` / `Stream<T> Function()`.
+library;
+
+import 'package:flutter/widgets.dart';
+
+/// Stub `.when` / `.maybeWhen` for `Future<T>`-returning queries. Source-side
+/// usage: `fetchData().when(ready: …, loading: …, error: …)`.
+extension FutureWhen<T> on Future<T> {
+  /// Source-time stub for `<query>().when({ready, loading, error})`. After
+  /// lowering, this resolves to the upstream `flutter_solidart` extension on
+  /// `ResourceState<T>` via `Resource<T>.call() => state`.
+  Widget when({
+    required Widget Function(T data) ready,
+    required Widget Function() loading,
+    required Widget Function(Object error, StackTrace stack) error,
+  }) {
+    throw Exception('This is just a stub for code generation.');
+  }
+
+  /// Source-time stub for `<query>().maybeWhen(...)` with an `orElse:`
+  /// fallback. Same lowering contract as [when].
+  Widget maybeWhen({
+    required Widget Function() orElse,
+    Widget Function(T data)? ready,
+    Widget Function(Object error, StackTrace stack)? error,
+    Widget Function()? loading,
+  }) {
+    throw Exception('This is just a stub for code generation.');
+  }
+}
+
+/// Stub `.when` / `.maybeWhen` for `Stream<T>`-returning queries. Source-side
+/// usage: `watchTicks().when(ready: …, loading: …, error: …)`.
+extension StreamWhen<T> on Stream<T> {
+  /// Source-time stub for `<query>().when({ready, loading, error})`. After
+  /// lowering, this resolves to the upstream `flutter_solidart` extension on
+  /// `ResourceState<T>` via `Resource<T>.call() => state`.
+  Widget when({
+    required Widget Function(T data) ready,
+    required Widget Function() loading,
+    required Widget Function(Object error, StackTrace stack) error,
+  }) {
+    throw Exception('This is just a stub for code generation.');
+  }
+
+  /// Source-time stub for `<query>().maybeWhen(...)` with an `orElse:`
+  /// fallback. Same lowering contract as [when].
+  Widget maybeWhen({
+    required Widget Function() orElse,
+    Widget Function(T data)? ready,
+    Widget Function(Object error, StackTrace stack)? error,
+    Widget Function()? loading,
+  }) {
+    throw Exception('This is just a stub for code generation.');
+  }
+}
+
+/// Stub `.refresh()` on a `Future<T> Function()` tear-off. Source-side
+/// usage: `fetchData.refresh()` (no parens after `fetchData`). After
+/// lowering, `<queryName>` is a `Resource<T>` field and `.refresh()`
+/// resolves to the upstream direct instance method on `Resource<T>`.
+extension RefreshFuture<T> on Future<T> Function() {
+  /// Source-time stub for `<query>.refresh()` on a Future-form query.
+  Future<void> refresh() {
+    throw Exception('This is just a stub for code generation.');
+  }
+}
+
+/// Stub `.refresh()` on a `Stream<T> Function()` tear-off. Same shape as
+/// [RefreshFuture] but for Stream-form queries.
+extension RefreshStream<T> on Stream<T> Function() {
+  /// Source-time stub for `<query>.refresh()` on a Stream-form query.
+  Future<void> refresh() {
+    throw Exception('This is just a stub for code generation.');
+  }
+}
+
+/// Stub `.isRefreshing` on `Future<T>` for Future-form queries. Source-side
+/// usage: `if (fetchData().isRefreshing) …`. After lowering this resolves
+/// through `Resource<T>.call() => state` to the upstream extension on
+/// `ResourceState<T>`.
+extension IsRefreshingFuture<T> on Future<T> {
+  /// Source-time stub for `<query>().isRefreshing` on a Future-form query.
+  bool get isRefreshing {
+    throw Exception('This is just a stub for code generation.');
+  }
+}
+
+/// Stub `.isRefreshing` on `Stream<T>` for Stream-form queries. Same shape as
+/// [IsRefreshingFuture] but for Stream-form queries.
+extension IsRefreshingStream<T> on Stream<T> {
+  /// Source-time stub for `<query>().isRefreshing` on a Stream-form query.
+  bool get isRefreshing {
+    throw Exception('This is just a stub for code generation.');
+  }
+}

--- a/packages/solid_generator/lib/builder.dart
+++ b/packages/solid_generator/lib/builder.dart
@@ -11,6 +11,7 @@ import 'package:solid_generator/src/field_model.dart';
 import 'package:solid_generator/src/getter_model.dart';
 import 'package:solid_generator/src/import_rewriter.dart';
 import 'package:solid_generator/src/plain_class_rewriter.dart';
+import 'package:solid_generator/src/query_model.dart';
 import 'package:solid_generator/src/reserved_annotation_validator.dart';
 import 'package:solid_generator/src/state_class_rewriter.dart';
 import 'package:solid_generator/src/stateless_rewriter.dart';
@@ -88,12 +89,16 @@ class _SolidBuilder implements Builder {
 
     final annotatedClasses = _collectAnnotatedClasses(parsed.unit, source);
     if (annotatedClasses.every(
-      (c) => c.fields.isEmpty && c.getters.isEmpty && c.effects.isEmpty,
+      (c) =>
+          c.fields.isEmpty &&
+          c.getters.isEmpty &&
+          c.effects.isEmpty &&
+          c.queries.isEmpty,
     )) {
-      // Hint matched, but no `@SolidState` field/getter or `@SolidEffect`
-      // method resolved — the file likely contains a comment or string
-      // literal mentioning `@Solid…`. Reserved annotations are caught
-      // upstream.
+      // Hint matched, but no `@SolidState` field/getter, `@SolidEffect`
+      // method, or `@SolidQuery` method resolved — the file likely contains
+      // a comment or string literal mentioning `@Solid…`. Reserved
+      // annotations are caught upstream.
       await buildStep.writeAsString(outputId, source);
       return;
     }
@@ -103,33 +108,35 @@ class _SolidBuilder implements Builder {
   }
 }
 
-/// One class declaration paired with the `@SolidState` fields and getters
-/// and `@SolidEffect` methods it contains.
+/// One class declaration paired with the `@SolidState` fields and getters,
+/// `@SolidEffect` methods, and `@SolidQuery` methods it contains.
 ///
-/// All three lists are empty when the class exists in the source but has no
-/// reactive annotations; such classes are passed through verbatim.
+/// Every annotation list is empty when the class exists in the source but
+/// has no reactive annotations; such classes are passed through verbatim.
 class _AnnotatedClass {
   _AnnotatedClass({
     required this.decl,
     required this.fields,
     required this.getters,
     required this.effects,
+    required this.queries,
   });
   final ClassDeclaration decl;
   final List<FieldModel> fields;
   final List<GetterModel> getters;
   final List<EffectModel> effects;
+  final List<QueryModel> queries;
 }
 
 /// Walks [unit] once and returns every class paired with its `@SolidState`
-/// fields and getters and `@SolidEffect` methods. Replaces an earlier
-/// double-walk (presence check + collection) with a single traversal per
-/// file.
+/// fields and getters, `@SolidEffect` methods, and `@SolidQuery` methods.
+/// Replaces an earlier double-walk (presence check + collection) with a
+/// single traversal per file.
 ///
-/// Fields are read first so a getter or effect body's reactive-name set
-/// already contains every field of the same class; getters then enter the
-/// name set in source order so a later getter or effect can reference an
-/// earlier annotated getter (SPEC §5.1).
+/// Fields are read first so a getter, effect, or query body's reactive-name
+/// set already contains every field of the same class; getters then enter
+/// the name set in source order so a later getter, effect, or query can
+/// reference an earlier annotated getter (SPEC §5.1).
 List<_AnnotatedClass> _collectAnnotatedClasses(
   CompilationUnit unit,
   String source,
@@ -140,6 +147,7 @@ List<_AnnotatedClass> _collectAnnotatedClasses(
     final fields = <FieldModel>[];
     final getters = <GetterModel>[];
     final effects = <EffectModel>[];
+    final queries = <QueryModel>[];
     final reactiveNames = <String>{};
     for (final member in decl.members) {
       if (member is FieldDeclaration) {
@@ -157,13 +165,19 @@ List<_AnnotatedClass> _collectAnnotatedClasses(
           reactiveNames.add(getter.getterName);
           continue;
         }
-        // Effect names are intentionally NOT added to `reactiveNames`:
-        // `@SolidEffect` lowers to a `void`-returning `Effect` with no
-        // observable `.value`, so a sibling effect/getter referencing it
-        // must not get a `.value` rewrite.
+        // Effect / query names are intentionally NOT added to
+        // `reactiveNames`: `@SolidEffect` lowers to a `void`-returning
+        // `Effect` with no observable `.value`, and `@SolidQuery` lowers to
+        // a `Resource<T>` field whose call sites are byte-identical (no
+        // `.value` rewrite) — see SPEC §4.8 rule 2 / §5.1.
         final effect = readSolidEffectMethod(member, reactiveNames, source);
         if (effect != null) {
           effects.add(effect);
+          continue;
+        }
+        final query = readSolidQueryMethod(member, reactiveNames, source);
+        if (query != null) {
+          queries.add(query);
         }
       }
     }
@@ -173,6 +187,7 @@ List<_AnnotatedClass> _collectAnnotatedClasses(
         fields: fields,
         getters: getters,
         effects: effects,
+        queries: queries,
       ),
     );
   }
@@ -191,13 +206,23 @@ String _renderOutput(
   String source,
 ) {
   final results = annotatedClasses.map((c) {
-    if (c.fields.isEmpty && c.getters.isEmpty && c.effects.isEmpty) {
+    if (c.fields.isEmpty &&
+        c.getters.isEmpty &&
+        c.effects.isEmpty &&
+        c.queries.isEmpty) {
       return (
         text: source.substring(c.decl.offset, c.decl.end),
         solidartNames: const <String>{},
       );
     }
-    return _rewriteClass(c.decl, c.fields, c.getters, c.effects, source);
+    return _rewriteClass(
+      c.decl,
+      c.fields,
+      c.getters,
+      c.effects,
+      c.queries,
+      source,
+    );
   }).toList();
 
   final imports = computeOutputImports(
@@ -214,27 +239,47 @@ String _renderOutput(
 }
 
 /// Dispatches on [decl]'s class kind to the matching rewriter.
+///
+/// `@SolidQuery` only lowers on `StatelessWidget` in M5-01. The plain-class
+/// and `State<X>` paths land in M5-08 / M5-09; until then, any query on
+/// those class kinds is rejected at the dispatch boundary so the rewriters
+/// stay query-unaware (their signatures don't change in this PR).
 RewriteResult _rewriteClass(
   ClassDeclaration decl,
   List<FieldModel> fields,
   List<GetterModel> getters,
   List<EffectModel> effects,
+  List<QueryModel> queries,
   String source,
 ) {
   final kind = classKindOf(decl);
+  final className = decl.name.lexeme;
   switch (kind) {
     case ClassKind.statelessWidget:
-      return rewriteStatelessWidget(decl, fields, getters, effects, source);
+      return rewriteStatelessWidget(
+        decl,
+        fields,
+        getters,
+        effects,
+        queries,
+        source,
+      );
     case ClassKind.plainClass:
+      rejectIfQueriesNotYetSupported(queries, 'plain class', className);
       return rewritePlainClass(decl, fields, getters, effects, source);
     case ClassKind.stateClass:
+      rejectIfQueriesNotYetSupported(
+        queries,
+        'existing State<X> subclass',
+        className,
+      );
       return rewriteStateClass(decl, fields, getters, effects, source);
     case ClassKind.statefulWidget:
       throw CodeGenerationError(
         'class-kind $kind is not supported yet '
         '(scheduled for a later M1 TODO)',
         null,
-        decl.name.lexeme,
+        className,
       );
   }
 }

--- a/packages/solid_generator/lib/src/annotation_reader.dart
+++ b/packages/solid_generator/lib/src/annotation_reader.dart
@@ -2,6 +2,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:solid_generator/src/effect_model.dart';
 import 'package:solid_generator/src/field_model.dart';
 import 'package:solid_generator/src/getter_model.dart';
+import 'package:solid_generator/src/query_model.dart';
 import 'package:solid_generator/src/transformation_error.dart';
 import 'package:solid_generator/src/value_rewriter.dart';
 
@@ -19,6 +20,10 @@ const String solidStateName = 'SolidState';
 /// Name of the `@SolidEffect` annotation class. Same matching contract as
 /// [solidStateName] (textual on unresolved AST).
 const String solidEffectName = 'SolidEffect';
+
+/// Name of the `@SolidQuery` annotation class. Same matching contract as
+/// [solidStateName] (textual on unresolved AST).
+const String solidQueryName = 'SolidQuery';
 
 /// Reads a `@SolidState(...)` annotation on [decl] and returns a [FieldModel].
 ///
@@ -102,19 +107,22 @@ GetterModel? readSolidStateGetter(
 }
 
 /// Returns the rewritten body text and whether it came from a block body.
-/// Shared between `readSolidStateGetter` and `readSolidEffectMethod`: both
-/// readers discriminate `ExpressionFunctionBody` vs `BlockFunctionBody`, run
-/// the SPEC §5.1 `.value` rewrite, and reject zero-deps and abstract/native
-/// bodies. Only the error wording differs (SPEC §4.5 vs §3.4) — pass it in.
+/// Shared between `readSolidStateGetter`, `readSolidEffectMethod`, and
+/// `readSolidQueryMethod`: all three discriminate `ExpressionFunctionBody`
+/// vs `BlockFunctionBody`, run the SPEC §5.1 `.value` rewrite, and reject
+/// abstract/native bodies. The zero-deps check (SPEC §4.5 / §3.4) fires
+/// only when [emptyDepsError] is non-null; queries pass `null` because
+/// SPEC §3.5 explicitly waives the reactive-deps requirement. Error wording
+/// differs per caller (SPEC §4.5 vs §3.4 vs §3.5) — pass it in.
 ///
 /// `trackedReadOffsets` are intentionally ignored — SignalBuilder placement
-/// is a `build()` concern, not a `Computed`/`Effect` body concern.
+/// is a `build()` concern, not a `Computed`/`Effect`/`Resource` body concern.
 (String bodyText, bool isBlockBody) _readReactiveBody(
   FunctionBody body,
   Set<String> reactiveFields,
   String source, {
   required String memberName,
-  required String emptyDepsError,
+  required String? emptyDepsError,
   required String unsupportedBodyError,
 }) {
   final AstNode node;
@@ -129,7 +137,7 @@ GetterModel? readSolidStateGetter(
     throw CodeGenerationError(unsupportedBodyError, null, memberName);
   }
   final result = collectValueEdits(node, reactiveFields, source);
-  if (result.edits.isEmpty) {
+  if (emptyDepsError != null && result.edits.isEmpty) {
     throw CodeGenerationError(emptyDepsError, null, memberName);
   }
   final bodyText = applyEditsToRange(
@@ -184,6 +192,64 @@ EffectModel? readSolidEffectMethod(
     methodName: methodName,
     bodyText: bodyText,
     isBlockBody: isBlockBody,
+    annotationName: extractNameArgument(annotation),
+  );
+}
+
+/// Reads a `@SolidQuery(...)` annotation on the method [decl] and returns a
+/// [QueryModel]. Returns `null` when [decl] is not an `@SolidQuery`-bearing
+/// instance method whose return type is `Future<T>` (Stream form not yet
+/// implemented). Getters, setters, and static methods are filtered out here
+/// defensively; the target validator rejects them with a clearer error
+/// before this reader runs.
+///
+/// The method body is rewritten in place per SPEC §5.1: any reference to a
+/// name in [reactiveFields] receives `.value`. Both expression-body
+/// (`Future<T> m() async => …;`) and block-body (`Future<T> m() async {…}`)
+/// shapes are supported per SPEC §3.5 / §4.8. Other body kinds (abstract /
+/// native) are rejected with a [CodeGenerationError].
+///
+/// Unlike [readSolidEffectMethod] / [readSolidStateGetter], this reader does
+/// NOT enforce a reactive-deps requirement — a query body MAY have zero
+/// reactive reads (SPEC §3.5 "No reactive-deps requirement").
+QueryModel? readSolidQueryMethod(
+  MethodDeclaration decl,
+  Set<String> reactiveFields,
+  String source,
+) {
+  if (decl.isGetter || decl.isSetter || decl.isStatic) return null;
+  final annotation = findAnnotationByName(solidQueryName, decl.metadata);
+  if (annotation == null) return null;
+  // Only `Future<T>` return types are handled here; non-`Future`/non-`Stream`
+  // returns are rejected by the target validator and fall through as `null`.
+  final returnType = decl.returnType;
+  if (returnType is! NamedType || returnType.name.lexeme != 'Future') {
+    return null;
+  }
+  final typeArg = returnType.typeArguments?.arguments.firstOrNull;
+  final innerTypeText = typeArg == null
+      ? ''
+      : source.substring(typeArg.offset, typeArg.end);
+
+  final methodName = decl.name.lexeme;
+  // emptyDepsError: null — SPEC §3.5 waives the reactive-deps requirement.
+  final (bodyText, isBlockBody) = _readReactiveBody(
+    decl.body,
+    reactiveFields,
+    source,
+    memberName: methodName,
+    emptyDepsError: null,
+    unsupportedBodyError:
+        '@SolidQuery method must have an expression body (=> ...) or a '
+        'block body ({ ... }); abstract and native bodies are not supported',
+  );
+
+  return QueryModel(
+    methodName: methodName,
+    bodyText: bodyText,
+    isBlockBody: isBlockBody,
+    isAsyncBody: decl.body.keyword?.lexeme == 'async',
+    innerTypeText: innerTypeText,
     annotationName: extractNameArgument(annotation),
   );
 }

--- a/packages/solid_generator/lib/src/build_rewriter.dart
+++ b/packages/solid_generator/lib/src/build_rewriter.dart
@@ -43,19 +43,30 @@ class SourceEdit {
 /// upgrades to resolved-element analysis at M3-05, at which point the call
 /// site swaps to a resolved predicate without restructuring this file.
 ///
+/// [queryNames] is the set of `@SolidQuery` method names declared on the
+/// enclosing class (M5-01). Their zero-arg call sites in the build body are
+/// recorded as tracked reads for SignalBuilder placement (SPEC §4.8 rule 3)
+/// without mutating the call expression itself.
+///
 /// [source] is the full source text of the input file. The returned string
 /// is the rewritten build method (from `@override` through the closing `}`),
 /// ready for the caller to embed into the emitted `State` class.
 String rewriteBuildMethod(
   MethodDeclaration buildMethod,
   Set<String> reactiveFields,
-  String source,
-) {
+  String source, {
+  Set<String> queryNames = const {},
+}) {
   final methodStart = buildMethod.offset;
   final methodEnd = buildMethod.end;
   final methodText = source.substring(methodStart, methodEnd);
 
-  final valueResult = collectValueEdits(buildMethod, reactiveFields, source);
+  final valueResult = collectValueEdits(
+    buildMethod,
+    reactiveFields,
+    source,
+    queryNames: queryNames,
+  );
   final wrapNodes = computeWrapSet(buildMethod, valueResult.trackedReadOffsets);
 
   final edits = <SourceEdit>[];

--- a/packages/solid_generator/lib/src/query_model.dart
+++ b/packages/solid_generator/lib/src/query_model.dart
@@ -1,0 +1,113 @@
+import 'package:meta/meta.dart';
+import 'package:solid_generator/src/transformation_error.dart';
+
+/// Parsed description of one `@SolidQuery`-annotated method.
+///
+/// Populated by `annotation_reader.dart` from unresolved AST and consumed by
+/// the rewriters (currently `stateless_rewriter.dart`). All string members are
+/// the raw source text of the corresponding AST node — except [bodyText],
+/// which is the source-substring of the method body with the SPEC §5.1
+/// `.value` rewrites already applied so the emitter can splice it directly
+/// into the `Resource(...)` fetcher closure.
+///
+/// Mirrors `EffectModel` for the parallel `@SolidEffect` method → `Effect`
+/// lowering (SPEC §4.7). The two models share an identical body-rewrite
+/// contract; the differences are (a) queries carry an [innerTypeText] for the
+/// `Resource<T>` type argument, (b) queries preserve the [isAsyncBody]
+/// keyword to splice into the emitted closure, and (c) queries do NOT enforce
+/// a reactive-deps requirement (SPEC §3.5 — a query body MAY have zero
+/// reactive reads).
+@immutable
+class QueryModel {
+  /// Creates a [QueryModel] describing an annotated method.
+  const QueryModel({
+    required this.methodName,
+    required this.bodyText,
+    required this.isBlockBody,
+    required this.isAsyncBody,
+    required this.innerTypeText,
+    this.isStream = false,
+    this.debounce,
+    this.useRefreshing,
+    this.annotationName,
+  });
+
+  /// Declared identifier of the method (e.g. `'fetchData'`). Used as the
+  /// public field name on the lowered class — no underscore prefix per
+  /// SPEC §4.8 rule 1.
+  final String methodName;
+
+  /// Source text of the method's body with the SPEC §5.1 reactive-read
+  /// rewrite already applied. The shape depends on [isBlockBody]:
+  ///
+  /// * **Expression body** (SPEC §4.8, [isBlockBody] is `false`): the
+  ///   rewritten expression text alone — for an input
+  ///   `Future<int> fetchOne() async => 1;`, this is the string `'1'`.
+  ///   The emitter wraps it in `() async => <text>`.
+  /// * **Block body** (SPEC §4.8, [isBlockBody] is `true`): the rewritten
+  ///   block including its braces — for an input
+  ///   `Future<int> fetchOne() async { return 1; }`, this is
+  ///   `'{ return 1; }'`. The emitter wraps it in `() async <text>`.
+  final String bodyText;
+
+  /// True when the source method has a block body (`Future<T> m() async {…}`);
+  /// false for an expression body (`Future<T> m() async => …;`). Determines
+  /// how the emitter shapes the closure passed to `Resource(...)`.
+  final bool isBlockBody;
+
+  /// True when the source method's body keyword is `async` (Future form) or
+  /// `async*` (Stream form). The emitter splices `async ` into the closure
+  /// signature so the lowered fetcher preserves the async semantics.
+  ///
+  /// In M5-01 only Future + `async` is reachable; the Stream + plain-bodied
+  /// path lands in M5-02 where this flag stays `false`.
+  final bool isAsyncBody;
+
+  /// Source text of the inner type `T` peeled from the method's `Future<T>`
+  /// (or in M5-02, `Stream<T>`) return type. Used as the `Resource<T>` type
+  /// argument in lowered output.
+  final String innerTypeText;
+
+  /// True when the source return type is `Stream<T>`; false for `Future<T>`.
+  /// Reserved in M5-01 for the M5-02 Stream-form branch in `emitResourceField`.
+  final bool isStream;
+
+  /// Value of the `debounce:` argument on `@SolidQuery(debounce: …)`, or
+  /// `null` if the annotation had no `debounce:` argument. Reserved in M5-01
+  /// for M5-11 — present on the model so future readers don't reshape it.
+  final Duration? debounce;
+
+  /// Value of the `useRefreshing:` argument on `@SolidQuery(useRefreshing: …)`,
+  /// or `null` if the annotation had no `useRefreshing:` argument. Reserved
+  /// in M5-01 for M5-11 — present on the model so future readers don't
+  /// reshape it.
+  final bool? useRefreshing;
+
+  /// Value of the `name:` argument on `@SolidQuery(name: '…')`, or `null` if
+  /// the annotation had no `name:` argument (SPEC §3.5 / §4.8 rule 8).
+  final String? annotationName;
+}
+
+/// Throws [CodeGenerationError] when [solidQueries] is non-empty, naming the
+/// first offending method and the [classKindLabel] (`'plain class'`,
+/// `'existing State<X> subclass'`, …) of the rewriter that has not yet
+/// implemented method→`Resource` lowering.
+///
+/// Mirrors `rejectIfEffectsNotYetSupported` in `effect_model.dart`: the
+/// message template lives in one place so two rewriters' "not yet supported"
+/// errors can never drift. The StatelessWidget path lands in M5-01; the
+/// `State<X>` and plain-class paths land in M5-08 / M5-09.
+void rejectIfQueriesNotYetSupported(
+  List<QueryModel> solidQueries,
+  String classKindLabel,
+  String className,
+) {
+  if (solidQueries.isEmpty) return;
+  throw CodeGenerationError(
+    '@SolidQuery on $classKindLabel is not yet supported '
+    '(will land in M5-08/M5-09); '
+    'offending method: ${solidQueries.first.methodName}',
+    null,
+    className,
+  );
+}

--- a/packages/solid_generator/lib/src/reserved_annotation_validator.dart
+++ b/packages/solid_generator/lib/src/reserved_annotation_validator.dart
@@ -8,17 +8,17 @@ import 'package:solid_generator/src/transformation_error.dart';
 /// the violation code stamped onto [ValidationError.violationType].
 ///
 /// `SolidEffect` is no longer in this list as of M4-01: the annotation now
-/// lowers to `Effect(() { … })` per SPEC §4.7. Only the still-deferred
-/// `@SolidQuery` and `@SolidEnvironment` remain reserved; both ship in
-/// later milestones before v2 release (SPEC §13).
+/// lowers to `Effect(() { … })` per SPEC §4.7. `SolidQuery` is no longer in
+/// this list as of M5-01: the annotation now lowers to `Resource(...)` per
+/// SPEC §4.8. Only `@SolidEnvironment` remains reserved; it ships in a
+/// later milestone before v2 release (SPEC §13).
 const Map<String, String> _reservedAnnotations = {
-  'SolidQuery': 'RESERVED_ANNOTATION_SOLID_QUERY',
   'SolidEnvironment': 'RESERVED_ANNOTATION_SOLID_ENVIRONMENT',
 };
 
-/// SPEC §3.2 + §13 build-time guard: reject any `@SolidQuery` or
-/// `@SolidEnvironment` use with a clear error that names the annotation and
-/// quotes the SPEC §3.2 phrase verbatim.
+/// SPEC §3.2 + §13 build-time guard: reject any `@SolidEnvironment` use with
+/// a clear error that names the annotation and quotes the SPEC §3.2 phrase
+/// verbatim.
 ///
 /// Runs before transformation so users learn at build time that they're
 /// using a not-yet-implemented annotation, instead of debugging missing

--- a/packages/solid_generator/lib/src/signal_emitter.dart
+++ b/packages/solid_generator/lib/src/signal_emitter.dart
@@ -1,6 +1,7 @@
 import 'package:solid_generator/src/effect_model.dart';
 import 'package:solid_generator/src/field_model.dart';
 import 'package:solid_generator/src/getter_model.dart';
+import 'package:solid_generator/src/query_model.dart';
 
 /// Shared signal-emission helpers used by every class-kind rewriter.
 
@@ -68,6 +69,33 @@ String emitEffectField(EffectModel e) {
   final closure = e.isBlockBody ? '() ${e.bodyText}' : '() => ${e.bodyText}';
   final ctor = "Effect($closure, name: '$debugName')";
   return '  late final ${e.methodName} = $ctor;';
+}
+
+/// Emits one `late final <name> = Resource<T>(<closure>, name: '<debug>');`
+/// line per SPEC §4.8. Mirrors [emitEffectField]'s closure-shape contract —
+/// same `late final` rationale, same body-text contract — but adds:
+///
+/// * a type argument `Resource<T>` peeled from the source `Future<T>` /
+///   `Stream<T>` return type (carried on [QueryModel.innerTypeText]),
+/// * an `async ` keyword spliced into the closure signature when
+///   [QueryModel.isAsyncBody] is true (Future-form queries require `async`;
+///   plain-bodied Stream queries leave the keyword empty), and
+/// * a public field name (no underscore prefix) — SPEC §4.8 rule 1 specifies
+///   a single emitted declaration per query.
+///
+/// The Resource field always joins the unified ordered dispose list managed
+/// by [emitDispose] (SPEC §4.8 rule 11). Resources are NEVER materialized in
+/// `initState()` / the synthesized constructor — the lazy `late final`
+/// initializer fires on first read at the first reactive call site
+/// (SPEC §4.8 rule 10 / §14 item 4).
+String emitResourceField(QueryModel q) {
+  final debugName = q.annotationName ?? q.methodName;
+  final asyncKw = q.isAsyncBody ? 'async ' : '';
+  final closure = q.isBlockBody
+      ? '() $asyncKw${q.bodyText}'
+      : '() $asyncKw=> ${q.bodyText}';
+  final ctor = "Resource<${q.innerTypeText}>($closure, name: '$debugName')";
+  return '  late final ${q.methodName} = $ctor;';
 }
 
 /// Emits a `dispose()` method disposing every name in

--- a/packages/solid_generator/lib/src/stateless_rewriter.dart
+++ b/packages/solid_generator/lib/src/stateless_rewriter.dart
@@ -4,14 +4,16 @@ import 'package:solid_generator/src/effect_model.dart';
 import 'package:solid_generator/src/field_model.dart';
 import 'package:solid_generator/src/getter_model.dart';
 import 'package:solid_generator/src/import_rewriter.dart';
+import 'package:solid_generator/src/query_model.dart';
 import 'package:solid_generator/src/signal_emitter.dart';
 import 'package:solid_generator/src/transformation_error.dart';
 
 /// Rewrites a `StatelessWidget` class containing `@SolidState` fields,
-/// `@SolidState` getters, and/or `@SolidEffect` methods as a
-/// `StatefulWidget` + `State<X>` pair. See SPEC §8.1 for the full
-/// field-partition and constructor-preservation contract; SPEC §4.5 for the
-/// getter→`Computed` lowering; SPEC §4.7 for the method→`Effect` lowering.
+/// `@SolidState` getters, `@SolidEffect` methods, and/or `@SolidQuery`
+/// methods as a `StatefulWidget` + `State<X>` pair. See SPEC §8.1 for the
+/// full field-partition and constructor-preservation contract; SPEC §4.5 for
+/// the getter→`Computed` lowering; SPEC §4.7 for the method→`Effect`
+/// lowering; SPEC §4.8 for the method→`Resource` lowering.
 ///
 /// The emitted string is syntactically valid Dart but is not guaranteed to be
 /// pretty-printed — run through `DartFormatter` before writing.
@@ -20,6 +22,7 @@ RewriteResult rewriteStatelessWidget(
   List<FieldModel> solidFields,
   List<GetterModel> solidGetters,
   List<EffectModel> solidEffects,
+  List<QueryModel> solidQueries,
   String source,
 ) {
   final className = classDecl.name.lexeme;
@@ -28,6 +31,12 @@ RewriteResult rewriteStatelessWidget(
     ...solidFields.map((f) => f.fieldName),
     ...solidGetters.map((g) => g.getterName),
   };
+  // SPEC §4.8 rule 3: query call expressions in `build` are tracked reads.
+  // Names are kept separate from `reactiveNames` so the `.value` rewrite
+  // (SPEC §5.1) does not fire on `<queryName>` identifiers.
+  final queryNames = solidQueries.isEmpty
+      ? const <String>{}
+      : {for (final q in solidQueries) q.methodName};
 
   final members = _splitMembers(classDecl);
   final widgetBoundNames = _collectWidgetBoundNames(members.ctors);
@@ -42,6 +51,7 @@ RewriteResult rewriteStatelessWidget(
     members.buildMethod,
     reactiveNames,
     source,
+    queryNames: queryNames,
   );
 
   final reactiveBlock = _emitReactiveBlock(
@@ -49,6 +59,7 @@ RewriteResult rewriteStatelessWidget(
     solidFields,
     solidGetters,
     solidEffects,
+    solidQueries,
   );
 
   final widgetClass = _emitWidgetClass(
@@ -71,6 +82,7 @@ RewriteResult rewriteStatelessWidget(
   final solidartNames = <String>{'Signal', 'SignalBuilder'};
   if (solidGetters.isNotEmpty) solidartNames.add('Computed');
   if (solidEffects.isNotEmpty) solidartNames.add('Effect');
+  if (solidQueries.isNotEmpty) solidartNames.add('Resource');
 
   return (
     text: '$widgetClass\n\n$stateClass\n',
@@ -79,17 +91,20 @@ RewriteResult rewriteStatelessWidget(
 }
 
 /// Returns the source-ordered emission of every reactive declaration on
-/// [classDecl] (Signal field + Computed getter + Effect method) as a single
-/// 2-space-indented block, plus the declaration-order list of dispose names
-/// that pairs with it. Source order is the contract that `Computed` and
-/// `Effect` depend on: each must reference declarations defined before it,
-/// so the emitted `late final` lines must appear after the declarations they
-/// read in the rewritten State class.
+/// [classDecl] (Signal field + Computed getter + Effect method + Resource
+/// query) as a single 2-space-indented block, plus the declaration-order
+/// list of dispose names that pairs with it. Source order is the contract
+/// that `Computed`, `Effect`, and the future M5-10 query-source-Computed
+/// depend on: each must reference declarations defined before it, so the
+/// emitted `late final` lines must appear after the declarations they read
+/// in the rewritten State class.
 ///
 /// `effectNamesInDeclarationOrder` is the Effect-only subset of
-/// `disposeNamesInDeclarationOrder`, pulled out so the rewriter can synthesize
-/// `initState()` that materializes each `late final` Effect field at mount
-/// time (SPEC §4.7).
+/// `disposeNamesInDeclarationOrder`, pulled out so the rewriter can
+/// synthesize `initState()` that materializes each `late final` Effect field
+/// at mount time (SPEC §4.7). Queries are intentionally NOT in this list —
+/// per SPEC §4.8 rule 10 / §14 item 4, Resources are lazy and the late-final
+/// initializer fires on first call-site read, never via `initState`.
 ({
   String fieldsText,
   List<String> disposeNamesInDeclarationOrder,
@@ -100,10 +115,12 @@ _emitReactiveBlock(
   List<FieldModel> solidFields,
   List<GetterModel> solidGetters,
   List<EffectModel> solidEffects,
+  List<QueryModel> solidQueries,
 ) {
   final fieldByName = {for (final f in solidFields) f.fieldName: f};
   final getterByName = {for (final g in solidGetters) g.getterName: g};
   final effectByName = {for (final e in solidEffects) e.methodName: e};
+  final queryByName = {for (final q in solidQueries) q.methodName: q};
   final lines = <String>[];
   final disposeNames = <String>[];
   final effectNames = <String>[];
@@ -132,6 +149,12 @@ _emitReactiveBlock(
           lines.add(emitEffectField(e));
           disposeNames.add(e.methodName);
           effectNames.add(e.methodName);
+          continue;
+        }
+        final q = queryByName[name];
+        if (q != null) {
+          lines.add(emitResourceField(q));
+          disposeNames.add(q.methodName);
         }
       }
     }

--- a/packages/solid_generator/lib/src/value_rewriter.dart
+++ b/packages/solid_generator/lib/src/value_rewriter.dart
@@ -65,6 +65,16 @@ bool _isOnPrefixedCallbackName(String name) {
 /// (`buildStep.resolver.compilationUnitFor` + `staticType` subtype queries)
 /// is deferred — it is the architectural prerequisite for M3-09 (shadowing).
 ///
+/// [queryNames] is the name-set of `@SolidQuery` methods declared on the
+/// enclosing class (M5-01). Zero-argument `MethodInvocation`s whose target is
+/// a bare `SimpleIdentifier` matching a query name (and not shadowed, and not
+/// inside an untracked context) have their offsets recorded in
+/// [ValueRewriteResult.trackedReadOffsets] so SPEC §7 SignalBuilder placement
+/// can wrap their enclosing widget subtree (SPEC §4.8 rule 3). NO source
+/// edit is emitted for the call expression itself — the call survives
+/// byte-identical because the lowered `<name>()` resolves through
+/// `Resource<T>.call() => state` to upstream extensions on `ResourceState<T>`.
+///
 /// [node] is typically the `build()` `MethodDeclaration` (the M1-05 path) or
 /// the body expression of a `@SolidState` getter (the M2-01 path). Both share
 /// the same identifier-rewrite contract; only `build()` consumes
@@ -72,9 +82,10 @@ bool _isOnPrefixedCallbackName(String name) {
 ValueRewriteResult collectValueEdits(
   AstNode node,
   Set<String> reactiveFields,
-  String source,
-) {
-  final visitor = _ValueRewriteVisitor(reactiveFields);
+  String source, {
+  Set<String> queryNames = const {},
+}) {
+  final visitor = _ValueRewriteVisitor(reactiveFields, queryNames);
   node.accept(visitor);
   return ValueRewriteResult(visitor.edits, visitor.trackedReadOffsets);
 }
@@ -113,9 +124,14 @@ const String _untrackedValueGetterName = 'untrackedValue';
 /// enclosing block. M3-09 replaces this heuristic with type-driven
 /// shadowing resolution.
 class _ValueRewriteVisitor extends RecursiveAstVisitor<void> {
-  _ValueRewriteVisitor(this._reactiveFields);
+  _ValueRewriteVisitor(this._reactiveFields, this._queryNames);
 
   final Set<String> _reactiveFields;
+
+  /// Per-class set of `@SolidQuery` method names. Empty when collecting edits
+  /// for a non-`build` body (M5-01 query-call detection only fires on
+  /// `build`'s body, where SignalBuilder placement consumes the offsets).
+  final Set<String> _queryNames;
   final List<ValueEdit> edits = [];
   final List<int> trackedReadOffsets = [];
 
@@ -175,6 +191,20 @@ class _ValueRewriteVisitor extends RecursiveAstVisitor<void> {
         null,
         'untracked() function-call form',
       );
+    }
+    // SPEC §4.8 rule 3: a zero-argument call to an `@SolidQuery` method on
+    // the enclosing class is a tracked read for SignalBuilder placement —
+    // the runtime subscription happens inside `Resource.call()` → `state`.
+    // No source edit is emitted: `fetchData()` survives byte-identical
+    // because the lowered field is a `Resource<T>` whose upstream callable
+    // returns `ResourceState<T>` and the trailing chain resolves to upstream
+    // extensions. Shadowing follows SPEC §5.5.
+    if (node.target == null &&
+        node.argumentList.arguments.isEmpty &&
+        _queryNames.contains(node.methodName.name) &&
+        !_isShadowed(node.methodName.name) &&
+        _untrackedDepth == 0) {
+      trackedReadOffsets.add(node.offset);
     }
     super.visitMethodInvocation(node);
   }

--- a/packages/solid_generator/test/golden/inputs/m1_15_query.dart
+++ b/packages/solid_generator/test/golden/inputs/m1_15_query.dart
@@ -1,6 +1,0 @@
-import 'package:solid_annotations/solid_annotations.dart';
-
-class Foo {
-  @SolidQuery()
-  Future<int> fetch() async => 0;
-}

--- a/packages/solid_generator/test/golden/inputs/m5_01_simple_query_with_future.dart
+++ b/packages/solid_generator/test/golden/inputs/m5_01_simple_query_with_future.dart
@@ -1,0 +1,23 @@
+// SPEC §3.5 query example: an async fetcher that delays before returning.
+// `Future.delayed` returns `Future<void>` here — explicit type-arg silences
+// `inference_failure_on_instance_creation` from the strict golden lints.
+// The `Greeter` widget has only a query (no mutable `@SolidState` field) so
+// its constructor could be const before lowering, but the SPEC §2 source
+// model writes user-facing widgets with non-const constructors uniformly.
+// ignore_for_file: prefer_const_constructors_in_immutables
+
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+
+class Greeter extends StatelessWidget {
+  Greeter({super.key});
+
+  @SolidQuery()
+  Future<String> fetchData() async {
+    await Future<void>.delayed(const Duration(seconds: 1));
+    return 'fetched';
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/golden/outputs/m5_01_simple_query_with_future.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m5_01_simple_query_with_future.g.dart
@@ -1,0 +1,26 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class Greeter extends StatefulWidget {
+  Greeter({super.key});
+
+  @override
+  State<Greeter> createState() => _GreeterState();
+}
+
+class _GreeterState extends State<Greeter> {
+  late final fetchData = Resource<String>(() async {
+    await Future<void>.delayed(const Duration(seconds: 1));
+    return 'fetched';
+  }, name: 'fetchData');
+
+  @override
+  void dispose() {
+    fetchData.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -46,6 +46,7 @@ const List<String> goldenNames = <String>[
   'm4_03_effect_block_body_shadowing',
   'm4_08_effect_on_state_class',
   'm4_08_effect_on_plain_class',
+  'm5_01_simple_query_with_future',
 ];
 
 /// Memoized golden directory resolution. Resolved relative to the package

--- a/packages/solid_generator/test/rejections/m1_15_non_m1_annotations_test.dart
+++ b/packages/solid_generator/test/rejections/m1_15_non_m1_annotations_test.dart
@@ -1,18 +1,13 @@
 // Rejection suite for M1-15: reserved annotations from SPEC §3.2 + §13.
-// Each case asserts that placing `@SolidQuery` or `@SolidEnvironment`
-// anywhere in a source file produces a build-time error quoting the SPEC
-// §3.2 phrase verbatim. `@SolidEffect` shipped in M4 and is no longer
-// reserved (M4-06 / pulled-into-M4-01).
+// Each case asserts that placing `@SolidEnvironment` anywhere in a source
+// file produces a build-time error quoting the SPEC §3.2 phrase verbatim.
+// `@SolidEffect` shipped in M4 and is no longer reserved (M4-06 /
+// pulled-into-M4-01); `@SolidQuery` shipped in M5 and is no longer reserved
+// (M5-01) — the former rejection case migrated to a positive M5-01 golden.
 
 import '../integration/golden_helpers.dart';
 
 const List<({String name, String errorContains})> _cases = [
-  (
-    name: 'm1_15_query',
-    errorContains:
-        '@SolidQuery is not yet implemented; '
-        'scheduled for a later v2 milestone',
-  ),
   (
     name: 'm1_15_environment',
     errorContains:


### PR DESCRIPTION
## Summary

- Implement `@SolidQuery` annotation lowering for the Future form: instance methods with `Future<T>` return type and `async` body become `late final <name> = Resource<T>(() async { … }, name: '…')` fields on the synthesized `State<T>` class (SPEC §3.5, §4.8). Single public field per query — no underscore prefix, no thin-accessor wrapper.
- Mirror the M4-01 (`@SolidEffect` method → `Effect`) pipeline: new `QueryModel`, `readSolidQueryMethod` reader (skips the §3.5-waived zero-deps check), `emitResourceField` emitter, and a Future-returning non-getter `MethodDeclaration` branch in both `_collectAnnotatedClasses` and `_emitReactiveBlock`.
- Support both expression-body (`Future<T> m() async => …;`) and block-body (`Future<T> m() async { … }`) shapes. SPEC §5.1 reactive-read rewrites apply inside the body.
- Resources are NEVER materialized in `initState()` per SPEC §4.8 rule 10 / §14 item 4 — the `late final` initializer fires lazily on first call-site read. Disposal joins the unified reverse-declaration order alongside Signals / Computeds / Effects (SPEC §10).
- SignalBuilder-placement detection (SPEC §4.8 rule 3): the body-rewrite visitor records zero-arg `<queryName>()` call offsets in `trackedReadOffsets` so §7 wraps the enclosing widget subtree. The call expression is NOT mutated — at runtime `<name>()` resolves through `Resource<T>.call() => state` to upstream extensions on `ResourceState<T>`. Detection is registered in M5-01; exercised end-to-end in M5-04.
- Pull M4-01-style migration into M5-01: remove `'SolidQuery'` from `_reservedAnnotations`, drop the `m1_15_query` rejection case, and migrate the input fixture to a positive M5-01 golden.
- `solid_annotations`: replace the `SolidQuery` placeholder with the full annotation (`@Target({TargetKind.method})`, optional `name` / `debounce` / `useRefreshing` parameters per SPEC §3.5; `debounce` and `useRefreshing` ship to output in M5-11). Add `query_extensions.dart` with the six runtime-throwing source-time stubs verbatim from the v1 reference: `FutureWhen` / `StreamWhen` / `RefreshFuture` (on `Future<T> Function()`) / `RefreshStream` / `IsRefreshingFuture` / `IsRefreshingStream`. Bodies throw because they're never executed at runtime — the lowered artifact is a `Resource<T>` field where the chain resolves to upstream `flutter_solidart` callable + extensions on `ResourceState<T>`.
- Reject `@SolidQuery` on `State<X>` subclasses and plain classes at the dispatch boundary in `builder.dart::_rewriteClass` with `rejectIfQueriesNotYetSupported(...)` pointing to M5-08 / M5-09. The `state_class_rewriter.dart` and `plain_class_rewriter.dart` signatures stay query-unaware in this PR; they grow query support in M5-08 / M5-09.
- Simplify-pass cleanups: unify `_readReactiveBody` to take a nullable `emptyDepsError` (queries pass `null` to skip the SPEC §3.5-waived check) — eliminates the initial copy-paste; trim milestone-narration comments that would go stale; short-circuit the empty-set `queryNames` allocation in `rewriteStatelessWidget`.

## Testing

- New golden `m5_01_simple_query_with_future` verifies single public `late final fetchData = Resource<String>(...)` field, `dispose()` calling `fetchData.dispose()` then `super.dispose()`, NO synthesized `initState()`, and `flutter_solidart` import injection.
- `dart test packages/solid_generator/`: 82 tests pass (every prior golden + new M5-01 golden + new M5-01 idempotency; `m1_15_query` rejection case removed).
- `dart analyze --fatal-infos packages/solid_annotations packages/solid_generator`: zero issues.
- `dart analyze packages/solid_generator/test/golden/outputs/ --fatal-infos`: zero issues.
- `dart format --set-exit-if-changed packages/solid_annotations packages/solid_generator`: zero diff.
- `build_runner build` on `example/`: success (no regression on the existing `counter.dart` source).
- TODOS.md: M5-01 flipped to DONE.