### PR TITLE
Implement M5-09: @SolidQuery on plain class

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1920,7 +1920,7 @@ The `fetchName().when(...)` chain is byte-identical between input and output —
 
 **Dependencies:** M5-01, M4-08.
 
-**Status:** TODO
+**Status:** DONE
 
 ---
 

--- a/packages/solid_generator/lib/builder.dart
+++ b/packages/solid_generator/lib/builder.dart
@@ -246,10 +246,10 @@ String _renderOutput(
 
 /// Dispatches on [decl]'s class kind to the matching rewriter.
 ///
-/// `@SolidQuery` lowers on `StatelessWidget` (M5-01) and existing `State<X>`
-/// subclasses (M5-08). The plain-class path lands in M5-09; until then, any
-/// query on a plain class is rejected at the dispatch boundary so the
-/// `rewritePlainClass` signature stays query-unaware.
+/// `@SolidQuery` lowers on every supported class kind: `StatelessWidget`
+/// (M5-01), existing `State<X>` subclasses (M5-08), and plain classes
+/// (M5-09). `StatefulWidget` lowering itself is the only class kind not yet
+/// implemented (scheduled for a later M1 TODO).
 RewriteResult _rewriteClass(
   ClassDeclaration decl,
   List<FieldModel> fields,
@@ -271,8 +271,14 @@ RewriteResult _rewriteClass(
         source,
       );
     case ClassKind.plainClass:
-      rejectIfQueriesNotYetSupported(queries, 'plain class', className);
-      return rewritePlainClass(decl, fields, getters, effects, source);
+      return rewritePlainClass(
+        decl,
+        fields,
+        getters,
+        effects,
+        queries,
+        source,
+      );
     case ClassKind.stateClass:
       return rewriteStateClass(
         decl,

--- a/packages/solid_generator/lib/src/plain_class_rewriter.dart
+++ b/packages/solid_generator/lib/src/plain_class_rewriter.dart
@@ -77,8 +77,8 @@ RewriteResult rewritePlainClass(
       continue;
     }
     if (member is MethodDeclaration) {
-      // Non-Effect/Query methods are rejected by `_checkUnsupportedMembers`
-      // above, so exactly one of the two lookups hits.
+      // `_checkUnsupportedMembers` above guarantees exactly one of the two
+      // map lookups hits, so the `!` on the query branch is safe.
       final name = member.name.lexeme;
       final effect = effectByName[name];
       if (effect != null) {
@@ -92,6 +92,7 @@ RewriteResult rewritePlainClass(
       final query = queryByName[name]!;
       pieces.add(emitResourceField(query));
       disposeNames.add(query.methodName);
+      continue;
     }
   }
 

--- a/packages/solid_generator/lib/src/plain_class_rewriter.dart
+++ b/packages/solid_generator/lib/src/plain_class_rewriter.dart
@@ -3,27 +3,31 @@ import 'package:solid_generator/src/effect_model.dart';
 import 'package:solid_generator/src/field_model.dart';
 import 'package:solid_generator/src/getter_model.dart';
 import 'package:solid_generator/src/import_rewriter.dart';
+import 'package:solid_generator/src/query_model.dart';
 import 'package:solid_generator/src/signal_emitter.dart';
 import 'package:solid_generator/src/transformation_error.dart';
 
 /// Rewrites a plain Dart class (no widget supertype) containing `@SolidState`
-/// fields and/or `@SolidEffect` methods by replacing each annotated field
-/// with a `Signal<T>(…)`, each annotated method with a `late final … =
-/// Effect(…)`, and synthesizing a fresh `dispose()` method (plus, when
-/// Effects exist, a fresh no-arg constructor whose body materializes them
-/// — the plain-class analogue of the State class's `initState()`
-/// materialization, SPEC §4.7).
+/// fields, `@SolidEffect` methods, and/or `@SolidQuery` methods by replacing
+/// each annotated field with a `Signal<T>(…)`, each annotated method with a
+/// `late final … = Effect(…)` (Effect) or `late final … = Resource<T>(…)`
+/// (Query) field, and synthesizing a fresh `dispose()` method (plus, when
+/// Effects exist, a fresh no-arg constructor whose body materializes the
+/// Effects — the plain-class analogue of the State class's `initState()`
+/// materialization, SPEC §4.7). Queries are intentionally never spliced
+/// into the synthesized constructor — Resources are lazy and the late-final
+/// initializer fires on first call-site read (SPEC §4.8 rule 10 / §8.3).
 ///
-/// See SPEC §8.3 (plain class lowering) and §10 (dispose contract). The
-/// synthesized `dispose()` has neither `@override` nor `super.dispose()`
-/// because the supertype chain is `Object` only.
+/// See SPEC §8.3 (plain class lowering), §4.8 (Resource lowering), and §10
+/// (dispose contract). The synthesized `dispose()` has neither `@override`
+/// nor `super.dispose()` because the supertype chain is `Object` only.
 ///
 /// Currently only classes whose every member is an `@SolidState`-annotated
-/// field or `@SolidEffect`-annotated method are supported. Any other member
-/// (existing `dispose()`, user-defined constructors, non-annotated fields,
-/// non-Effect methods, …) throws [CodeGenerationError] — dispose-merge,
-/// constructor-merge, and in-place patching are scheduled for later
-/// milestones.
+/// field, an `@SolidEffect`-annotated method, or an `@SolidQuery`-annotated
+/// method are supported. Any other member (existing `dispose()`, user-defined
+/// constructors, non-annotated fields, non-annotated methods, …) throws
+/// [CodeGenerationError] — dispose-merge, constructor-merge, and in-place
+/// patching are scheduled for later milestones.
 ///
 /// The emitted string is syntactically valid Dart but is not guaranteed to be
 /// pretty-printed — run through `DartFormatter` before writing.
@@ -36,19 +40,28 @@ RewriteResult rewritePlainClass(
   List<FieldModel> solidFields,
   List<GetterModel> solidGetters,
   List<EffectModel> solidEffects,
+  List<QueryModel> solidQueries,
   String source,
 ) {
   final className = classDecl.name.lexeme;
   // M2-01 ships getter→Computed for `StatelessWidget` only; reject here so
   // M1-14's valid-target pass isn't silently undone.
   rejectIfGettersNotYetSupported(solidGetters, 'plain class', className);
-  // Source-ordered emission so Signal fields and Effect fields interleave by
-  // declaration order — required by SPEC §10's reverse-disposal rule (an
-  // Effect must be declared after the Signals it reads, so reverse order
-  // disposes the Effect before its dependencies).
+  // Source-ordered emission so Signal fields, Effect fields, and Resource
+  // fields interleave by declaration order — required by SPEC §10's
+  // reverse-disposal rule (an Effect or Resource must be declared after the
+  // Signals it reads, so reverse order disposes dependents before their
+  // dependencies).
   final fieldByName = {for (final f in solidFields) f.fieldName: f};
   final effectByName = {for (final e in solidEffects) e.methodName: e};
-  _checkUnsupportedMembers(classDecl, fieldByName, effectByName, className);
+  final queryByName = {for (final q in solidQueries) q.methodName: q};
+  _checkUnsupportedMembers(
+    classDecl,
+    fieldByName,
+    effectByName,
+    queryByName,
+    className,
+  );
 
   final pieces = <String>[];
   final disposeNames = <String>[];
@@ -64,19 +77,28 @@ RewriteResult rewritePlainClass(
       continue;
     }
     if (member is MethodDeclaration) {
-      // Non-Effect methods are rejected by `_checkUnsupportedMembers`
-      // above, so the lookup always hits.
-      final e = effectByName[member.name.lexeme]!;
-      pieces.add(emitEffectField(e));
-      disposeNames.add(e.methodName);
-      effectNames.add(e.methodName);
+      // Non-Effect/Query methods are rejected by `_checkUnsupportedMembers`
+      // above, so exactly one of the two lookups hits.
+      final name = member.name.lexeme;
+      final effect = effectByName[name];
+      if (effect != null) {
+        pieces.add(emitEffectField(effect));
+        disposeNames.add(effect.methodName);
+        effectNames.add(effect.methodName);
+        continue;
+      }
+      // Queries are lazy — `disposeNames` only, never `effectNames`, so the
+      // synthesized constructor below skips them (SPEC §4.8 rule 10 / §8.3).
+      final query = queryByName[name]!;
+      pieces.add(emitResourceField(query));
+      disposeNames.add(query.methodName);
     }
   }
 
   final fields = pieces.join('\n');
   // No-arg constructor only when Effects need materialization — keeps the
-  // Signal-only output byte-identical to the M1-06 plain-class golden,
-  // which has no synthesized constructor.
+  // Signal-only output byte-identical to the M1-06 plain-class golden, and
+  // applies equally to queries-only classes (Resources are lazy).
   final ctor = effectNames.isEmpty
       ? ''
       : '\n\n${emitConstructor(className, effectNames)}';
@@ -87,19 +109,28 @@ RewriteResult rewritePlainClass(
     solidartNames: <String>{
       'Signal',
       if (effectNames.isNotEmpty) 'Effect',
+      if (solidQueries.isNotEmpty) 'Resource',
     },
   );
 }
 
 /// Throws [CodeGenerationError] if [classDecl] contains any member other than
-/// an `@SolidState`-annotated field (key in [fieldByName]) or an
-/// `@SolidEffect`-annotated method (key in [effectByName]). Surfacing these
+/// an `@SolidState`-annotated field (key in [fieldByName]), an
+/// `@SolidEffect`-annotated method (key in [effectByName]), or an
+/// `@SolidQuery`-annotated method (key in [queryByName]). Surfacing these
 /// explicitly avoids silently dropping user code while the rewriter is
 /// incomplete.
+///
+/// User-defined constructors are still rejected even on queries-only plain
+/// classes (where SPEC §8.3 permits them, since Resources are lazy and need
+/// no synthesized constructor). Lifting that restriction requires emitting
+/// the user's constructor verbatim from `source` and gating the synthesized
+/// one — deferred to a later milestone.
 void _checkUnsupportedMembers(
   ClassDeclaration classDecl,
   Map<String, FieldModel> fieldByName,
   Map<String, EffectModel> effectByName,
+  Map<String, QueryModel> queryByName,
   String className,
 ) {
   for (final member in classDecl.members) {
@@ -116,7 +147,8 @@ void _checkUnsupportedMembers(
       continue;
     }
     if (member is MethodDeclaration &&
-        effectByName.containsKey(member.name.lexeme)) {
+        (effectByName.containsKey(member.name.lexeme) ||
+            queryByName.containsKey(member.name.lexeme))) {
       continue;
     }
     throw CodeGenerationError(

--- a/packages/solid_generator/lib/src/query_model.dart
+++ b/packages/solid_generator/lib/src/query_model.dart
@@ -1,5 +1,4 @@
 import 'package:meta/meta.dart';
-import 'package:solid_generator/src/transformation_error.dart';
 
 /// Parsed description of one `@SolidQuery`-annotated method.
 ///
@@ -85,28 +84,4 @@ class QueryModel {
   /// Value of the `name:` argument on `@SolidQuery(name: '…')`, or `null` if
   /// the annotation had no `name:` argument (SPEC §3.5 / §4.8 rule 8).
   final String? annotationName;
-}
-
-/// Throws [CodeGenerationError] when [solidQueries] is non-empty, naming the
-/// first offending method and the [classKindLabel] (`'plain class'`,
-/// `'existing State<X> subclass'`, …) of the rewriter that has not yet
-/// implemented method→`Resource` lowering.
-///
-/// Mirrors `rejectIfEffectsNotYetSupported` in `effect_model.dart`: the
-/// message template lives in one place so two rewriters' "not yet supported"
-/// errors can never drift. The StatelessWidget path lands in M5-01; the
-/// `State<X>` and plain-class paths land in M5-08 / M5-09.
-void rejectIfQueriesNotYetSupported(
-  List<QueryModel> solidQueries,
-  String classKindLabel,
-  String className,
-) {
-  if (solidQueries.isEmpty) return;
-  throw CodeGenerationError(
-    '@SolidQuery on $classKindLabel is not yet supported '
-    '(will land in M5-08/M5-09); '
-    'offending method: ${solidQueries.first.methodName}',
-    null,
-    className,
-  );
 }

--- a/packages/solid_generator/test/golden/inputs/m5_09_query_on_plain_class.dart
+++ b/packages/solid_generator/test/golden/inputs/m5_09_query_on_plain_class.dart
@@ -1,0 +1,17 @@
+// SPEC §3.4 / §4.7 use `print` as the canonical Effect side-effect example.
+// ignore_for_file: avoid_print
+
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Counter {
+  @SolidState()
+  int value = 0;
+
+  @SolidEffect()
+  void log() {
+    print('value: $value');
+  }
+
+  @SolidQuery()
+  Future<int> fetchSnapshot() async => 0;
+}

--- a/packages/solid_generator/test/golden/outputs/m5_09_query_on_plain_class.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m5_09_query_on_plain_class.g.dart
@@ -1,0 +1,23 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class Counter {
+  final value = Signal<int>(0, name: 'value');
+  late final log = Effect(() {
+    print('value: ${value.value}');
+  }, name: 'log');
+  late final fetchSnapshot = Resource<int>(
+    () async => 0,
+    name: 'fetchSnapshot',
+  );
+
+  Counter() {
+    log;
+  }
+
+  void dispose() {
+    fetchSnapshot.dispose();
+    log.dispose();
+    value.dispose();
+  }
+}

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -52,6 +52,7 @@ const List<String> goldenNames = <String>[
   'm5_04_query_when_in_build',
   'm5_06_query_refresh_in_onpressed',
   'm5_08_query_on_state_class',
+  'm5_09_query_on_plain_class',
 ];
 
 /// Memoized golden directory resolution. Resolved relative to the package


### PR DESCRIPTION
## Summary

- Plain (non-Widget) classes now accept `@SolidQuery` methods, mirroring M5-08's `State<X>` lowering: each annotated method becomes a single `late final <name> = Resource<T>(...)` field that joins the dispose-name list in reverse-declaration order.
- Queries are intentionally **never** spliced into the synthesized constructor — `Resource` is lazy by design (SPEC §4.8 rule 10 / §8.3), so the late-final initializer fires on first call-site read.
- Closes the third (and final in-scope) class-kind for method-targeted query lowering. M5-10 (auto-tracked `source:` wiring) and M5-11 (annotation parameters) remain.

## Test plan

- [x] `dart test packages/solid_generator/` — 102 tests pass, including the new `m5_09_query_on_plain_class` golden
- [x] `dart analyze packages/solid_generator/test/golden/outputs/` — zero issues on the generated golden
- [x] `dart analyze --fatal-infos` — zero new issues (one pre-existing M4-06 issue in `example/test/effect_widget_test.dart:114` unrelated to this PR)
- [x] `dart format --set-exit-if-changed .` — zero diff
- [x] Reviewer rubric (`plans/features/reviewer-rubric.md`) — all 8 checks pass