### PR TITLE
Implement M5-02: Stream-form @SolidQuery queries

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1648,9 +1648,9 @@ class _GreeterState extends State<Greeter> {
 
 ---
 
-### TODO M5-02 — Golden: `@SolidQuery` Stream-method form
+### DONE M5-02 — Golden: `@SolidQuery` Stream-method form
 
-**Goal:** `@SolidQuery() Stream<int> watchTicks() => Stream.periodic(const Duration(seconds: 1), (i) => i);` on a `StatelessWidget` becomes `late final _watchTicks = Resource<int>.stream(() => Stream.periodic(...), name: 'watchTicks');` plus `Resource<int> watchTicks() => _watchTicks;`. Adds the `Resource<T>.stream(...)` branch in `emitResourceField`, the `isStream` discriminator in `QueryModel`, and the Stream-form body handling in `readSolidQueryMethod` (plain-bodied returning a Stream, OR `async*` block-bodied).
+**Goal:** `@SolidQuery() Stream<int> watchTicks() { return Stream.periodic(const Duration(seconds: 1), (i) => i); }` on a `StatelessWidget` becomes a single `late final watchTicks = Resource<int>.stream(() { return Stream.periodic(...); }, name: 'watchTicks');` field — no underscore prefix, no thin-accessor wrapper, matching SPEC §4.8 rule 1 and the M5-01 lowering shape. Adds the `Resource<T>.stream(...)` branch in `emitResourceField`, the `isStream` discriminator in `QueryModel`, generalizes the body keyword to a single `bodyKeyword: String` field (preserving `async`, `async*`, or empty), and adds the Stream-form body handling in `readSolidQueryMethod` (plain-bodied returning a Stream, OR `async*` block-bodied).
 
 **SPEC references:** Section 3.5, Section 4.8 (Stream form).
 
@@ -1662,9 +1662,9 @@ class _GreeterState extends State<Greeter> {
 
 **Files to modify:**
 
-- `packages/solid_generator/lib/src/query_model.dart` — confirm `isStream` flag is consumed.
-- `packages/solid_generator/lib/src/annotation_reader.dart` — extend `readSolidQueryMethod` to detect `Stream<T>` return type and either body shape (synchronous returning a `Stream<T>`, OR `async*` block); set `isStream: true`.
-- `packages/solid_generator/lib/src/signal_emitter.dart` — extend `emitResourceField` to emit `Resource<T>.stream(...)` instead of `Resource<T>(...)` when `isStream` is true.
+- `packages/solid_generator/lib/src/query_model.dart` — `isStream` flag is consumed; replaced the M5-01 `isAsyncBody: bool` with a generalized `bodyKeyword: String` field (`'async'`, `'async*'`, or `''`) so the emitter splices the source body keyword verbatim.
+- `packages/solid_generator/lib/src/annotation_reader.dart` — extend `readSolidQueryMethod` to detect `Stream<T>` return type and either body shape (synchronous returning a `Stream<T>`, OR `async*` block); set `isStream: true`; route `decl.body.keyword?.lexeme` directly into `bodyKeyword`. Adds `futureLexeme` / `streamLexeme` constants alongside `solidStateName` / `solidEffectName` / `solidQueryName`.
+- `packages/solid_generator/lib/src/signal_emitter.dart` — extend `emitResourceField` to emit `Resource<T>.stream(...)` instead of `Resource<T>(...)` when `isStream` is true, and to splice the source `bodyKeyword` (with trailing space) into the closure signature.
 
 **Expected input content:**
 
@@ -1685,15 +1685,15 @@ class Ticker extends StatelessWidget {
 }
 ```
 
-**Expected output content:** State class with `late final _watchTicks = Resource<int>.stream(() => Stream.periodic(const Duration(seconds: 1), (i) => i), name: 'watchTicks');` plus `Resource<int> watchTicks() => _watchTicks;`. Standard `dispose()` body.
+**Expected output content:** State class with `late final watchTicks = Resource<int>.stream(() { return Stream.periodic(const Duration(seconds: 1), (i) => i); }, name: 'watchTicks');` (single public field, no underscore prefix, no thin-accessor wrapper — SPEC §4.8 rule 1). Standard `dispose()` body. No `initState()` (Resources are lazy per §4.8 rule 10).
 
-**Expected implementation change:** Stream-form branch in `emitResourceField` plus `isStream` detection in the reader. No changes to dispose / accessor / import paths beyond what M5-01 already established.
+**Expected implementation change:** Stream-form branch in `emitResourceField` plus `isStream` detection in the reader plus generalized `bodyKeyword: String` model field replacing `isAsyncBody: bool` (so `async*` bodies are preserved verbatim). No changes to dispose / import paths beyond what M5-01 already established.
 
-**Acceptance:** `dart test --name=m5_02` passes; golden analyzes clean; emitted code uses `Resource<T>.stream(...)` named constructor; the thin-accessor's return type is `Resource<int>`.
+**Acceptance:** `dart test --name=m5_02` passes; golden analyzes clean; emitted code uses `Resource<T>.stream(...)` named constructor; the public field's runtime type is `Resource<int>`.
 
 **Dependencies:** M5-01.
 
-**Status:** TODO
+**Status:** DONE
 
 ---
 

--- a/packages/solid_generator/lib/src/annotation_reader.dart
+++ b/packages/solid_generator/lib/src/annotation_reader.dart
@@ -25,6 +25,16 @@ const String solidEffectName = 'SolidEffect';
 /// [solidStateName] (textual on unresolved AST).
 const String solidQueryName = 'SolidQuery';
 
+/// Lexeme of the `Future` return-type identifier on a `@SolidQuery` method.
+/// Matched textually on the unresolved AST per the same contract as
+/// [solidStateName] — the user must import `dart:async` (or its re-export via
+/// `dart:core`) to write the type at all.
+const String futureLexeme = 'Future';
+
+/// Lexeme of the `Stream` return-type identifier on a `@SolidQuery` method.
+/// Same matching contract as [futureLexeme].
+const String streamLexeme = 'Stream';
+
 /// Reads a `@SolidState(...)` annotation on [decl] and returns a [FieldModel].
 ///
 /// Returns `null` if [decl] carries no `@SolidState` annotation. The raw
@@ -198,16 +208,16 @@ EffectModel? readSolidEffectMethod(
 
 /// Reads a `@SolidQuery(...)` annotation on the method [decl] and returns a
 /// [QueryModel]. Returns `null` when [decl] is not an `@SolidQuery`-bearing
-/// instance method whose return type is `Future<T>` (Stream form not yet
-/// implemented). Getters, setters, and static methods are filtered out here
-/// defensively; the target validator rejects them with a clearer error
-/// before this reader runs.
+/// instance method whose return type is `Future<T>` or `Stream<T>`. Getters,
+/// setters, and static methods are filtered out here defensively; the target
+/// validator rejects them with a clearer error before this reader runs.
 ///
 /// The method body is rewritten in place per SPEC §5.1: any reference to a
 /// name in [reactiveFields] receives `.value`. Both expression-body
-/// (`Future<T> m() async => …;`) and block-body (`Future<T> m() async {…}`)
-/// shapes are supported per SPEC §3.5 / §4.8. Other body kinds (abstract /
-/// native) are rejected with a [CodeGenerationError].
+/// (`Future<T> m() async => …;` / `Stream<T> m() => …;`) and block-body
+/// (`Future<T> m() async {…}` / `Stream<T> m() async* {…}` /
+/// `Stream<T> m() {…}`) shapes are supported per SPEC §3.5 / §4.8. Other body
+/// kinds (abstract / native) are rejected with a [CodeGenerationError].
 ///
 /// Unlike [readSolidEffectMethod] / [readSolidStateGetter], this reader does
 /// NOT enforce a reactive-deps requirement — a query body MAY have zero
@@ -220,10 +230,11 @@ QueryModel? readSolidQueryMethod(
   if (decl.isGetter || decl.isSetter || decl.isStatic) return null;
   final annotation = findAnnotationByName(solidQueryName, decl.metadata);
   if (annotation == null) return null;
-  // Only `Future<T>` return types are handled here; non-`Future`/non-`Stream`
-  // returns are rejected by the target validator and fall through as `null`.
+  // Other return types silently fall through; rejection lands in M5-05.
   final returnType = decl.returnType;
-  if (returnType is! NamedType || returnType.name.lexeme != 'Future') {
+  if (returnType is! NamedType) return null;
+  final returnTypeName = returnType.name.lexeme;
+  if (returnTypeName != futureLexeme && returnTypeName != streamLexeme) {
     return null;
   }
   final typeArg = returnType.typeArguments?.arguments.firstOrNull;
@@ -248,8 +259,9 @@ QueryModel? readSolidQueryMethod(
     methodName: methodName,
     bodyText: bodyText,
     isBlockBody: isBlockBody,
-    isAsyncBody: decl.body.keyword?.lexeme == 'async',
     innerTypeText: innerTypeText,
+    bodyKeyword: decl.body.keyword?.lexeme ?? '',
+    isStream: returnTypeName == streamLexeme,
     annotationName: extractNameArgument(annotation),
   );
 }

--- a/packages/solid_generator/lib/src/query_model.dart
+++ b/packages/solid_generator/lib/src/query_model.dart
@@ -13,10 +13,10 @@ import 'package:solid_generator/src/transformation_error.dart';
 /// Mirrors `EffectModel` for the parallel `@SolidEffect` method → `Effect`
 /// lowering (SPEC §4.7). The two models share an identical body-rewrite
 /// contract; the differences are (a) queries carry an [innerTypeText] for the
-/// `Resource<T>` type argument, (b) queries preserve the [isAsyncBody]
-/// keyword to splice into the emitted closure, and (c) queries do NOT enforce
-/// a reactive-deps requirement (SPEC §3.5 — a query body MAY have zero
-/// reactive reads).
+/// `Resource<T>` type argument, (b) queries preserve the [bodyKeyword] to
+/// splice into the emitted closure, and (c) queries do NOT enforce a
+/// reactive-deps requirement (SPEC §3.5 — a query body MAY have zero reactive
+/// reads).
 @immutable
 class QueryModel {
   /// Creates a [QueryModel] describing an annotated method.
@@ -24,8 +24,8 @@ class QueryModel {
     required this.methodName,
     required this.bodyText,
     required this.isBlockBody,
-    required this.isAsyncBody,
     required this.innerTypeText,
+    this.bodyKeyword = '',
     this.isStream = false,
     this.debounce,
     this.useRefreshing,
@@ -55,21 +55,20 @@ class QueryModel {
   /// how the emitter shapes the closure passed to `Resource(...)`.
   final bool isBlockBody;
 
-  /// True when the source method's body keyword is `async` (Future form) or
-  /// `async*` (Stream form). The emitter splices `async ` into the closure
-  /// signature so the lowered fetcher preserves the async semantics.
-  ///
-  /// In M5-01 only Future + `async` is reachable; the Stream + plain-bodied
-  /// path lands in M5-02 where this flag stays `false`.
-  final bool isAsyncBody;
-
-  /// Source text of the inner type `T` peeled from the method's `Future<T>`
-  /// (or in M5-02, `Stream<T>`) return type. Used as the `Resource<T>` type
-  /// argument in lowered output.
+  /// Source text of the inner type `T` peeled from the method's `Future<T>` /
+  /// `Stream<T>` return type. Used as the `Resource<T>` type argument in
+  /// lowered output.
   final String innerTypeText;
 
+  /// Source method's body modifier keyword — one of `'async'`, `'async*'`, or
+  /// `''` (empty for sync-bodied Stream queries like `Stream<T> m() => …;` or
+  /// `Stream<T> m() { return …; }`). Spliced verbatim into the closure
+  /// signature so the lowered fetcher preserves the original body semantics.
+  final String bodyKeyword;
+
   /// True when the source return type is `Stream<T>`; false for `Future<T>`.
-  /// Reserved in M5-01 for the M5-02 Stream-form branch in `emitResourceField`.
+  /// Drives the choice between `Resource<T>(...)` and `Resource<T>.stream(...)`
+  /// in the emitter.
   final bool isStream;
 
   /// Value of the `debounce:` argument on `@SolidQuery(debounce: …)`, or

--- a/packages/solid_generator/lib/src/signal_emitter.dart
+++ b/packages/solid_generator/lib/src/signal_emitter.dart
@@ -72,14 +72,18 @@ String emitEffectField(EffectModel e) {
 }
 
 /// Emits one `late final <name> = Resource<T>(<closure>, name: '<debug>');`
-/// line per SPEC §4.8. Mirrors [emitEffectField]'s closure-shape contract —
-/// same `late final` rationale, same body-text contract — but adds:
+/// (Future form) or the `Resource<T>.stream(...)` named-constructor variant
+/// (Stream form) line per SPEC §4.8. Mirrors [emitEffectField]'s closure-shape
+/// contract — same `late final` rationale, same body-text contract — but
+/// adds:
 ///
 /// * a type argument `Resource<T>` peeled from the source `Future<T>` /
 ///   `Stream<T>` return type (carried on [QueryModel.innerTypeText]),
-/// * an `async ` keyword spliced into the closure signature when
-///   [QueryModel.isAsyncBody] is true (Future-form queries require `async`;
-///   plain-bodied Stream queries leave the keyword empty), and
+/// * the upstream `.stream` named constructor when [QueryModel.isStream] is
+///   true (its fetcher signature is `Stream<T> Function()`, not the default
+///   `Future<T> Function()`),
+/// * the source body keyword spliced verbatim into the closure signature
+///   ([QueryModel.bodyKeyword] is one of `'async'`, `'async*'`, or `''`), and
 /// * a public field name (no underscore prefix) — SPEC §4.8 rule 1 specifies
 ///   a single emitted declaration per query.
 ///
@@ -90,11 +94,14 @@ String emitEffectField(EffectModel e) {
 /// (SPEC §4.8 rule 10 / §14 item 4).
 String emitResourceField(QueryModel q) {
   final debugName = q.annotationName ?? q.methodName;
-  final asyncKw = q.isAsyncBody ? 'async ' : '';
+  final asyncKw = q.bodyKeyword.isEmpty ? '' : '${q.bodyKeyword} ';
   final closure = q.isBlockBody
       ? '() $asyncKw${q.bodyText}'
       : '() $asyncKw=> ${q.bodyText}';
-  final ctor = "Resource<${q.innerTypeText}>($closure, name: '$debugName')";
+  final ctorName = q.isStream
+      ? 'Resource<${q.innerTypeText}>.stream'
+      : 'Resource<${q.innerTypeText}>';
+  final ctor = "$ctorName($closure, name: '$debugName')";
   return '  late final ${q.methodName} = $ctor;';
 }
 

--- a/packages/solid_generator/test/golden/inputs/m5_02_simple_query_with_stream.dart
+++ b/packages/solid_generator/test/golden/inputs/m5_02_simple_query_with_stream.dart
@@ -1,0 +1,21 @@
+// SPEC §4.8 Stream-form query: a synchronous block body returning a Stream.
+// `Stream.periodic` produces an integer stream ticking every second.
+// `Ticker` has only a query (no mutable `@SolidState` field) so its
+// constructor could be const before lowering, but the SPEC §2 source model
+// writes user-facing widgets with non-const constructors uniformly.
+// ignore_for_file: prefer_const_constructors_in_immutables
+
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+
+class Ticker extends StatelessWidget {
+  Ticker({super.key});
+
+  @SolidQuery()
+  Stream<int> watchTicks() {
+    return Stream.periodic(const Duration(seconds: 1), (i) => i);
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/golden/outputs/m5_02_simple_query_with_stream.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m5_02_simple_query_with_stream.g.dart
@@ -1,0 +1,25 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class Ticker extends StatefulWidget {
+  Ticker({super.key});
+
+  @override
+  State<Ticker> createState() => _TickerState();
+}
+
+class _TickerState extends State<Ticker> {
+  late final watchTicks = Resource<int>.stream(() {
+    return Stream.periodic(const Duration(seconds: 1), (i) => i);
+  }, name: 'watchTicks');
+
+  @override
+  void dispose() {
+    watchTicks.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -47,6 +47,7 @@ const List<String> goldenNames = <String>[
   'm4_08_effect_on_state_class',
   'm4_08_effect_on_plain_class',
   'm5_01_simple_query_with_future',
+  'm5_02_simple_query_with_stream',
 ];
 
 /// Memoized golden directory resolution. Resolved relative to the package


### PR DESCRIPTION
## Summary

- Adds support for `Stream<T>` return types in `@SolidQuery` methods alongside existing `Future<T>`
- Replaces `isAsyncBody: bool` with generalized `bodyKeyword: String` field to preserve source body modifiers (`'async'`, `'async*'`, or `''`)
- Emits `Resource<T>.stream(...)` named constructor for Stream-form queries instead of `Resource<T>(...)`
- Supports both `async*` block-body and synchronous returning-Stream forms per SPEC §3.5 / §4.8
- Adds golden test for simple Stream query with synchronous block body
- Single public field per SPEC §4.8 rule 1 (no underscore prefix, no thin-accessor wrapper)

## Testing

- Golden test added: `m5_02_simple_query_with_stream` (input and expected output)
- `dart test --name=m5_02` passes with correct `Resource<T>.stream(...)` output
- Code generation matches SPEC requirements for Stream-form lowering
- No changes to dispose lifecycle or import paths beyond M5-01