### PR TITLE
Add M5-03 golden: @SolidQuery coexists with @SolidState and @SolidEffect

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1697,7 +1697,7 @@ class Ticker extends StatelessWidget {
 
 ---
 
-### TODO M5-03 — Golden: `@SolidQuery` co-exists with `@SolidState` field + getter + `@SolidEffect`
+### DONE M5-03 — Golden: `@SolidQuery` co-exists with `@SolidState` field + getter + `@SolidEffect`
 
 **Goal:** A class with all four annotated shapes — `@SolidState()` field, `@SolidState()` getter, `@SolidEffect()` method, `@SolidQuery()` method — produces a State class with all four lowered shapes interleaved in source order, and a `dispose()` body in reverse-declaration order. `initState()` materializes ONLY the Effect (queries are lazy per §4.8). Validates the unified ordered-name list under all four lowered shapes.
 
@@ -1711,15 +1711,15 @@ class Ticker extends StatelessWidget {
 
 **Expected input content:** A `StatelessWidget` with (in source order) `@SolidState() int counter = 0;`, `@SolidState() int get doubleCounter => counter * 2;`, `@SolidEffect() void logBoth() { print('$counter / $doubleCounter'); }`, `@SolidQuery() Future<int> fetchSnapshot() async => 0;` (no upstream signals — auto-tracking lands in M5-10).
 
-**Expected output content:** State class declares `counter` (Signal), then `doubleCounter` (late final Computed), then `logBoth` (late final Effect), then `_fetchSnapshot` (late final Resource) + `fetchSnapshot()` thin-accessor — all in source order. `initState()` materializes ONLY `logBoth` after `super.initState();`. `dispose()` body calls `_fetchSnapshot.dispose()`, then `logBoth.dispose()`, then `doubleCounter.dispose()`, then `counter.dispose()`, then `super.dispose()` — reverse declaration order per SPEC Section 10.
+**Expected output content:** State class declares `counter` (Signal), then `doubleCounter` (late final Computed), then `logBoth` (late final Effect), then `fetchSnapshot` (late final Resource) — single public field, no underscore prefix, no thin-accessor wrapper per the M5-01 emit shape; all in source order. `initState()` materializes ONLY `logBoth` after `super.initState();`. `dispose()` body calls `fetchSnapshot.dispose()`, then `logBoth.dispose()`, then `doubleCounter.dispose()`, then `counter.dispose()`, then `super.dispose()` — reverse declaration order per SPEC Section 10.
 
 **Expected implementation change:** None beyond M5-01 + M4-02 — this is a regression fence on the unified dispose-ordering rule across all four shapes AND a regression fence proving Effects (always materialized) and queries (NEVER materialized) coexist correctly.
 
-**Acceptance:** `dart test --name=m5_03` passes; golden's `dispose()` body has Resource → Effect → Computed → Signal → super order verbatim; `initState()` body is `super.initState(); logBoth;` (no `_fetchSnapshot;`).
+**Acceptance:** `dart test --name=m5_03` passes; golden's `dispose()` body has Resource → Effect → Computed → Signal → super order verbatim; `initState()` body is `super.initState(); logBoth;` (no `fetchSnapshot;`).
 
 **Dependencies:** M5-01, M4-02.
 
-**Status:** TODO
+**Status:** DONE
 
 ---
 

--- a/packages/solid_generator/test/golden/inputs/m5_03_query_with_signal_computed_effect.dart
+++ b/packages/solid_generator/test/golden/inputs/m5_03_query_with_signal_computed_effect.dart
@@ -1,0 +1,26 @@
+// SPEC §3.4 / §4.7 use `print` as the canonical Effect side-effect example.
+// ignore_for_file: avoid_print
+
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+
+class Dashboard extends StatelessWidget {
+  Dashboard({super.key});
+
+  @SolidState()
+  int counter = 0;
+
+  @SolidState()
+  int get doubleCounter => counter * 2;
+
+  @SolidEffect()
+  void logBoth() {
+    print('$counter / $doubleCounter');
+  }
+
+  @SolidQuery()
+  Future<int> fetchSnapshot() async => 0;
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/golden/outputs/m5_03_query_with_signal_computed_effect.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m5_03_query_with_signal_computed_effect.g.dart
@@ -1,0 +1,43 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class Dashboard extends StatefulWidget {
+  Dashboard({super.key});
+
+  @override
+  State<Dashboard> createState() => _DashboardState();
+}
+
+class _DashboardState extends State<Dashboard> {
+  final counter = Signal<int>(0, name: 'counter');
+  late final doubleCounter = Computed<int>(
+    () => counter.value * 2,
+    name: 'doubleCounter',
+  );
+  late final logBoth = Effect(() {
+    print('${counter.value} / ${doubleCounter.value}');
+  }, name: 'logBoth');
+  late final fetchSnapshot = Resource<int>(
+    () async => 0,
+    name: 'fetchSnapshot',
+  );
+
+  @override
+  void initState() {
+    super.initState();
+    logBoth;
+  }
+
+  @override
+  void dispose() {
+    fetchSnapshot.dispose();
+    logBoth.dispose();
+    doubleCounter.dispose();
+    counter.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -48,6 +48,7 @@ const List<String> goldenNames = <String>[
   'm4_08_effect_on_plain_class',
   'm5_01_simple_query_with_future',
   'm5_02_simple_query_with_stream',
+  'm5_03_query_with_signal_computed_effect',
 ];
 
 /// Memoized golden directory resolution. Resolved relative to the package


### PR DESCRIPTION
## Summary

- Add golden test validating all four annotated shapes coexist and interleave in source order: `@SolidState()` field, `@SolidState()` getter, `@SolidEffect()` method, `@SolidQuery()` method
- Verify generated State class declares shapes in source order: Signal → Computed → Effect → Resource
- Verify `initState()` materializes ONLY the Effect (Queries remain lazy per §4.8)
- Verify `dispose()` body calls in reverse-declaration order: Resource → Effect → Computed → Signal → super
- Update TODOS.md to reflect M5-03 as DONE; clarify Resource emit shape uses public field name (no thin-accessor per M5-01)

## Testing

- `dart test --name=m5_03` passes
- Generated `dispose()` body ordering verified: Resource → Effect → Computed → Signal → super
- Generated `initState()` contains `super.initState(); logBoth;` (Effect materialized, Query not)
- Regression fence on unified dispose-ordering across all four shapes