### PR TITLE
Implement M5-11: @SolidQuery debounce: and useRefreshing: parameters

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1981,6 +1981,6 @@ The `fetchName().when(...)` chain is byte-identical between input and output —
 
 **Dependencies:** M5-01.
 
-**Status:** TODO
+**Status:** DONE
 
 ---

--- a/packages/solid_generator/lib/src/annotation_reader.dart
+++ b/packages/solid_generator/lib/src/annotation_reader.dart
@@ -278,6 +278,8 @@ QueryModel? readSolidQueryMethod(
     isStream: returnTypeName == streamLexeme,
     trackedSignalNames: trackedNames,
     annotationName: extractNameArgument(annotation),
+    debounce: extractDebounceArgument(annotation, source),
+    useRefreshing: extractUseRefreshingArgument(annotation),
   );
 }
 
@@ -296,17 +298,58 @@ Annotation? findAnnotationByName(
   return null;
 }
 
+/// Returns the [Expression] passed for `<label>: <expr>` on [annotation], or
+/// `null` if the annotation has no named argument with that label.
+Expression? _findNamedArg(Annotation annotation, String label) {
+  final args = annotation.arguments?.arguments ?? const [];
+  for (final arg in args) {
+    if (arg is NamedExpression && arg.name.label.name == label) {
+      return arg.expression;
+    }
+  }
+  return null;
+}
+
 /// Extracts the string value of a `name: '…'` named argument on [annotation],
 /// or `null` if the annotation has no such argument. Shared between the field
 /// and getter readers so both reactive shapes thread the SPEC §4.4 debug name
 /// uniformly.
 String? extractNameArgument(Annotation annotation) {
-  final args = annotation.arguments?.arguments ?? const [];
-  for (final arg in args) {
-    if (arg is NamedExpression && arg.name.label.name == 'name') {
-      final expr = arg.expression;
-      if (expr is SimpleStringLiteral) return expr.value;
-    }
-  }
-  return null;
+  final expr = _findNamedArg(annotation, 'name');
+  return expr is SimpleStringLiteral ? expr.value : null;
+}
+
+/// Returns the emit-ready source text of the `debounce:` argument's
+/// expression on `@SolidQuery(debounce: …)`, or `null` if the annotation has
+/// no `debounce:` argument.
+///
+/// In the unresolved AST that the builder operates on, `Duration(...)` (no
+/// keyword) parses as a [MethodInvocation] because the parser cannot tell
+/// it's a constructor call without semantic resolution; `const Duration(...)`
+/// parses as an [InstanceCreationExpression] because the keyword
+/// disambiguates. Annotation argument context is implicit-const, so the
+/// canonical user shape lacks `const`; both no-keyword shapes therefore
+/// receive a `const ` prefix so the lowered
+/// `Resource(... debounceDelay: <text>, ...)` arg compiles in its non-const
+/// constructor-arg context. Other shapes (`const Duration(...)`, identifier
+/// references like a const-declared `_myDebounce`) emit verbatim.
+String? extractDebounceArgument(Annotation annotation, String source) {
+  final expr = _findNamedArg(annotation, 'debounce');
+  if (expr == null) return null;
+  final raw = source.substring(expr.offset, expr.end);
+  final implicitConst =
+      expr is MethodInvocation ||
+      (expr is InstanceCreationExpression && expr.keyword == null);
+  return implicitConst ? 'const $raw' : raw;
+}
+
+/// Returns `true`/`false` for `useRefreshing: <bool>` on
+/// `@SolidQuery(useRefreshing: …)`, or `null` if the annotation has no
+/// `useRefreshing:` argument. The `null` case is distinct from the
+/// annotation default (`true`) at the model layer, but per SPEC §4.8 rule 9
+/// both omit the emitted `useRefreshing:` argument (the upstream
+/// `Resource` default is `true`, so emitting it would be redundant noise).
+bool? extractUseRefreshingArgument(Annotation annotation) {
+  final expr = _findNamedArg(annotation, 'useRefreshing');
+  return expr is BooleanLiteral ? expr.value : null;
 }

