### PR TITLE
Implement M5-04: SignalBuilder wraps `<query>().when(...)` chain

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1723,7 +1723,7 @@ class Ticker extends StatelessWidget {
 
 ---
 
-### TODO M5-04 — Golden: `fetchData().when(ready:..., loading:..., error:...)` byte-identical, wrapped in SignalBuilder
+### DONE M5-04 — Golden: `fetchData().when(ready:..., loading:..., error:...)` byte-identical, wrapped in SignalBuilder
 
 **Goal:** A widget whose `build` body invokes `fetchData().when({ready, loading, error})` is lowered such that (a) the build method is wrapped in a `SignalBuilder` (the SignalBuilder-placement detection rule fires on the `fetchData()` call expression — SPEC §4.8 rule 3) and (b) the `fetchData().when(...)` chain is byte-identical between input and output. At runtime, `fetchData()` invokes the upstream `Resource<T>.call() => state;` operator returning `ResourceState<T>`, and `.when(...)` resolves to upstream `flutter_solidart`'s extension on `ResourceState<T>` directly. Validates the source-time typecheck contract (`fetchData().when(...)` typechecks against the `Future<T>.when` stub in `solid_annotations`) AND the runtime contract (lowered `fetchData()` is the upstream callable on a `Resource<String>` field). Critical regression fence for the SPEC §4.8 rule 3 detection rule and §7 SignalBuilder placement.
 
@@ -1783,7 +1783,7 @@ The `fetchName().when(...)` chain is byte-identical between input and output —
 
 **Dependencies:** M5-01.
 
-**Status:** TODO
+**Status:** DONE
 
 ---
 

--- a/packages/solid_generator/lib/src/build_rewriter.dart
+++ b/packages/solid_generator/lib/src/build_rewriter.dart
@@ -67,7 +67,11 @@ String rewriteBuildMethod(
     source,
     queryNames: queryNames,
   );
-  final wrapNodes = computeWrapSet(buildMethod, valueResult.trackedReadOffsets);
+  final wrapNodes = computeWrapSet(
+    buildMethod,
+    valueResult.trackedReadOffsets,
+    queryNames: queryNames,
+  );
 
   final edits = <SourceEdit>[];
 

--- a/packages/solid_generator/lib/src/placement_visitor.dart
+++ b/packages/solid_generator/lib/src/placement_visitor.dart
@@ -13,9 +13,15 @@ import 'package:analyzer/dart/ast/visitor.dart';
 ///    an UpperCamelCase identifier (the `Text(...)` style used without
 ///    `const` or `new`; the analyzer only upgrades these to
 ///    `InstanceCreationExpression` during resolution, which we defer to
-///    M3-05 per SPEC 5.4). Constructor expressions used as the value of a
-///    `key:` named argument are filtered out — Keys are not Widgets and
-///    cannot host a `SignalBuilder` wrapper (see `_isAtKeyPosition`).
+///    M3-05 per SPEC 5.4). The collector also recognizes the SPEC §3.5 /
+///    §4.8 query-state chain `<queryName>().when(...)` and
+///    `<queryName>().maybeWhen(...)` — the `FutureWhen` / `StreamWhen`
+///    extensions on `Future<T>` / `Stream<T>` from `solid_annotations`
+///    return `Widget`, so the entire chain is a valid SignalBuilder wrap
+///    target even though its callee is the lowercase `when` / `maybeWhen`.
+///    Constructor expressions used as the value of a `key:` named argument
+///    are filtered out — Keys are not Widgets and cannot host a
+///    `SignalBuilder` wrapper (see `_isAtKeyPosition`).
 /// 2. For each tracked-read offset T (from `value_rewriter`), pick the
 ///    smallest (deepest) widget expression whose source range contains T —
 ///    SPEC Section 7.2's minimum-subtree rule.
@@ -23,13 +29,19 @@ import 'package:analyzer/dart/ast/visitor.dart';
 ///    wrap set, drop the outer (SPEC Section 7.5 nested-reads rule).
 /// 4. Suppress any wrap whose ancestor chain already contains a
 ///    hand-written `SignalBuilder` (SPEC Section 7.3).
+///
+/// [queryNames] is the per-class set of `@SolidQuery` method names. It is
+/// consulted only to recognize the `<queryName>().when(...)` /
+/// `<queryName>().maybeWhen(...)` widget-shape (SPEC §4.8 rule 3); the
+/// recorded tracked-read offsets themselves come from `value_rewriter`.
 Set<Expression> computeWrapSet(
   MethodDeclaration buildMethod,
-  List<int> trackedReadOffsets,
-) {
+  List<int> trackedReadOffsets, {
+  Set<String> queryNames = const {},
+}) {
   if (trackedReadOffsets.isEmpty) return <Expression>{};
 
-  final collector = _WidgetCollector();
+  final collector = _WidgetCollector(queryNames);
   buildMethod.accept(collector);
   final widgets = collector.widgets;
   if (widgets.isEmpty) return <Expression>{};
@@ -97,6 +109,14 @@ bool _isSignalBuilder(AstNode node) {
 }
 
 class _WidgetCollector extends RecursiveAstVisitor<void> {
+  _WidgetCollector(this._queryNames);
+
+  /// Per-class set of `@SolidQuery` method names — consumed by
+  /// [_isQueryStateChain] to recognize `<query>().when(...)` /
+  /// `<query>().maybeWhen(...)` chains as widget expressions (SPEC §4.8
+  /// rule 3). Empty when the enclosing class has no `@SolidQuery` methods.
+  final Set<String> _queryNames;
+
   final List<Expression> widgets = [];
 
   @override
@@ -110,8 +130,30 @@ class _WidgetCollector extends RecursiveAstVisitor<void> {
   @override
   void visitMethodInvocation(MethodInvocation node) {
     super.visitMethodInvocation(node);
-    if (!_looksLikeWidgetCtor(node) || _isAtKeyPosition(node)) return;
-    widgets.add(node);
+    if (_isAtKeyPosition(node)) return;
+    if (_looksLikeWidgetCtor(node) || _isQueryStateChain(node)) {
+      widgets.add(node);
+    }
+  }
+
+  /// True if [node] is a SPEC §3.5 / §4.8 query-state chain, i.e.
+  /// `<queryName>().when(...)` or `<queryName>().maybeWhen(...)`. The
+  /// `FutureWhen<T> on Future<T>` / `StreamWhen<T> on Stream<T>` source-time
+  /// stubs in `solid_annotations` return `Widget`, and the lowered chain
+  /// resolves through `Resource<T>.call() => state` to upstream
+  /// `flutter_solidart` extensions on `ResourceState<T>` that also return
+  /// `Widget`. The chain is therefore a valid SignalBuilder wrap target.
+  ///
+  /// The query-name guard ensures the clause never fires on user-defined
+  /// `.when` / `.maybeWhen` methods on non-query targets.
+  bool _isQueryStateChain(MethodInvocation node) {
+    final name = node.methodName.name;
+    if (name != 'when' && name != 'maybeWhen') return false;
+    final target = node.target;
+    if (target is! MethodInvocation) return false;
+    if (target.target != null) return false;
+    if (target.argumentList.arguments.isNotEmpty) return false;
+    return _queryNames.contains(target.methodName.name);
   }
 }
 

--- a/packages/solid_generator/lib/src/placement_visitor.dart
+++ b/packages/solid_generator/lib/src/placement_visitor.dart
@@ -108,6 +108,11 @@ bool _isSignalBuilder(AstNode node) {
   return false;
 }
 
+/// SPEC §3.5 query-state extension methods — both `<query>().when(...)` and
+/// `<query>().maybeWhen(...)` resolve to `Widget`-returning extensions, so
+/// either is a valid SignalBuilder wrap target.
+const Set<String> _queryStateChainMethods = {'when', 'maybeWhen'};
+
 class _WidgetCollector extends RecursiveAstVisitor<void> {
   _WidgetCollector(this._queryNames);
 
@@ -136,19 +141,13 @@ class _WidgetCollector extends RecursiveAstVisitor<void> {
     }
   }
 
-  /// True if [node] is a SPEC §3.5 / §4.8 query-state chain, i.e.
-  /// `<queryName>().when(...)` or `<queryName>().maybeWhen(...)`. The
-  /// `FutureWhen<T> on Future<T>` / `StreamWhen<T> on Stream<T>` source-time
-  /// stubs in `solid_annotations` return `Widget`, and the lowered chain
-  /// resolves through `Resource<T>.call() => state` to upstream
-  /// `flutter_solidart` extensions on `ResourceState<T>` that also return
-  /// `Widget`. The chain is therefore a valid SignalBuilder wrap target.
-  ///
-  /// The query-name guard ensures the clause never fires on user-defined
-  /// `.when` / `.maybeWhen` methods on non-query targets.
+  /// True if [node] is a SPEC §3.5 / §4.8 query-state chain
+  /// `<queryName>().when(...)` / `.maybeWhen(...)`. The query-name guard
+  /// prevents matches on user-defined `.when` / `.maybeWhen` methods on
+  /// non-query targets.
   bool _isQueryStateChain(MethodInvocation node) {
-    final name = node.methodName.name;
-    if (name != 'when' && name != 'maybeWhen') return false;
+    if (_queryNames.isEmpty) return false;
+    if (!_queryStateChainMethods.contains(node.methodName.name)) return false;
     final target = node.target;
     if (target is! MethodInvocation) return false;
     if (target.target != null) return false;

--- a/packages/solid_generator/test/golden/inputs/m5_04_query_when_in_build.dart
+++ b/packages/solid_generator/test/golden/inputs/m5_04_query_when_in_build.dart
@@ -1,0 +1,29 @@
+// SPEC §4.8 rule 3: a `<query>().when(...)` chain in build is the canonical
+// reactive call site. The chain is byte-identical between input and output;
+// the SignalBuilder wrap is the only delta. UserScreen has only a query
+// (no mutable @SolidState field) so its constructor could be const before
+// lowering, but the SPEC §2 source model writes user-facing widgets with
+// non-const constructors uniformly. The `loading: () => const CircularProgress
+// Indicator()` closure intentionally preserves the const-construction wrapper
+// (a const tear-off is not expressible in Dart), so `unnecessary_lambdas` is
+// silenced for this file.
+// ignore_for_file: prefer_const_constructors_in_immutables, unnecessary_lambdas
+
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/material.dart';
+
+class UserScreen extends StatelessWidget {
+  UserScreen({super.key});
+
+  @SolidQuery()
+  Future<String> fetchName() async => 'Alice';
+
+  @override
+  Widget build(BuildContext context) {
+    return fetchName().when(
+      ready: (name) => Text(name),
+      loading: () => const CircularProgressIndicator(),
+      error: (e, _) => Text('error: $e'),
+    );
+  }
+}

--- a/packages/solid_generator/test/golden/inputs/m5_04_query_when_in_build.dart
+++ b/packages/solid_generator/test/golden/inputs/m5_04_query_when_in_build.dart
@@ -1,12 +1,7 @@
-// SPEC §4.8 rule 3: a `<query>().when(...)` chain in build is the canonical
-// reactive call site. The chain is byte-identical between input and output;
-// the SignalBuilder wrap is the only delta. UserScreen has only a query
-// (no mutable @SolidState field) so its constructor could be const before
-// lowering, but the SPEC §2 source model writes user-facing widgets with
-// non-const constructors uniformly. The `loading: () => const CircularProgress
-// Indicator()` closure intentionally preserves the const-construction wrapper
-// (a const tear-off is not expressible in Dart), so `unnecessary_lambdas` is
-// silenced for this file.
+// SPEC §4.8 rule 3 + §7: a `<query>().when(...)` chain is wrapped in
+// SignalBuilder while the chain itself is byte-identical input/output. The
+// `loading:` lambda preserves a const-constructed widget (Dart has no const
+// tear-off form), so `unnecessary_lambdas` is silenced.
 // ignore_for_file: prefer_const_constructors_in_immutables, unnecessary_lambdas
 
 import 'package:solid_annotations/solid_annotations.dart';

--- a/packages/solid_generator/test/golden/outputs/m5_04_query_when_in_build.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m5_04_query_when_in_build.g.dart
@@ -1,0 +1,36 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class UserScreen extends StatefulWidget {
+  UserScreen({super.key});
+
+  @override
+  State<UserScreen> createState() => _UserScreenState();
+}
+
+class _UserScreenState extends State<UserScreen> {
+  late final fetchName = Resource<String>(
+    () async => 'Alice',
+    name: 'fetchName',
+  );
+
+  @override
+  void dispose() {
+    fetchName.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SignalBuilder(
+      builder: (context, child) {
+        return fetchName().when(
+          ready: (name) => Text(name),
+          loading: () => const CircularProgressIndicator(),
+          error: (e, _) => Text('error: $e'),
+        );
+      },
+    );
+  }
+}

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -49,6 +49,7 @@ const List<String> goldenNames = <String>[
   'm5_01_simple_query_with_future',
   'm5_02_simple_query_with_stream',
   'm5_03_query_with_signal_computed_effect',
+  'm5_04_query_when_in_build',
 ];
 
 /// Memoized golden directory resolution. Resolved relative to the package


### PR DESCRIPTION
## Summary

- Closes the gap between M5-01's tracked-read detection and SPEC §7 SignalBuilder placement: a `<query>().when(...)` chain in `build` is now recognized as a widget wrap target, so the smallest-subtree wrap rule fires correctly.
- Extends `_WidgetCollector` (`packages/solid_generator/lib/src/placement_visitor.dart`) with `_isQueryStateChain`, gated on the per-class `queryNames` set so it never matches user-defined `.when`/`.maybeWhen` on non-query targets. Threads `queryNames` from `rewriteBuildMethod` (`build_rewriter.dart`) into `computeWrapSet`.
- Adds the paired M5-04 golden: a `UserScreen` whose `build` returns `fetchName().when(ready, loading, error)` lowers to a `Resource<String>` field plus a `SignalBuilder` whose inner `.when(...)` chain is byte-identical to the input (SPEC §4.8 rule 2).

## Why an implementation change was needed

M5-01 wired the **detection** half: `value_rewriter.dart` records the offset of every zero-arg `<queryName>()` call in `trackedReadOffsets`. The TODOS.md M5-04 entry assumed this would flow end-to-end through SPEC §7 placement with no further code change. In practice, `_WidgetCollector` only collected `MethodInvocation`s passing `_looksLikeWidgetCtor` (UpperCamelCase callee, no target). A `fetchName().when(...)` chain has the lowercase callee `when` and a non-null target (`fetchName()`), so it was never collected as a widget candidate. With only `Text(...)` / `CircularProgressIndicator()` (which appear inside lambda bodies of named arguments, after the `fetchName()` offset) collected, no widget contained the tracked offset, the wrap set came back empty, and no SignalBuilder was emitted.

The fix is small and localized: one new helper (`_isQueryStateChain`) plus one parameter threaded through one call site. No new abstractions; existing `_pruneAncestors` / `_suppressAlreadyWrapped` passes work unchanged.

## Test plan

- [x] `dart test packages/solid_generator/` — 88 tests pass (every prior golden + the new `m5_04_query_when_in_build`)
- [x] `dart analyze packages/solid_generator/test/golden/outputs/` — zero issues on every generated golden
- [x] `dart analyze --fatal-infos` — only the pre-existing `effect_widget_test.dart:114:5` info (unrelated to this PR)
- [x] `dart format --set-exit-if-changed .` — zero diff
- [x] `flutter test example/` — all 5 widget tests pass
- [x] M5-04 idempotency test passes — running the builder twice produces byte-identical output