### PR TITLE
Implement M5-06: @SolidQuery refresh tear-off byte-identical golden

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1843,7 +1843,7 @@ The `fetchName().when(...)` chain is byte-identical between input and output —
 
 **Dependencies:** M5-01.
 
-**Status:** TODO
+**Status:** DONE
 
 ---
 

--- a/packages/solid_generator/test/golden/inputs/m5_06_query_refresh_in_onpressed.dart
+++ b/packages/solid_generator/test/golden/inputs/m5_06_query_refresh_in_onpressed.dart
@@ -1,0 +1,30 @@
+// SPEC §3.5 "Refresh" + §4.8 rule 2 + §6.2: tear-off `fetchCount.refresh()`
+// inside an `onPressed` callback. Source typechecks via the
+// `RefreshFuture<T> on Future<T> Function()` stub extension in
+// `solid_annotations`. The tear-off is byte-identical between input and
+// output because the call-expression rewrite (§4.8 rule 2) fires only on
+// zero-arg `MethodInvocation` shapes (`fetchCount()`), NOT on
+// tear-off-then-method-call shapes (`fetchCount.refresh()`). The FAB is
+// NOT wrapped in `SignalBuilder` per §6.2 — `onPressed` matches the
+// untracked-context callback pattern. The `() => fetchCount.refresh()`
+// lambda matches SPEC §3.5's canonical Refresh example verbatim, so
+// `unnecessary_lambdas` is silenced.
+// ignore_for_file: prefer_const_constructors_in_immutables, unnecessary_lambdas
+
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/material.dart';
+
+class CounterScreen extends StatelessWidget {
+  CounterScreen({super.key});
+
+  @SolidQuery()
+  Future<int> fetchCount() async => 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return FloatingActionButton(
+      onPressed: () => fetchCount.refresh(),
+      child: const Icon(Icons.refresh),
+    );
+  }
+}

--- a/packages/solid_generator/test/golden/outputs/m5_06_query_refresh_in_onpressed.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m5_06_query_refresh_in_onpressed.g.dart
@@ -1,0 +1,28 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class CounterScreen extends StatefulWidget {
+  CounterScreen({super.key});
+
+  @override
+  State<CounterScreen> createState() => _CounterScreenState();
+}
+
+class _CounterScreenState extends State<CounterScreen> {
+  late final fetchCount = Resource<int>(() async => 0, name: 'fetchCount');
+
+  @override
+  void dispose() {
+    fetchCount.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FloatingActionButton(
+      onPressed: () => fetchCount.refresh(),
+      child: const Icon(Icons.refresh),
+    );
+  }
+}

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -50,6 +50,7 @@ const List<String> goldenNames = <String>[
   'm5_02_simple_query_with_stream',
   'm5_03_query_with_signal_computed_effect',
   'm5_04_query_when_in_build',
+  'm5_06_query_refresh_in_onpressed',
 ];
 
 /// Memoized golden directory resolution. Resolved relative to the package


### PR DESCRIPTION
## Summary

- Adds a regression-fence golden (`m5_06_query_refresh_in_onpressed`) proving the SPEC §4.8 rule 2 call-expression rewrite is shape-specific: it fires on zero-arg `fetchCount()` invocations but NOT on the tear-off-then-method-call shape `fetchCount.refresh()` inside an `onPressed` callback. Source typechecks via the `RefreshFuture<T> on Future<T> Function()` stub; lowered output is byte-identical because `Resource<T>.refresh()` is a direct upstream method. Per §6.2, the FAB stays unwrapped — `onPressed` is an untracked context.
- Zero generator code changes: all guards already exist in `value_rewriter.dart` (M5-01).
- Flips M5-06 status `TODO` → `DONE` in `TODOS.md`.

## Test plan

- [x] `dart test packages/solid_generator --name=m5_06_query_refresh_in_onpressed` passes (golden + idempotency)
- [x] `dart test packages/solid_generator` — full corpus passes (98 tests)
- [x] `dart analyze --fatal-infos packages/solid_generator` — zero issues
- [x] `dart analyze packages/solid_generator/test/golden/outputs/` — zero issues
- [x] `dart format --set-exit-if-changed .` — zero diff
- [x] Verified output is byte-identical to the predicted shape (input `() => fetchCount.refresh()` survives verbatim in lowered build body)