--- a/packages/solid_generator/lib/src/query_model.dart
+++ b/packages/solid_generator/lib/src/query_model.dart
@@ -100,10 +100,16 @@ class QueryModel {
   /// list pushes in every rewriter.
   String get sourceFieldName => '_${methodName}Source';
 
-  /// Value of the `debounce:` argument on `@SolidQuery(debounce: …)`, or
-  /// `null` if the annotation had no `debounce:` argument. Reserved in M5-01
-  /// for M5-11 — present on the model so future readers don't reshape it.
-  final Duration? debounce;
+  /// Emit-ready source text of the `debounce:` annotation argument
+  /// (e.g. `'const Duration(milliseconds: 300)'`), or `null` if the
+  /// annotation had no `debounce:` argument. The reader prepends `const ` for
+  /// the implicit-const annotation form so the lowered
+  /// `Resource(... debounceDelay: <text>, ...)` arg compiles in a non-const
+  /// constructor-arg context. Stored as source text (not a runtime
+  /// `Duration`) so the emitter can splice it verbatim — mirrors how
+  /// [bodyText], [innerTypeText], and [annotationName] carry source
+  /// substrings. Wired in M5-11.
+  final String? debounce;
 
   /// Value of the `useRefreshing:` argument on `@SolidQuery(useRefreshing: …)`,
   /// or `null` if the annotation had no `useRefreshing:` argument. Reserved

--- a/packages/solid_generator/lib/src/signal_emitter.dart
+++ b/packages/solid_generator/lib/src/signal_emitter.dart
@@ -104,16 +104,21 @@ String emitResourceField(QueryModel q) {
       : 'Resource<${q.innerTypeText}>';
   // SPEC §4.8 rule 5: a single-Signal Computed wrapper would be a no-op, so
   // the one-name case passes the Signal/Computed directly as `source:`.
-  final String sourceArg;
-  if (q.trackedSignalNames.isEmpty) {
-    sourceArg = '';
-  } else if (q.trackedSignalNames.length == 1) {
-    sourceArg = ', source: ${q.trackedSignalNames.first}';
-  } else {
-    sourceArg = ', source: ${q.sourceFieldName}';
-  }
-  final ctor = "$ctorName($closure$sourceArg, name: '$debugName')";
-  return '  late final ${q.methodName} = $ctor;';
+  // SPEC §4.8 rule 9: `useRefreshing: true` is the upstream default and is
+  // omitted from emitted output to keep generated lines short.
+  final source = switch (q.trackedSignalNames) {
+    [] => null,
+    [final only] => only,
+    _ => q.sourceFieldName,
+  };
+  final args = [
+    closure,
+    if (source != null) 'source: $source',
+    if (q.debounce != null) 'debounceDelay: ${q.debounce}',
+    if (q.useRefreshing == false) 'useRefreshing: false',
+    "name: '$debugName'",
+  ].join(', ');
+  return '  late final ${q.methodName} = $ctorName($args);';
 }
 
 /// Emits the synthesized Record-Computed source field for an `@SolidQuery`

--- a/packages/solid_generator/test/golden/inputs/m5_11_query_with_debounce.dart
+++ b/packages/solid_generator/test/golden/inputs/m5_11_query_with_debounce.dart
@@ -1,0 +1,15 @@
+// M5-11: exercises `debounce:` propagation to `debounceDelay:`.
+// ignore_for_file: prefer_const_constructors_in_immutables
+
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+
+class Searcher extends StatelessWidget {
+  Searcher({super.key});
+
+  @SolidQuery(debounce: Duration(milliseconds: 300))
+  Future<String> fetchData() async => 'result';
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/golden/inputs/m5_11_query_with_debounce_and_use_refreshing_false.dart
+++ b/packages/solid_generator/test/golden/inputs/m5_11_query_with_debounce_and_use_refreshing_false.dart
@@ -1,0 +1,18 @@
+// SPEC §3.5 / §4.8 rule 9: both annotation parameters combine; emitted order
+// is closure (positional), source:, debounceDelay:, useRefreshing:, name:.
+// This case has no tracked signals — the source: arg is absent, so the
+// adjacency between debounceDelay: and useRefreshing: is exercised directly.
+// ignore_for_file: prefer_const_constructors_in_immutables
+
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+
+class Combined extends StatelessWidget {
+  Combined({super.key});
+
+  @SolidQuery(debounce: Duration(milliseconds: 300), useRefreshing: false)
+  Future<String> fetchData() async => 'result';
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/golden/inputs/m5_11_query_with_use_refreshing_false.dart
+++ b/packages/solid_generator/test/golden/inputs/m5_11_query_with_use_refreshing_false.dart
@@ -1,0 +1,16 @@
+// M5-11: exercises `useRefreshing: false` propagation. The default `true` is
+// omitted from emitted output (upstream `Resource` default).
+// ignore_for_file: prefer_const_constructors_in_immutables
+
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+
+class Loader extends StatelessWidget {
+  Loader({super.key});
+
+  @SolidQuery(useRefreshing: false)
+  Future<String> fetchData() async => 'result';
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/golden/outputs/m5_11_query_with_debounce.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m5_11_query_with_debounce.g.dart
@@ -1,0 +1,27 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class Searcher extends StatefulWidget {
+  Searcher({super.key});
+
+  @override
+  State<Searcher> createState() => _SearcherState();
+}
+
+class _SearcherState extends State<Searcher> {
+  late final fetchData = Resource<String>(
+    () async => 'result',
+    debounceDelay: const Duration(milliseconds: 300),
+    name: 'fetchData',
+  );
+
+  @override
+  void dispose() {
+    fetchData.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/golden/outputs/m5_11_query_with_debounce_and_use_refreshing_false.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m5_11_query_with_debounce_and_use_refreshing_false.g.dart
@@ -1,0 +1,28 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class Combined extends StatefulWidget {
+  Combined({super.key});
+
+  @override
+  State<Combined> createState() => _CombinedState();
+}
+
+class _CombinedState extends State<Combined> {
+  late final fetchData = Resource<String>(
+    () async => 'result',
+    debounceDelay: const Duration(milliseconds: 300),
+    useRefreshing: false,
+    name: 'fetchData',
+  );
+
+  @override
+  void dispose() {
+    fetchData.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/golden/outputs/m5_11_query_with_use_refreshing_false.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m5_11_query_with_use_refreshing_false.g.dart
@@ -1,0 +1,27 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class Loader extends StatefulWidget {
+  Loader({super.key});
+
+  @override
+  State<Loader> createState() => _LoaderState();
+}
+
+class _LoaderState extends State<Loader> {
+  late final fetchData = Resource<String>(
+    () async => 'result',
+    useRefreshing: false,
+    name: 'fetchData',
+  );
+
+  @override
+  void dispose() {
+    fetchData.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -55,6 +55,9 @@ const List<String> goldenNames = <String>[
   'm5_09_query_on_plain_class',
   'm5_10_query_with_one_signal_dep',
   'm5_10_query_with_multi_signal_deps',
+  'm5_11_query_with_debounce',
+  'm5_11_query_with_use_refreshing_false',
+  'm5_11_query_with_debounce_and_use_refreshing_false',
 ];
 
 /// Memoized golden directory resolution. Resolved relative to the package


### PR DESCRIPTION
## Summary

- Add support for `debounce: Duration(...)` parameter on `@SolidQuery` annotations, wired to the emitted `Resource(debounceDelay: ...)`
- Add support for `useRefreshing: false` parameter on `@SolidQuery` annotations, wired to the emitted `Resource(useRefreshing: false)`
- Extract annotation arguments as source text to preserve exact user expressions; prepend `const ` for implicit-const annotation forms so lowered arguments compile in non-const constructor contexts
- Omit `useRefreshing: true` from output per SPEC §4.8 rule 9 (upstream `Resource` default)
- Add three golden test cases covering debounce only, useRefreshing only, and combined parameters

## Testing

- Golden test cases: `m5_11_query_with_debounce`, `m5_11_query_with_use_refreshing_false`, `m5_11_query_with_debounce_and_use_refreshing_false` validate correct parameter extraction and emission
- Verified that `const Duration(...)` and implicit-const `Duration(...)` forms both compile in the emitted `Resource(debounceDelay: ...)` constructor argument
- Verified that `useRefreshing: true` is omitted from output while `useRefreshing: false` is included
- Verified parameter ordering in emitted code: closure (positional), source:, debounceDelay:, useRefreshing:, name: