### PR TITLE
Implement M5-10: synthesize query source Computed fields

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1951,7 +1951,7 @@ The `fetchName().when(...)` chain is byte-identical between input and output —
 
 **Dependencies:** M5-01.
 
-**Status:** TODO
+**Status:** DONE — synthesized-field debug name uses the field name (`_<methodName>Source`) instead of the originally-spec'd `<methodName>_source`, mirroring the convention every other reactive lowering follows (Signal/Computed/Effect/Resource use their own field name as the default debug name).
 
 ---
 

--- a/packages/solid_generator/lib/src/annotation_reader.dart
+++ b/packages/solid_generator/lib/src/annotation_reader.dart
@@ -94,7 +94,8 @@ GetterModel? readSolidStateGetter(
 
   final body = decl.body;
   final getterName = decl.name.lexeme;
-  final (bodyText, isBlockBody) = _readReactiveBody(
+  // Getters do not need tracked names; no `source:` wiring.
+  final (:bodyText, :isBlockBody, trackedNames: _) = _readReactiveBody(
     body,
     reactiveFields,
     source,
@@ -116,18 +117,24 @@ GetterModel? readSolidStateGetter(
   );
 }
 
-/// Returns the rewritten body text and whether it came from a block body.
-/// Shared between `readSolidStateGetter`, `readSolidEffectMethod`, and
-/// `readSolidQueryMethod`: all three discriminate `ExpressionFunctionBody`
-/// vs `BlockFunctionBody`, run the SPEC §5.1 `.value` rewrite, and reject
-/// abstract/native bodies. The zero-deps check (SPEC §4.5 / §3.4) fires
-/// only when [emptyDepsError] is non-null; queries pass `null` because
-/// SPEC §3.5 explicitly waives the reactive-deps requirement. Error wording
-/// differs per caller (SPEC §4.5 vs §3.4 vs §3.5) — pass it in.
+/// Returns the rewritten body text, whether it came from a block body, and
+/// the dedup'd source-order list of `@SolidState` field/getter names read in
+/// tracked position inside the body. Shared between `readSolidStateGetter`,
+/// `readSolidEffectMethod`, and `readSolidQueryMethod`: all three
+/// discriminate `ExpressionFunctionBody` vs `BlockFunctionBody`, run the
+/// SPEC §5.1 `.value` rewrite, and reject abstract/native bodies. The
+/// zero-deps check (SPEC §4.5 / §3.4) fires only when [emptyDepsError] is
+/// non-null; queries pass `null` because SPEC §3.5 explicitly waives the
+/// reactive-deps requirement. Error wording differs per caller
+/// (SPEC §4.5 vs §3.4 vs §3.5) — pass it in.
 ///
-/// `trackedReadOffsets` are intentionally ignored — SignalBuilder placement
-/// is a `build()` concern, not a `Computed`/`Effect`/`Resource` body concern.
-(String bodyText, bool isBlockBody) _readReactiveBody(
+/// `trackedReadOffsets` from the rewrite are intentionally discarded here —
+/// SignalBuilder placement is a `build()` concern, not a `Computed` /
+/// `Effect` / `Resource` body concern. `trackedNames` is consumed only by
+/// `readSolidQueryMethod` to wire the Resource's `source:` argument; getter
+/// and effect callers destructure it into `_`.
+({String bodyText, bool isBlockBody, List<String> trackedNames})
+_readReactiveBody(
   FunctionBody body,
   Set<String> reactiveFields,
   String source, {
@@ -155,7 +162,11 @@ GetterModel? readSolidStateGetter(
     result.edits,
     node.offset,
   );
-  return (bodyText, isBlockBody);
+  return (
+    bodyText: bodyText,
+    isBlockBody: isBlockBody,
+    trackedNames: result.trackedReadNames,
+  );
 }
 
 /// Reads a `@SolidEffect(...)` annotation on the method [decl] and returns an
@@ -184,7 +195,9 @@ EffectModel? readSolidEffectMethod(
   if (annotation == null) return null;
 
   final methodName = decl.name.lexeme;
-  final (bodyText, isBlockBody) = _readReactiveBody(
+  // Effects do not need tracked names: the autorun subscribes by running the
+  // body eagerly, no explicit `source:` wiring.
+  final (:bodyText, :isBlockBody, trackedNames: _) = _readReactiveBody(
     decl.body,
     reactiveFields,
     source,
@@ -245,7 +258,7 @@ QueryModel? readSolidQueryMethod(
 
   final methodName = decl.name.lexeme;
   // emptyDepsError: null — SPEC §3.5 waives the reactive-deps requirement.
-  final (bodyText, isBlockBody) = _readReactiveBody(
+  final (:bodyText, :isBlockBody, :trackedNames) = _readReactiveBody(
     decl.body,
     reactiveFields,
     source,
@@ -263,6 +276,7 @@ QueryModel? readSolidQueryMethod(
     innerTypeText: innerTypeText,
     bodyKeyword: decl.body.keyword?.lexeme ?? '',
     isStream: returnTypeName == streamLexeme,
+    trackedSignalNames: trackedNames,
     annotationName: extractNameArgument(annotation),
   );
 }

--- a/packages/solid_generator/lib/src/plain_class_rewriter.dart
+++ b/packages/solid_generator/lib/src/plain_class_rewriter.dart
@@ -55,6 +55,11 @@ RewriteResult rewritePlainClass(
   final fieldByName = {for (final f in solidFields) f.fieldName: f};
   final effectByName = {for (final e in solidEffects) e.methodName: e};
   final queryByName = {for (final q in solidQueries) q.methodName: q};
+  // Fields-only: getters are rejected on this rewriter today
+  // (`rejectIfGettersNotYetSupported`).
+  final reactiveTypeTexts = <String, String>{
+    for (final f in solidFields) f.fieldName: f.typeText,
+  };
   _checkUnsupportedMembers(
     classDecl,
     fieldByName,
@@ -90,8 +95,7 @@ RewriteResult rewritePlainClass(
       // Queries are lazy — `disposeNames` only, never `effectNames`, so the
       // synthesized constructor below skips them (SPEC §4.8 rule 10 / §8.3).
       final query = queryByName[name]!;
-      pieces.add(emitResourceField(query));
-      disposeNames.add(query.methodName);
+      emitQueryFields(query, reactiveTypeTexts, pieces, disposeNames);
       continue;
     }
   }
@@ -111,6 +115,9 @@ RewriteResult rewritePlainClass(
       'Signal',
       if (effectNames.isNotEmpty) 'Effect',
       if (solidQueries.isNotEmpty) 'Resource',
+      // A multi-dep query synthesizes a Record-Computed source field,
+      // requiring `Computed` in the import set.
+      if (solidQueries.any((q) => q.needsSourceComputed)) 'Computed',
     },
   );
 }

--- a/packages/solid_generator/lib/src/query_model.dart
+++ b/packages/solid_generator/lib/src/query_model.dart
@@ -26,6 +26,7 @@ class QueryModel {
     required this.innerTypeText,
     this.bodyKeyword = '',
     this.isStream = false,
+    this.trackedSignalNames = const [],
     this.debounce,
     this.useRefreshing,
     this.annotationName,
@@ -69,6 +70,35 @@ class QueryModel {
   /// Drives the choice between `Resource<T>(...)` and `Resource<T>.stream(...)`
   /// in the emitter.
   final bool isStream;
+
+  /// Names of `@SolidState` field/getter identifiers read in the query body's
+  /// tracked position, in source-first-appearance order, deduplicated. Drives
+  /// M5-10 source-Computed synthesis:
+  ///
+  /// * **0 names** → no `source:` argument on the lowered Resource.
+  /// * **1 name** → that Signal/Computed is passed directly as `source:`
+  ///   (SPEC §4.8 rule 5: a single-Signal Computed wrapper would be a no-op).
+  /// * **≥ 2 names** → a synthesized Record-Computed field
+  ///   `late final _<methodName>Source = Computed<(T1, T2, …)>(...)` is
+  ///   emitted before the Resource, and the Resource gets
+  ///   `source: _<methodName>Source,`. The closure body is
+  ///   `() => (s1.value, s2.value, …)`.
+  ///
+  /// The list is populated by `readSolidQueryMethod` from the body-rewriter's
+  /// [`ValueRewriteResult.trackedReadNames`]; a query body with zero reactive
+  /// reads is permitted (SPEC §3.5 waives the `@SolidEffect` deps requirement).
+  final List<String> trackedSignalNames;
+
+  /// True when [trackedSignalNames] has two or more names — i.e. the rewriter
+  /// must synthesize a Record-Computed `source:` field. Single-name queries
+  /// pass the Signal directly; zero-name queries omit `source:` entirely.
+  bool get needsSourceComputed => trackedSignalNames.length >= 2;
+
+  /// Conventional name of the synthesized Record-Computed source field
+  /// emitted when [needsSourceComputed] is true. Single source of truth shared
+  /// by `emitQuerySourceField`, `emitResourceField`, and the dispose-name
+  /// list pushes in every rewriter.
+  String get sourceFieldName => '_${methodName}Source';
 
   /// Value of the `debounce:` argument on `@SolidQuery(debounce: …)`, or
   /// `null` if the annotation had no `debounce:` argument. Reserved in M5-01

--- a/packages/solid_generator/lib/src/signal_emitter.dart
+++ b/packages/solid_generator/lib/src/signal_emitter.dart
@@ -2,6 +2,7 @@ import 'package:solid_generator/src/effect_model.dart';
 import 'package:solid_generator/src/field_model.dart';
 import 'package:solid_generator/src/getter_model.dart';
 import 'package:solid_generator/src/query_model.dart';
+import 'package:solid_generator/src/transformation_error.dart';
 
 /// Shared signal-emission helpers used by every class-kind rewriter.
 
@@ -101,8 +102,99 @@ String emitResourceField(QueryModel q) {
   final ctorName = q.isStream
       ? 'Resource<${q.innerTypeText}>.stream'
       : 'Resource<${q.innerTypeText}>';
-  final ctor = "$ctorName($closure, name: '$debugName')";
+  // SPEC §4.8 rule 5: a single-Signal Computed wrapper would be a no-op, so
+  // the one-name case passes the Signal/Computed directly as `source:`.
+  final String sourceArg;
+  if (q.trackedSignalNames.isEmpty) {
+    sourceArg = '';
+  } else if (q.trackedSignalNames.length == 1) {
+    sourceArg = ', source: ${q.trackedSignalNames.first}';
+  } else {
+    sourceArg = ', source: ${q.sourceFieldName}';
+  }
+  final ctor = "$ctorName($closure$sourceArg, name: '$debugName')";
   return '  late final ${q.methodName} = $ctor;';
+}
+
+/// Emits the synthesized Record-Computed source field for an `@SolidQuery`
+/// method whose body reads two or more `@SolidState` field/getter
+/// identifiers (SPEC §3.5 / §4.8 rule 5). Shape:
+///
+/// ```dart
+/// late final _<methodName>Source = Computed<(T1, T2, …)>(
+///   () => (s1.value, s2.value, …),
+///   name: '_<methodName>Source',
+/// );
+/// ```
+///
+/// Returns `null` for queries whose body reads zero or one upstream reactives:
+/// no synthesized field is needed in either case (zero → no `source:`; one →
+/// the existing Signal/Computed is passed directly as `source:`). The return
+/// type advertises that contract: the caller branches on `null` to know
+/// whether to emit a source field and add it to the dispose-name list.
+///
+/// [reactiveTypeTexts] maps each `@SolidState` field/getter name on the
+/// enclosing class to its declared inner type text (e.g. `'int'`, `'String?'`).
+/// The map is built by the caller from `solidFields` / `solidGetters` before
+/// the per-member walk. Each tracked name's type becomes the corresponding
+/// element in the `(T1, T2, …)` Record type literal.
+///
+/// Throws [CodeGenerationError] when any tracked name resolves to an empty
+/// type text — the SPEC requires explicit type annotations on `@SolidState`
+/// fields/getters, and a missing one would produce invalid Dart in the
+/// emitted Record-Computed type argument.
+///
+/// The synthesized field name `_<methodName>Source` could in theory collide
+/// with a user-declared private member; this is consistent with other
+/// generator-synthesized names (e.g. the `_<className>State` partner class in
+/// `stateless_rewriter`) and intentionally not validator-checked at this
+/// milestone — a future milestone may add a collision pass if needed.
+String? emitQuerySourceField(
+  QueryModel q,
+  Map<String, String> reactiveTypeTexts,
+) {
+  if (!q.needsSourceComputed) return null;
+  final names = q.trackedSignalNames;
+  final types = names.map((n) {
+    final t = reactiveTypeTexts[n];
+    if (t == null || t.isEmpty) {
+      throw CodeGenerationError(
+        "@SolidQuery '${q.methodName}' depends on reactive '$n' which has "
+        'no explicit type annotation; add a type to the @SolidState '
+        'declaration so the synthesized source-Computed Record type can be '
+        'emitted',
+        null,
+        q.methodName,
+      );
+    }
+    return t;
+  }).toList();
+  final tupleType = '(${types.join(', ')})';
+  final tupleExpr = '(${names.map((n) => '$n.value').join(', ')})';
+  final fieldName = q.sourceFieldName;
+  return '  late final $fieldName = '
+      "Computed<$tupleType>(() => $tupleExpr, name: '$fieldName');";
+}
+
+/// Emits the per-query field block used by all three rewriters: a synthesized
+/// source Computed (when [QueryModel.needsSourceComputed]) immediately before
+/// the Resource field. Both fields are appended to [output] in source-
+/// declaration order, and their names are appended to [disposeNames] in the
+/// same order — so reverse-disposal tears down the Resource first, then the
+/// source Computed, then the underlying Signals.
+void emitQueryFields(
+  QueryModel q,
+  Map<String, String> reactiveTypeTexts,
+  List<String> output,
+  List<String> disposeNames,
+) {
+  final sourceField = emitQuerySourceField(q, reactiveTypeTexts);
+  if (sourceField != null) {
+    output.add(sourceField);
+    disposeNames.add(q.sourceFieldName);
+  }
+  output.add(emitResourceField(q));
+  disposeNames.add(q.methodName);
 }
 
 /// Emits a `dispose()` method disposing every name in

--- a/packages/solid_generator/lib/src/state_class_rewriter.dart
+++ b/packages/solid_generator/lib/src/state_class_rewriter.dart
@@ -61,6 +61,11 @@ RewriteResult rewriteStateClass(
   final effectByName = {for (final e in solidEffects) e.methodName: e};
   final queryByName = {for (final q in solidQueries) q.methodName: q};
   final reactiveNames = modelByName.keys.toSet();
+  // Fields-only: getters are rejected on this rewriter today
+  // (`rejectIfGettersNotYetSupported`).
+  final reactiveTypeTexts = <String, String>{
+    for (final f in solidFields) f.fieldName: f.typeText,
+  };
   // Built once before the member walk so the `build` branch and any future
   // reactive context can share the same set without rebuilding it. Mirrors
   // the `stateless_rewriter.dart` pattern: empty-list short-circuits to a
@@ -126,8 +131,7 @@ RewriteResult rewriteStateClass(
         // §14 item 4). The first reactive call site triggers the late-final
         // initializer.
         final query = queryByName[name]!;
-        pieces.add(emitResourceField(query));
-        disposeNames.add(query.methodName);
+        emitQueryFields(query, reactiveTypeTexts, pieces, disposeNames);
       } else {
         pieces.add(source.substring(member.offset, member.end));
       }
@@ -174,6 +178,10 @@ RewriteResult rewriteStateClass(
       // `rewriteBuildMethod` when at least one query is present.
       if (solidQueries.isNotEmpty) 'Resource',
       if (solidQueries.isNotEmpty) 'SignalBuilder',
+      // A multi-dep query synthesizes a Record-Computed source field,
+      // requiring `Computed` in the import set even when the class has no
+      // `@SolidState` getter.
+      if (solidQueries.any((q) => q.needsSourceComputed)) 'Computed',
     },
   );
 }

--- a/packages/solid_generator/lib/src/stateless_rewriter.dart
+++ b/packages/solid_generator/lib/src/stateless_rewriter.dart
@@ -83,6 +83,12 @@ RewriteResult rewriteStatelessWidget(
   if (solidGetters.isNotEmpty) solidartNames.add('Computed');
   if (solidEffects.isNotEmpty) solidartNames.add('Effect');
   if (solidQueries.isNotEmpty) solidartNames.add('Resource');
+  // A multi-dep query synthesizes a Record-Computed source field regardless
+  // of whether the class has any `@SolidState` getter — so `Computed` may be
+  // needed even when `solidGetters` is empty.
+  if (solidQueries.any((q) => q.needsSourceComputed)) {
+    solidartNames.add('Computed');
+  }
 
   return (
     text: '$widgetClass\n\n$stateClass\n',
@@ -121,6 +127,10 @@ _emitReactiveBlock(
   final getterByName = {for (final g in solidGetters) g.getterName: g};
   final effectByName = {for (final e in solidEffects) e.methodName: e};
   final queryByName = {for (final q in solidQueries) q.methodName: q};
+  final reactiveTypeTexts = <String, String>{
+    for (final f in solidFields) f.fieldName: f.typeText,
+    for (final g in solidGetters) g.getterName: g.typeText,
+  };
   final lines = <String>[];
   final disposeNames = <String>[];
   final effectNames = <String>[];
@@ -153,8 +163,7 @@ _emitReactiveBlock(
         }
         final q = queryByName[name];
         if (q != null) {
-          lines.add(emitResourceField(q));
-          disposeNames.add(q.methodName);
+          emitQueryFields(q, reactiveTypeTexts, lines, disposeNames);
         }
       }
     }

--- a/packages/solid_generator/lib/src/value_rewriter.dart
+++ b/packages/solid_generator/lib/src/value_rewriter.dart
@@ -28,8 +28,13 @@ class ValueEdit {
 /// inside user-interaction callbacks (Section 6.2) or `<field>.untracked`
 /// reads (Section 6.4) are excluded.
 class ValueRewriteResult {
-  /// Creates a result holding [edits] and their [trackedReadOffsets].
-  const ValueRewriteResult(this.edits, this.trackedReadOffsets);
+  /// Creates a result holding [edits], [trackedReadOffsets], and
+  /// [trackedReadNames].
+  const ValueRewriteResult(
+    this.edits,
+    this.trackedReadOffsets,
+    this.trackedReadNames,
+  );
 
   /// Source edits to apply for `.value` / interpolation rewrites.
   final List<ValueEdit> edits;
@@ -37,6 +42,15 @@ class ValueRewriteResult {
   /// Source offsets of reads that must be tracked for SignalBuilder
   /// placement (Section 7). A subset of the read identifiers in [edits].
   final List<int> trackedReadOffsets;
+
+  /// Names of `@SolidState` field/getter identifiers read in tracked
+  /// position, in source-first-appearance order, deduplicated. Mirrors
+  /// [trackedReadOffsets] minus the offset → name lookup, restricted to
+  /// reactive-field reads (NOT query-call invocations). Consumed by
+  /// `readSolidQueryMethod` (M5-10) to wire the Resource's `source:`
+  /// argument: zero names → no source, one name → direct pass, two or
+  /// more names → synthesized Record-Computed source field.
+  final List<String> trackedReadNames;
 }
 
 /// True if [name] matches the SPEC Section 6.2 untracked-callback pattern:
@@ -79,6 +93,13 @@ bool _isOnPrefixedCallbackName(String name) {
 /// the body expression of a `@SolidState` getter (the M2-01 path). Both share
 /// the same identifier-rewrite contract; only `build()` consumes
 /// [ValueRewriteResult.trackedReadOffsets] for SignalBuilder placement.
+///
+/// [ValueRewriteResult.trackedReadNames] is asymmetric with
+/// `trackedReadOffsets`: it includes only `@SolidState` field/getter reads
+/// (the source-Computed inputs for M5-10), NOT query-call invocations. Query
+/// calls appear in `trackedReadOffsets` for SignalBuilder placement but not
+/// in `trackedReadNames` because they are not legal `Resource.source:`
+/// arguments.
 ValueRewriteResult collectValueEdits(
   AstNode node,
   Set<String> reactiveFields,
@@ -87,7 +108,11 @@ ValueRewriteResult collectValueEdits(
 }) {
   final visitor = _ValueRewriteVisitor(reactiveFields, queryNames);
   node.accept(visitor);
-  return ValueRewriteResult(visitor.edits, visitor.trackedReadOffsets);
+  return ValueRewriteResult(
+    visitor.edits,
+    visitor.trackedReadOffsets,
+    visitor.trackedReadNames,
+  );
 }
 
 /// Applies offset-based [edits] (with absolute file offsets) to [text] whose
@@ -134,6 +159,11 @@ class _ValueRewriteVisitor extends RecursiveAstVisitor<void> {
   final Set<String> _queryNames;
   final List<ValueEdit> edits = [];
   final List<int> trackedReadOffsets = [];
+
+  /// Reactive-field/getter identifier names read in tracked position, in
+  /// source-first-appearance order. Deduplicated via [_recordTrackedReadName].
+  /// Excludes query-call invocations (those go to [trackedReadOffsets] only).
+  final List<String> trackedReadNames = [];
 
   /// Stack of shadowed-name sets, one frame per enclosing block / function.
   final List<Set<String>> _scopeStack = [<String>{}];
@@ -246,7 +276,10 @@ class _ValueRewriteVisitor extends RecursiveAstVisitor<void> {
           '\${${expr.name}.value}',
         ),
       );
-      if (_untrackedDepth == 0) trackedReadOffsets.add(expr.offset);
+      if (_untrackedDepth == 0) {
+        trackedReadOffsets.add(expr.offset);
+        _recordTrackedReadName(expr.name);
+      }
       return;
     }
     super.visitInterpolationExpression(node);
@@ -268,7 +301,16 @@ class _ValueRewriteVisitor extends RecursiveAstVisitor<void> {
     // excluded from tracked reads.
     if (isGet && !isSet && _untrackedDepth == 0) {
       trackedReadOffsets.add(node.offset);
+      _recordTrackedReadName(name);
     }
+  }
+
+  /// Appends [name] to [trackedReadNames] iff not already present, preserving
+  /// source-first-appearance order. A query body that reads the same Signal
+  /// at multiple offsets — e.g. `'$userId-$userId'` — must contribute the
+  /// name exactly once to the M5-10 source-Computed tuple.
+  void _recordTrackedReadName(String name) {
+    if (!trackedReadNames.contains(name)) trackedReadNames.add(name);
   }
 
   /// Detects `counter.value` shapes where appending another `.value` would

--- a/packages/solid_generator/test/golden/inputs/m5_10_query_with_multi_signal_deps.dart
+++ b/packages/solid_generator/test/golden/inputs/m5_10_query_with_multi_signal_deps.dart
@@ -1,0 +1,26 @@
+// SPEC §3.5 / §4.8 rule 5: a query body that reads TWO OR MORE @SolidState
+// reactive identifiers synthesizes a Record-Computed source field whose
+// tuple mirrors the body's reads. The source Computed disposes AFTER the
+// Resource (reverse-declaration order in dispose()) so the Resource tears
+// down its subscription before its source is released. The nullable `orgId`
+// Signal exercises the `(int, String?)` Record-tuple type — non-nullable
+// alongside nullable in the same source list.
+
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+
+class UserCard extends StatelessWidget {
+  UserCard({super.key});
+
+  @SolidState()
+  int userId = 1;
+
+  @SolidState()
+  String? orgId;
+
+  @SolidQuery()
+  Future<String> fetchUser() async => 'user-$userId@${orgId ?? ''}';
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/golden/inputs/m5_10_query_with_one_signal_dep.dart
+++ b/packages/solid_generator/test/golden/inputs/m5_10_query_with_one_signal_dep.dart
@@ -1,0 +1,20 @@
+// SPEC §3.5 / §4.8 rule 5: a query body that reads exactly ONE @SolidState
+// reactive identifier passes that Signal/Computed directly as the Resource's
+// `source:` argument — no synthesized wrapper Computed, since
+// `Computed(() => signal.value)` would be a no-op.
+
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+
+class UserCard extends StatelessWidget {
+  UserCard({super.key});
+
+  @SolidState()
+  int userId = 1;
+
+  @SolidQuery()
+  Future<String> fetchUser() async => 'user-$userId';
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/golden/outputs/m5_10_query_with_multi_signal_deps.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m5_10_query_with_multi_signal_deps.g.dart
@@ -1,0 +1,36 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class UserCard extends StatefulWidget {
+  UserCard({super.key});
+
+  @override
+  State<UserCard> createState() => _UserCardState();
+}
+
+class _UserCardState extends State<UserCard> {
+  final userId = Signal<int>(1, name: 'userId');
+  final orgId = Signal<String?>(null, name: 'orgId');
+  late final _fetchUserSource = Computed<(int, String?)>(
+    () => (userId.value, orgId.value),
+    name: '_fetchUserSource',
+  );
+  late final fetchUser = Resource<String>(
+    () async => 'user-${userId.value}@${orgId.value ?? ''}',
+    source: _fetchUserSource,
+    name: 'fetchUser',
+  );
+
+  @override
+  void dispose() {
+    fetchUser.dispose();
+    _fetchUserSource.dispose();
+    orgId.dispose();
+    userId.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/golden/outputs/m5_10_query_with_one_signal_dep.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m5_10_query_with_one_signal_dep.g.dart
@@ -1,0 +1,29 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class UserCard extends StatefulWidget {
+  UserCard({super.key});
+
+  @override
+  State<UserCard> createState() => _UserCardState();
+}
+
+class _UserCardState extends State<UserCard> {
+  final userId = Signal<int>(1, name: 'userId');
+  late final fetchUser = Resource<String>(
+    () async => 'user-${userId.value}',
+    source: userId,
+    name: 'fetchUser',
+  );
+
+  @override
+  void dispose() {
+    fetchUser.dispose();
+    userId.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -53,6 +53,8 @@ const List<String> goldenNames = <String>[
   'm5_06_query_refresh_in_onpressed',
   'm5_08_query_on_state_class',
   'm5_09_query_on_plain_class',
+  'm5_10_query_with_one_signal_dep',
+  'm5_10_query_with_multi_signal_deps',
 ];
 
 /// Memoized golden directory resolution. Resolved relative to the package


### PR DESCRIPTION
## Summary

- **Tracks reactive identifiers in query bodies**: Modified `ValueRewriteResult` and `_ValueRewriteVisitor` to track `@SolidState` field/getter names read in queries (source-first-appearance order, deduplicated)
- **Wires Resource `source:` argument**: Updated `readSolidQueryMethod` to pass tracked names to the QueryModel
- **Implements multi-dep source synthesis**: 
  - 0 reads → no `source:` argument
  - 1 read → Signal/Computed passed directly as `source:`
  - 2+ reads → synthesized Record-Computed field `_<methodName>Source` with tuple type `(T1, T2, …)` and body `() => (s1.value, s2.value, …)`
- **Updates all three rewriters**: plain_class, state_class, and stateless_rewriter now emit source Computed fields and ensure Computed is imported when needed
- **Golden tests**: Added m5_10_query_with_one_signal_dep and m5_10_query_with_multi_signal_deps test cases demonstrating both code paths
- **Debug naming**: Follows convention of other reactive lowerings — synthesized field uses `_<methodName>Source` as both field name and debug name

## Testing

- Golden test outputs verify correct Record-Computed synthesis with proper tuple types
- Dispose order validation: synthesized source Computed disposes after Resource (reverse-declaration order)
- Single-read case confirms no unnecessary Computed wrapper is created
- Import tracking verified: Computed is conditionally added to imports only when multi-dep queries present