### PR TITLE
Implement M5-08: @SolidQuery on existing State<X> subclasses

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1894,7 +1894,7 @@ The `fetchName().when(...)` chain is byte-identical between input and output —
 
 **Dependencies:** M5-01, M4-08.
 
-**Status:** TODO
+**Status:** DONE
 
 ---
 

--- a/packages/solid_generator/lib/builder.dart
+++ b/packages/solid_generator/lib/builder.dart
@@ -246,10 +246,10 @@ String _renderOutput(
 
 /// Dispatches on [decl]'s class kind to the matching rewriter.
 ///
-/// `@SolidQuery` only lowers on `StatelessWidget` in M5-01. The plain-class
-/// and `State<X>` paths land in M5-08 / M5-09; until then, any query on
-/// those class kinds is rejected at the dispatch boundary so the rewriters
-/// stay query-unaware (their signatures don't change in this PR).
+/// `@SolidQuery` lowers on `StatelessWidget` (M5-01) and existing `State<X>`
+/// subclasses (M5-08). The plain-class path lands in M5-09; until then, any
+/// query on a plain class is rejected at the dispatch boundary so the
+/// `rewritePlainClass` signature stays query-unaware.
 RewriteResult _rewriteClass(
   ClassDeclaration decl,
   List<FieldModel> fields,
@@ -274,12 +274,14 @@ RewriteResult _rewriteClass(
       rejectIfQueriesNotYetSupported(queries, 'plain class', className);
       return rewritePlainClass(decl, fields, getters, effects, source);
     case ClassKind.stateClass:
-      rejectIfQueriesNotYetSupported(
+      return rewriteStateClass(
+        decl,
+        fields,
+        getters,
+        effects,
         queries,
-        'existing State<X> subclass',
-        className,
+        source,
       );
-      return rewriteStateClass(decl, fields, getters, effects, source);
     case ClassKind.statefulWidget:
       throw CodeGenerationError(
         'class-kind $kind is not supported yet '

--- a/packages/solid_generator/lib/src/state_class_rewriter.dart
+++ b/packages/solid_generator/lib/src/state_class_rewriter.dart
@@ -4,23 +4,29 @@ import 'package:solid_generator/src/effect_model.dart';
 import 'package:solid_generator/src/field_model.dart';
 import 'package:solid_generator/src/getter_model.dart';
 import 'package:solid_generator/src/import_rewriter.dart';
+import 'package:solid_generator/src/query_model.dart';
 import 'package:solid_generator/src/signal_emitter.dart';
 import 'package:solid_generator/src/transformation_error.dart';
 
-/// Rewrites an existing `State<X>` subclass containing `@SolidState` fields
-/// and/or `@SolidEffect` methods **in place** — without splitting the class.
-/// Replaces every `@SolidState` field with a `Signal<T>(…)` declaration,
-/// every `@SolidEffect` method with a `late final … = Effect(…)` field,
-/// routes `build()` through the reactive-read pipeline, and merges reactive
-/// disposals into any existing `dispose()` body. When Effects exist, Effect
-/// materialization reads (`<effectName>;`) are also merged into any existing
-/// `initState()` body, or a fresh `initState()` is synthesized if none was
-/// declared.
+/// Rewrites an existing `State<X>` subclass containing `@SolidState` fields,
+/// `@SolidEffect` methods, and/or `@SolidQuery` methods **in place** —
+/// without splitting the class. Replaces every `@SolidState` field with a
+/// `Signal<T>(…)` declaration, every `@SolidEffect` method with a
+/// `late final … = Effect(…)` field, every `@SolidQuery` method with a
+/// `late final … = Resource<T>(…)` field, routes `build()` through the
+/// reactive-read pipeline, and merges reactive disposals into any existing
+/// `dispose()` body. When Effects exist, Effect materialization reads
+/// (`<effectName>;`) are also merged into any existing `initState()` body,
+/// or a fresh `initState()` is synthesized if none was declared. Queries
+/// are intentionally never spliced into `initState` — Resources are lazy
+/// and the late-final initializer fires on first call-site read (SPEC §4.8
+/// rule 10 / §14 item 4).
 ///
-/// See SPEC §8.2 (in-place State lowering), §10 (dispose merging), and §4.7
-/// (Effect materialization). The Signal-only path is the fix for issue #3 —
-/// a `StatefulWidget` whose `State<X>` subclass declared `@SolidState` fields
-/// was silently passed through unchanged in v1.
+/// See SPEC §8.2 (in-place State lowering), §10 (dispose merging), §4.7
+/// (Effect materialization), and §4.8 (Resource lowering). The Signal-only
+/// path is the fix for issue #3 — a `StatefulWidget` whose `State<X>`
+/// subclass declared `@SolidState` fields was silently passed through
+/// unchanged in v1.
 ///
 /// Member ordering and non-annotated members (other fields,
 /// `didUpdateWidget`, user methods, constructors, …) are emitted verbatim
@@ -33,6 +39,7 @@ RewriteResult rewriteStateClass(
   List<FieldModel> solidFields,
   List<GetterModel> solidGetters,
   List<EffectModel> solidEffects,
+  List<QueryModel> solidQueries,
   String source,
 ) {
   final className = classDecl.name.lexeme;
@@ -46,15 +53,25 @@ RewriteResult rewriteStateClass(
     className,
   );
   // Index annotated fields and methods by name for O(1) lookup during the
-  // member walk. The builder already parsed `@SolidState`/`@SolidEffect`
-  // once when computing [solidFields] / [solidEffects]; re-parsing here would
-  // double the annotation-reader cost per file.
+  // member walk. The builder already parsed `@SolidState`/`@SolidEffect`/
+  // `@SolidQuery` once when computing [solidFields] / [solidEffects] /
+  // [solidQueries]; re-parsing here would double the annotation-reader cost
+  // per file.
   final modelByName = {for (final f in solidFields) f.fieldName: f};
   final effectByName = {for (final e in solidEffects) e.methodName: e};
+  final queryByName = {for (final q in solidQueries) q.methodName: q};
   final reactiveNames = modelByName.keys.toSet();
-  // Built incrementally during the walk so Signal field names and Effect
-  // method names interleave in source-declaration order — the contract
-  // `emitDispose` relies on for reverse-disposal correctness (SPEC §10).
+  // Built once before the member walk so the `build` branch and any future
+  // reactive context can share the same set without rebuilding it. Mirrors
+  // the `stateless_rewriter.dart` pattern: empty-list short-circuits to a
+  // shared const set so query-free classes pay zero allocation.
+  final queryNames = solidQueries.isEmpty
+      ? const <String>{}
+      : {for (final q in solidQueries) q.methodName};
+  // Built incrementally during the walk so Signal field names, Effect method
+  // names, and Query method names interleave in source-declaration order —
+  // the contract `emitDispose` relies on for reverse-disposal correctness
+  // (SPEC §10).
   final disposeNames = <String>[];
   final effectNames = <String>[];
   final pieces = <String>[];
@@ -82,7 +99,14 @@ RewriteResult rewriteStateClass(
     if (member is MethodDeclaration) {
       final name = member.name.lexeme;
       if (name == 'build') {
-        pieces.add(rewriteBuildMethod(member, reactiveNames, source));
+        pieces.add(
+          rewriteBuildMethod(
+            member,
+            reactiveNames,
+            source,
+            queryNames: queryNames,
+          ),
+        );
       } else if (name == 'initState') {
         initStateMethod = member;
         initStateSlot = pieces.length;
@@ -96,6 +120,14 @@ RewriteResult rewriteStateClass(
         pieces.add(emitEffectField(effect));
         disposeNames.add(effect.methodName);
         effectNames.add(effect.methodName);
+      } else if (queryByName.containsKey(name)) {
+        // Queries are lazy — joining `disposeNames` only, never
+        // `effectNames` / `initState` materialization (SPEC §4.8 rule 10 /
+        // §14 item 4). The first reactive call site triggers the late-final
+        // initializer.
+        final query = queryByName[name]!;
+        pieces.add(emitResourceField(query));
+        disposeNames.add(query.methodName);
       } else {
         pieces.add(source.substring(member.offset, member.end));
       }
@@ -137,6 +169,11 @@ RewriteResult rewriteStateClass(
     solidartNames: <String>{
       'Signal',
       if (effectNames.isNotEmpty) 'Effect',
+      // Queries emit `Resource<T>(...)` fields; their `<query>().when(...)`
+      // call sites in `build` are wrapped in `SignalBuilder` by
+      // `rewriteBuildMethod` when at least one query is present.
+      if (solidQueries.isNotEmpty) 'Resource',
+      if (solidQueries.isNotEmpty) 'SignalBuilder',
     },
   );
 }

--- a/packages/solid_generator/test/golden/inputs/m5_08_query_on_state_class.dart
+++ b/packages/solid_generator/test/golden/inputs/m5_08_query_on_state_class.dart
@@ -1,0 +1,56 @@
+// SPEC §4.8 rule 10 / §14 item 4: Resources on an existing State<X> subclass
+// are lazy — never spliced into initState. SPEC §10: disposal is prepended
+// to the existing dispose() body in reverse-declaration order.
+// `Future.delayed` returns `Future<void>` here — explicit type-arg silences
+// `inference_failure_on_instance_creation` from the strict golden lints. The
+// `loading:` lambda preserves a const-constructed widget (Dart has no const
+// tear-off form), so `unnecessary_lambdas` is silenced.
+// ignore_for_file: unnecessary_lambdas
+
+import 'dart:async';
+
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/material.dart';
+
+class UserCard extends StatefulWidget {
+  const UserCard({super.key});
+
+  @override
+  State<UserCard> createState() => _UserCardState();
+}
+
+class _UserCardState extends State<UserCard> {
+  final StreamSubscription<void> _subscription = Stream<void>.periodic(
+    const Duration(seconds: 1),
+  ).listen((_) {});
+
+  @SolidQuery()
+  Future<String> fetchUser() async => 'Alice';
+
+  @override
+  void initState() {
+    super.initState();
+    debugPrint('init');
+  }
+
+  @override
+  void didUpdateWidget(covariant UserCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    debugPrint('update');
+  }
+
+  @override
+  void dispose() {
+    unawaited(_subscription.cancel());
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return fetchUser().when(
+      ready: (name) => Text(name),
+      loading: () => const CircularProgressIndicator(),
+      error: (e, _) => Text('error: $e'),
+    );
+  }
+}

--- a/packages/solid_generator/test/golden/outputs/m5_08_query_on_state_class.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m5_08_query_on_state_class.g.dart
@@ -1,0 +1,54 @@
+import 'dart:async';
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class UserCard extends StatefulWidget {
+  const UserCard({super.key});
+
+  @override
+  State<UserCard> createState() => _UserCardState();
+}
+
+class _UserCardState extends State<UserCard> {
+  final StreamSubscription<void> _subscription = Stream<void>.periodic(
+    const Duration(seconds: 1),
+  ).listen((_) {});
+
+  late final fetchUser = Resource<String>(
+    () async => 'Alice',
+    name: 'fetchUser',
+  );
+
+  @override
+  void initState() {
+    super.initState();
+    debugPrint('init');
+  }
+
+  @override
+  void didUpdateWidget(covariant UserCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    debugPrint('update');
+  }
+
+  @override
+  void dispose() {
+    fetchUser.dispose();
+    unawaited(_subscription.cancel());
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SignalBuilder(
+      builder: (context, child) {
+        return fetchUser().when(
+          ready: (name) => Text(name),
+          loading: () => const CircularProgressIndicator(),
+          error: (e, _) => Text('error: $e'),
+        );
+      },
+    );
+  }
+}

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -51,6 +51,7 @@ const List<String> goldenNames = <String>[
   'm5_03_query_with_signal_computed_effect',
   'm5_04_query_when_in_build',
   'm5_06_query_refresh_in_onpressed',
+  'm5_08_query_on_state_class',
 ];
 
 /// Memoized golden directory resolution. Resolved relative to the package


### PR DESCRIPTION
## Summary

- Extends `@SolidQuery` support to existing `State<X>` subclasses (previously only `StatelessWidget` was supported in M5-01)
- Converts `@SolidQuery` methods to lazy `Resource<T>` fields in State classes
- Wraps `build()` method with `SignalBuilder` when queries are present to enable reactive reads
- Handles disposal of Resources in reverse-declaration order, merged into existing `dispose()` body
- Resources are intentionally never materialized in `initState` — they fire on first call-site read (lazy evaluation per SPEC §4.8)
- Updates `rewriteStateClass` to accept and process `QueryModel` instances alongside existing `@SolidState` and `@SolidEffect` support

## Testing

- Golden test added: `m5_08_query_on_state_class` validates transformation of `@SolidQuery` on State subclass with existing `initState`, `didUpdateWidget`, and `dispose()` methods
- Input test file demonstrates a `StatefulWidget` with `@SolidQuery`, field subscriptions, and lifecycle methods
- Output validates: Resource field generation, SignalBuilder wrapping, dispose merging in correct order, proper imports
- Existing golden tests remain passing