### PR TITLE
Implement M6-02: plain-class implements Disposable + dispose merge

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1242,6 +1242,8 @@ class Counter implements Comparable<Counter>, Disposable {
 
 When the source plain class has reactive declarations AND a user-defined `void dispose()` method, the synthesized reactive disposals (in reverse-declaration order) are PREPENDED to the user's body; the user's body is preserved verbatim afterwards. This parallels Section 14 item 4's existing rule for `State<X>`.
 
+When the user's source `dispose()` lacks an `@override` annotation, the generator prepends one — the merged dispose always overrides `Disposable.dispose()` (plain class) or the supertype's `dispose()` (`State<X>`). The typical user pattern is to write a plain `void dispose() { … }` in source (no `@override`, no `implements Disposable`); the generator adds both during lowering.
+
 Source:
 
 ```dart

--- a/TODOS.md
+++ b/TODOS.md
@@ -2141,9 +2141,9 @@ class Counter implements Disposable {
 
 **Dependencies:** M6-01.
 
-**Implementation note:** This PR is purely a regression-fence + amendment to plain-class lowering. It does NOT introduce `@SolidEnvironment`-handling code yet. The new test goldens (b, c, d, e) exist as forward-compat: once M6-04's cross-class type-driven rewrite lands, consumers passing Solid-lowered types via `Provider<T>(dispose: (_, c) => c.dispose())` rely on the lowered class having a `dispose()` method (and `implements Disposable` as the typed contract).
+**Implementation note:** This PR is purely a regression-fence + amendment to plain-class lowering. It does NOT introduce `@SolidEnvironment`-handling code yet. The new test goldens (b, c, d, e) exist as forward-compat: once M6-04's cross-class type-driven rewrite lands, consumers passing Solid-lowered types via `Provider<T>(dispose: (_, c) => c.dispose())` rely on the lowered class having a `dispose()` method (and `implements Disposable` as the typed contract). Sub-case b additionally exercises a single-level slice of the SPEC §5.1 cross-class chain rewrite (typed-parameter receivers only, parsed-AST gated) so that the `compareTo(Counter other) => value - other.value;` body lowers cleanly to `=> value.value - other.value.value;` — full SPEC §5.4 type-driven resolution (resolved AST + `staticType`) lands in M6-04.
 
-**Status:** TODO
+**Status:** DONE
 
 ---
 

--- a/packages/solid_generator/lib/builder.dart
+++ b/packages/solid_generator/lib/builder.dart
@@ -107,9 +107,41 @@ class _SolidBuilder implements Builder {
       return;
     }
 
-    final transformed = _renderOutput(parsed.unit, annotatedClasses, source);
+    final classRegistry = _buildClassRegistry(annotatedClasses);
+    final transformed = _renderOutput(
+      parsed.unit,
+      annotatedClasses,
+      classRegistry,
+      source,
+    );
     await buildStep.writeAsString(outputId, transformed);
   }
+}
+
+/// Builds the cross-class reactivity map: class name → set of `@SolidState`
+/// field/getter names declared on that class. Consumed by `value_rewriter`
+/// to detect `<receiver>.<field>` reads where the receiver's declared type
+/// names a class with reactive declarations (SPEC §5.1 cross-class chain
+/// rewrite — single-level subset shipped in M6-02; full chains land in
+/// M6-04 alongside the resolved-AST migration).
+///
+/// `@SolidEffect` and `@SolidQuery` names are intentionally excluded — an
+/// Effect lowers to a `void`-returning `Effect` field with no observable
+/// `.value`, and a Query lowers to a `Resource<T>` whose call sites resolve
+/// through `Resource.call()` → `state` (no `.value` rewrite — SPEC §4.8
+/// rule 2 / §5.1).
+Map<String, Set<String>> _buildClassRegistry(
+  List<_AnnotatedClass> annotatedClasses,
+) {
+  final registry = <String, Set<String>>{};
+  for (final c in annotatedClasses) {
+    final names = <String>{
+      for (final f in c.fields) f.fieldName,
+      for (final g in c.getters) g.getterName,
+    };
+    if (names.isNotEmpty) registry[c.decl.name.lexeme] = names;
+  }
+  return registry;
 }
 
 /// One class declaration paired with the `@SolidState` fields and getters,
@@ -207,6 +239,7 @@ List<_AnnotatedClass> _collectAnnotatedClasses(
 String _renderOutput(
   CompilationUnit unit,
   List<_AnnotatedClass> annotatedClasses,
+  Map<String, Set<String>> classRegistry,
   String source,
 ) {
   final results = annotatedClasses.map((c) {
@@ -225,6 +258,7 @@ String _renderOutput(
       c.getters,
       c.effects,
       c.queries,
+      classRegistry,
       source,
     );
   }).toList();
@@ -254,6 +288,7 @@ RewriteResult _rewriteClass(
   List<GetterModel> getters,
   List<EffectModel> effects,
   List<QueryModel> queries,
+  Map<String, Set<String>> classRegistry,
   String source,
 ) {
   final kind = classKindOf(decl);
@@ -266,6 +301,7 @@ RewriteResult _rewriteClass(
         getters,
         effects,
         queries,
+        classRegistry,
         source,
       );
     case ClassKind.plainClass:
@@ -275,6 +311,7 @@ RewriteResult _rewriteClass(
         getters,
         effects,
         queries,
+        classRegistry,
         source,
       );
     case ClassKind.stateClass:
@@ -284,6 +321,7 @@ RewriteResult _rewriteClass(
         getters,
         effects,
         queries,
+        classRegistry,
         source,
       );
     case ClassKind.statefulWidget:

--- a/packages/solid_generator/lib/src/build_rewriter.dart
+++ b/packages/solid_generator/lib/src/build_rewriter.dart
@@ -48,6 +48,11 @@ class SourceEdit {
 /// recorded as tracked reads for SignalBuilder placement (SPEC §4.8 rule 3)
 /// without mutating the call expression itself.
 ///
+/// [classRegistry] is the cross-class reactivity map (class name → reactive
+/// field/getter names). Threaded through to the value-rewrite visitor so
+/// SPEC §5.1's single-level `<param>.<reactiveField>` cross-class rewrite
+/// fires (M6-02). Empty map → no-op for the cross-class branch.
+///
 /// [source] is the full source text of the input file. The returned string
 /// is the rewritten build method (from `@override` through the closing `}`),
 /// ready for the caller to embed into the emitted `State` class.
@@ -56,6 +61,7 @@ String rewriteBuildMethod(
   Set<String> reactiveFields,
   String source, {
   Set<String> queryNames = const {},
+  Map<String, Set<String>> classRegistry = const {},
 }) {
   final methodStart = buildMethod.offset;
   final methodEnd = buildMethod.end;
@@ -66,6 +72,7 @@ String rewriteBuildMethod(
     reactiveFields,
     source,
     queryNames: queryNames,
+    classRegistry: classRegistry,
   );
   final wrapNodes = computeWrapSet(
     buildMethod,

--- a/packages/solid_generator/lib/src/plain_class_rewriter.dart
+++ b/packages/solid_generator/lib/src/plain_class_rewriter.dart
@@ -6,41 +6,61 @@ import 'package:solid_generator/src/import_rewriter.dart';
 import 'package:solid_generator/src/query_model.dart';
 import 'package:solid_generator/src/signal_emitter.dart';
 import 'package:solid_generator/src/transformation_error.dart';
+import 'package:solid_generator/src/value_rewriter.dart';
+
+/// Simple-identifier name of the `Disposable` interface from
+/// `package:solid_annotations` (SPEC §10). Used to detect an existing
+/// declaration in the user's `implements` clause and to splice the marker
+/// into lowered headers.
+const String _disposableMarkerName = 'Disposable';
 
 /// Rewrites a plain Dart class (no widget supertype) containing `@SolidState`
 /// fields, `@SolidEffect` methods, and/or `@SolidQuery` methods by replacing
 /// each annotated field with a `Signal<T>(…)`, each annotated method with a
 /// `late final … = Effect(…)` (Effect) or `late final … = Resource<T>(…)`
-/// (Query) field, and synthesizing a fresh `dispose()` method (plus, when
-/// Effects exist, a fresh no-arg constructor whose body materializes the
-/// Effects — the plain-class analogue of the State class's `initState()`
-/// materialization, SPEC §4.7). Queries are intentionally never spliced
-/// into the synthesized constructor — Resources are lazy and the late-final
-/// initializer fires on first call-site read (SPEC §4.8 rule 10 / §8.3).
+/// (Query) field, and synthesizing a `dispose()` method (or merging into a
+/// user-defined one — SPEC §10 / §14 item 4). When Effects exist, a fresh
+/// no-arg constructor body materializes them — the plain-class analogue of
+/// the State class's `initState()` materialization (SPEC §4.7). Queries are
+/// intentionally never spliced into the synthesized constructor — Resources
+/// are lazy and the late-final initializer fires on first call-site read
+/// (SPEC §4.8 rule 10 / §8.3).
 ///
-/// See SPEC §8.3 (plain class lowering), §4.8 (Resource lowering), and §10
-/// (dispose contract). The synthesized `dispose()` has neither `@override`
-/// nor `super.dispose()` because the supertype chain is `Object` only.
+/// Class header: M6-02 adds `implements Disposable` to every Solid-lowered
+/// plain class per SPEC §10's marker rule (lines 1206–1210 of SPEC.md):
+/// when no `implements` clause is present, ` implements Disposable` is
+/// appended after any `extends` / `with` clauses; when one is present,
+/// `, Disposable` is appended to the existing list; when `Disposable` is
+/// already named (simple identifier match), the header is left unchanged.
+/// The `extends` and `with` clauses are preserved verbatim.
 ///
-/// Currently only classes whose every member is an `@SolidState`-annotated
-/// field, an `@SolidEffect`-annotated method, or an `@SolidQuery`-annotated
-/// method are supported. Any other member (existing `dispose()`, user-defined
-/// constructors, non-annotated fields, non-annotated methods, …) throws
-/// [CodeGenerationError] — dispose-merge, constructor-merge, and in-place
-/// patching are scheduled for later milestones.
+/// `@override` is added to every synthesized `dispose()` (the marker
+/// interface contract). When the user has declared their own `dispose()`,
+/// the merge prepends synthesized reactive disposals to the user's body
+/// and the user's existing `@override` (or absence thereof) is carried
+/// through verbatim.
+///
+/// Non-annotated members (other fields, user-defined methods other than
+/// `dispose()`, …) are emitted verbatim — with the SPEC §5.1 same-class
+/// `.value` rewrite applied to user method bodies (and the M6-02 single-
+/// level cross-class slice from [classRegistry], so a `compareTo(Counter
+/// other) => value - other.value;` body lowers to
+/// `=> value.value - other.value.value;`). User-defined constructors are
+/// still rejected — constructor-merge is deferred to a later milestone.
+///
+/// See SPEC §8.3 (plain-class lowering header), §10 (dispose contract +
+/// `Disposable` marker rule + body merge), §14 item 4 (existing `State<X>`
+/// rule, extended here to plain classes).
 ///
 /// The emitted string is syntactically valid Dart but is not guaranteed to be
 /// pretty-printed — run through `DartFormatter` before writing.
-///
-/// [source] is unused here (full reconstruction from AST); it is part of the
-/// signature so the dispatcher in `builder.dart` can pass it uniformly to
-/// every class-kind rewriter.
 RewriteResult rewritePlainClass(
   ClassDeclaration classDecl,
   List<FieldModel> solidFields,
   List<GetterModel> solidGetters,
   List<EffectModel> solidEffects,
   List<QueryModel> solidQueries,
+  Map<String, Set<String>> classRegistry,
   String source,
 ) {
   final className = classDecl.name.lexeme;
@@ -60,57 +80,99 @@ RewriteResult rewritePlainClass(
   final reactiveTypeTexts = <String, String>{
     for (final f in solidFields) f.fieldName: f.typeText,
   };
-  _checkUnsupportedMembers(
-    classDecl,
-    fieldByName,
-    effectByName,
-    queryByName,
-    className,
-  );
+  final reactiveNames = fieldByName.keys.toSet();
 
   final pieces = <String>[];
   final disposeNames = <String>[];
   final effectNames = <String>[];
+  // `dispose` emission is deferred until after the walk so the merge sees
+  // the fully-populated `disposeNames` list. The slot index reserves the
+  // member's source-order position in `pieces` so a user-declared
+  // `dispose()` round-trips at its original position relative to the
+  // synthesized fields.
+  MethodDeclaration? disposeMethod;
+  var disposeSlot = -1;
 
   for (final member in classDecl.members) {
+    if (member is ConstructorDeclaration) {
+      // Constructor-merge would need to gate the synthesized Effect-
+      // materialization constructor; deferred to a later milestone.
+      throw CodeGenerationError(
+        'plain class with constructor is not yet supported',
+        null,
+        className,
+      );
+    }
     if (member is FieldDeclaration) {
-      // Non-annotated fields are rejected by `_checkUnsupportedMembers`
-      // above, so the lookup always hits.
-      final f = fieldByName[member.fields.variables.first.name.lexeme]!;
-      pieces.add(emitSignalField(f));
-      disposeNames.add(f.fieldName);
+      final varName = member.fields.variables.first.name.lexeme;
+      final f = fieldByName[varName];
+      if (f != null) {
+        pieces.add(emitSignalField(f));
+        disposeNames.add(f.fieldName);
+      } else {
+        pieces.add(source.substring(member.offset, member.end));
+      }
       continue;
     }
     if (member is MethodDeclaration) {
-      // `_checkUnsupportedMembers` above guarantees exactly one of the two
-      // map lookups hits, so the `!` on the query branch is safe.
       final name = member.name.lexeme;
-      final effect = effectByName[name];
-      if (effect != null) {
+      if (name == 'dispose') {
+        disposeMethod = member;
+        disposeSlot = pieces.length;
+        pieces.add('');
+      } else if (effectByName.containsKey(name)) {
+        final effect = effectByName[name]!;
         pieces.add(emitEffectField(effect));
         disposeNames.add(effect.methodName);
         effectNames.add(effect.methodName);
-        continue;
+      } else if (queryByName.containsKey(name)) {
+        // Queries are lazy — joining `disposeNames` only, never
+        // `effectNames`, so the synthesized constructor below skips them
+        // (SPEC §4.8 rule 10 / §8.3).
+        final query = queryByName[name]!;
+        emitQueryFields(query, reactiveTypeTexts, pieces, disposeNames);
+      } else {
+        pieces.add(
+          _rewriteUserMethod(member, reactiveNames, classRegistry, source),
+        );
       }
-      // Queries are lazy — `disposeNames` only, never `effectNames`, so the
-      // synthesized constructor below skips them (SPEC §4.8 rule 10 / §8.3).
-      final query = queryByName[name]!;
-      emitQueryFields(query, reactiveTypeTexts, pieces, disposeNames);
       continue;
     }
+    pieces.add(source.substring(member.offset, member.end));
   }
 
-  final fields = pieces.join('\n');
-  // No-arg constructor only when Effects need materialization — keeps the
-  // Signal-only output byte-identical to the M1-06 plain-class golden, and
-  // applies equally to queries-only classes (Resources are lazy).
-  final ctor = effectNames.isEmpty
-      ? ''
-      : '\n\n${emitConstructor(className, effectNames)}';
-  final dispose = emitDispose(disposeNames, inheritsDispose: false);
+  // Dispose: merge into user body if present, else synthesize. `@override`
+  // is emitted in either case (the marker interface contract). On the merge
+  // path the user's `@override` (if any) is carried through verbatim by
+  // `mergeDispose`'s byte-for-byte slice. `super.dispose()` is never
+  // emitted — a plain class's supertype is `Object` (no `dispose()` to
+  // forward to).
+  final disposeText = disposeMethod != null
+      ? mergeDispose(disposeMethod, disposeNames, source, className)
+      : emitDispose(
+          disposeNames,
+          emitOverride: true,
+          emitSuperCall: false,
+        );
+  // No-arg constructor: only when Effects need materialization. When the
+  // user declared `dispose()`, place the constructor immediately before
+  // the (slot-reserved) dispose body so the rendered order is fields →
+  // ctor → dispose.
+  if (disposeMethod != null) {
+    pieces[disposeSlot] = disposeText;
+    if (effectNames.isNotEmpty) {
+      pieces.insert(disposeSlot, emitConstructor(className, effectNames));
+    }
+  } else {
+    if (effectNames.isNotEmpty) {
+      pieces.add(emitConstructor(className, effectNames));
+    }
+    pieces.add(disposeText);
+  }
 
+  final header = _buildHeaderWithDisposable(classDecl, source);
   return (
-    text: 'class $className {\n$fields$ctor\n\n$dispose\n}',
+    text: '$header{\n${pieces.join('\n\n')}\n}',
     solidartNames: <String>{
       'Signal',
       if (effectNames.isNotEmpty) 'Effect',
@@ -122,59 +184,58 @@ RewriteResult rewritePlainClass(
   );
 }
 
-/// Throws [CodeGenerationError] if [classDecl] contains any member other than
-/// an `@SolidState`-annotated field (key in [fieldByName]), an
-/// `@SolidEffect`-annotated method (key in [effectByName]), or an
-/// `@SolidQuery`-annotated method (key in [queryByName]). Surfacing these
-/// explicitly avoids silently dropping user code while the rewriter is
-/// incomplete.
-///
-/// User-defined constructors are still rejected even on queries-only plain
-/// classes (where SPEC §8.3 permits them, since Resources are lazy and need
-/// no synthesized constructor). Lifting that restriction requires emitting
-/// the user's constructor verbatim from `source` and gating the synthesized
-/// one — deferred to a later milestone.
-void _checkUnsupportedMembers(
-  ClassDeclaration classDecl,
-  Map<String, FieldModel> fieldByName,
-  Map<String, EffectModel> effectByName,
-  Map<String, QueryModel> queryByName,
-  String className,
-) {
-  for (final member in classDecl.members) {
-    if (member is FieldDeclaration) {
-      final varName = member.fields.variables.first.name.lexeme;
-      if (!fieldByName.containsKey(varName)) {
-        throw CodeGenerationError(
-          'plain class with non-annotated field "$varName" is not yet '
-          'supported',
-          null,
-          className,
-        );
-      }
-      continue;
-    }
-    if (member is MethodDeclaration &&
-        (effectByName.containsKey(member.name.lexeme) ||
-            queryByName.containsKey(member.name.lexeme))) {
-      continue;
-    }
-    throw CodeGenerationError(
-      'plain class with ${_memberKindLabel(member)} is not yet supported',
-      null,
-      className,
-    );
+/// Returns the verbatim class header (everything from `class` up to the
+/// opening `{`) with `Disposable` merged into the `implements` clause per
+/// SPEC §10 (lines 1206–1210). `extends` and `with` clauses are preserved
+/// verbatim.
+String _buildHeaderWithDisposable(ClassDeclaration classDecl, String source) {
+  final classStart = classDecl.offset;
+  final base = source.substring(classStart, classDecl.leftBracket.offset);
+  final implementsClause = classDecl.implementsClause;
+
+  if (implementsClause == null) {
+    // Splice after the last header clause that IS present.
+    final beforeImplements =
+        classDecl.withClause?.end ??
+        classDecl.extendsClause?.end ??
+        classDecl.typeParameters?.end ??
+        classDecl.name.end;
+    final spliceIdx = beforeImplements - classStart;
+    return '${base.substring(0, spliceIdx)} implements $_disposableMarkerName'
+        '${base.substring(spliceIdx)}';
   }
+
+  final alreadyDeclared = implementsClause.interfaces.any(
+    (nt) => nt.name.lexeme == _disposableMarkerName,
+  );
+  if (alreadyDeclared) return base;
+
+  // Splice at the implements-clause `.end` so any trailing whitespace
+  // before `{` is preserved verbatim after the splice.
+  final spliceIdx = implementsClause.end - classStart;
+  return '${base.substring(0, spliceIdx)}, $_disposableMarkerName'
+      '${base.substring(spliceIdx)}';
 }
 
-/// Human-readable label for an unsupported [ClassMember], used in error
-/// messages. Avoids leaking the analyzer's `…Impl` runtime type names.
-String _memberKindLabel(ClassMember member) {
-  if (member is MethodDeclaration) {
-    return member.name.lexeme == 'dispose'
-        ? 'existing dispose() method'
-        : 'method "${member.name.lexeme}"';
-  }
-  if (member is ConstructorDeclaration) return 'constructor';
-  return 'member';
+/// Emits a non-annotated user method with the SPEC §5.1 `.value` rewrite
+/// applied to its body — both the same-class branch (bare `SimpleIdentifier`
+/// reads of [reactiveFields]) and the cross-class single-level branch from
+/// [classRegistry] in one AST walk.
+String _rewriteUserMethod(
+  MethodDeclaration method,
+  Set<String> reactiveFields,
+  Map<String, Set<String>> classRegistry,
+  String source,
+) {
+  final result = collectValueEdits(
+    method,
+    reactiveFields,
+    source,
+    classRegistry: classRegistry,
+  );
+  return applyEditsToRange(
+    source.substring(method.offset, method.end),
+    result.edits,
+    method.offset,
+  );
 }

--- a/packages/solid_generator/lib/src/signal_emitter.dart
+++ b/packages/solid_generator/lib/src/signal_emitter.dart
@@ -1,3 +1,4 @@
+import 'package:analyzer/dart/ast/ast.dart';
 import 'package:solid_generator/src/effect_model.dart';
 import 'package:solid_generator/src/field_model.dart';
 import 'package:solid_generator/src/getter_model.dart';
@@ -212,28 +213,83 @@ void emitQueryFields(
 /// declared after the `Signal`s it reads) ahead of their dependencies in the
 /// dispose body.
 ///
-/// [inheritsDispose] is `true` when the owning class's supertype chain
-/// contains a `dispose()` method (e.g. `State<T>`, `ChangeNotifier`); the
-/// emitted method is then `@override` and ends with `super.dispose();`. For
-/// a plain class whose supertype is `Object`, pass `false` — neither
-/// annotation nor super-call is emitted (SPEC §8.3).
+/// [emitOverride] gates the `@override` annotation. Pass `true` when the
+/// emitted `dispose()` overrides a supertype declaration — either `State<T>`
+/// (whose supertype chain has `dispose()`) or `Disposable` (the
+/// `solid_annotations` marker interface that lowered plain classes implement
+/// per SPEC §10).
+///
+/// [emitSuperCall] gates the trailing `super.dispose();` line. Pass `true`
+/// only when the class's supertype chain actually contains a `dispose()`
+/// method to forward to (e.g. `State<T>`, `ChangeNotifier`). For a plain
+/// class whose supertype is `Object` and which `implements Disposable`,
+/// pass `false` — there is no super-`dispose()` to call.
 String emitDispose(
   List<String> disposeNamesInDeclarationOrder, {
-  required bool inheritsDispose,
+  required bool emitOverride,
+  required bool emitSuperCall,
 }) {
   final buffer = StringBuffer();
-  if (inheritsDispose) {
+  if (emitOverride) {
     buffer.writeln('  @override');
   }
   buffer.writeln('  void dispose() {');
   for (final name in disposeNamesInDeclarationOrder.reversed) {
     buffer.writeln('    $name.dispose();');
   }
-  if (inheritsDispose) {
+  if (emitSuperCall) {
     buffer.writeln('    super.dispose();');
   }
   buffer.write('  }');
   return buffer.toString();
+}
+
+/// Prepends one `<name>.dispose();` call per reactive declaration to the
+/// existing `dispose()` body's leading boundary, leaving the rest of the body
+/// untouched (SPEC §10 / §14 item 4).
+///
+/// Shared by `state_class_rewriter` and `plain_class_rewriter` so the
+/// dispose-body merge contract stays single-sourced. The user's source body
+/// — including any `@override` annotation, return type, and existing
+/// statements (e.g. `unawaited(_subscription.cancel());`) — is sliced
+/// verbatim from `source.substring(method.offset, method.end)` and a single
+/// `\n<disposals>` block is spliced immediately after the body's opening
+/// brace.
+///
+/// [disposeNamesInDeclarationOrder] is the unified, source-ordered list of
+/// reactive declarations (Signal field + Effect method + Resource query).
+/// Reverse-iterating it puts dependents (Effects, Resources) ahead of their
+/// dependencies (Signals, Computeds) in the merged dispose body — matching
+/// the unmerged [emitDispose] case.
+///
+/// Throws [CodeGenerationError] if the existing `dispose()` uses an
+/// expression body (`=> …`) — the merge is only well-defined for a block.
+String mergeDispose(
+  MethodDeclaration method,
+  List<String> disposeNamesInDeclarationOrder,
+  String source,
+  String className,
+) {
+  final body = method.body;
+  if (body is! BlockFunctionBody) {
+    throw CodeGenerationError(
+      'existing dispose() must have a block body for reactive merge',
+      null,
+      className,
+    );
+  }
+  final lbrace = body.block.leftBracket.offset;
+  // The original source after `{` already begins with `\n` (the body's first
+  // line break) on every reasonable formatting; prepending `\n<disposals>`
+  // yields a single blank-line-free splice, leaving the rest of the body
+  // byte-identical to the source. The `DartFormatter` pass normalises any
+  // residual whitespace.
+  final disposals = disposeNamesInDeclarationOrder.reversed
+      .map((name) => '    $name.dispose();')
+      .join('\n');
+  return '${source.substring(method.offset, lbrace + 1)}'
+      '\n$disposals'
+      '${source.substring(lbrace + 1, method.end)}';
 }
 
 /// Emits an `initState()` method that materializes every `late final` Effect

--- a/packages/solid_generator/lib/src/signal_emitter.dart
+++ b/packages/solid_generator/lib/src/signal_emitter.dart
@@ -254,7 +254,11 @@ String emitDispose(
 /// statements (e.g. `unawaited(_subscription.cancel());`) — is sliced
 /// verbatim from `source.substring(method.offset, method.end)` and a single
 /// `\n<disposals>` block is spliced immediately after the body's opening
-/// brace.
+/// brace. When the user's source `dispose()` lacks `@override`, the
+/// generator prepends one: the merged dispose always overrides — either
+/// `Disposable.dispose()` (plain class — SPEC §10 marker rule) or the
+/// supertype's `dispose()` (`State<X>` — SPEC §14 item 4) — so the lowered
+/// output is lint-clean against `annotate_overrides`.
 ///
 /// [disposeNamesInDeclarationOrder] is the unified, source-ordered list of
 /// reactive declarations (Signal field + Effect method + Resource query).
@@ -287,7 +291,11 @@ String mergeDispose(
   final disposals = disposeNamesInDeclarationOrder.reversed
       .map((name) => '    $name.dispose();')
       .join('\n');
-  return '${source.substring(method.offset, lbrace + 1)}'
+  // Auto-add `@override` if the user omitted it — see the function-level
+  // doc comment for the SPEC contract.
+  final hasOverride = method.metadata.any((a) => a.name.name == 'override');
+  final overridePrefix = hasOverride ? '' : '@override\n  ';
+  return '$overridePrefix${source.substring(method.offset, lbrace + 1)}'
       '\n$disposals'
       '${source.substring(lbrace + 1, method.end)}';
 }

--- a/packages/solid_generator/lib/src/state_class_rewriter.dart
+++ b/packages/solid_generator/lib/src/state_class_rewriter.dart
@@ -40,6 +40,7 @@ RewriteResult rewriteStateClass(
   List<GetterModel> solidGetters,
   List<EffectModel> solidEffects,
   List<QueryModel> solidQueries,
+  Map<String, Set<String>> classRegistry,
   String source,
 ) {
   final className = classDecl.name.lexeme;
@@ -110,6 +111,7 @@ RewriteResult rewriteStateClass(
             reactiveNames,
             source,
             queryNames: queryNames,
+            classRegistry: classRegistry,
           ),
         );
       } else if (name == 'initState') {
@@ -154,14 +156,16 @@ RewriteResult rewriteStateClass(
     pieces.add(emitInitState(effectNames));
   }
   if (disposeMethod != null) {
-    pieces[disposeSlot] = _mergeDispose(
+    pieces[disposeSlot] = mergeDispose(
       disposeMethod,
       disposeNames,
       source,
       className,
     );
   } else {
-    pieces.add(emitDispose(disposeNames, inheritsDispose: true));
+    pieces.add(
+      emitDispose(disposeNames, emitOverride: true, emitSuperCall: true),
+    );
   }
 
   final header = source.substring(
@@ -184,45 +188,6 @@ RewriteResult rewriteStateClass(
       if (solidQueries.any((q) => q.needsSourceComputed)) 'Computed',
     },
   );
-}
-
-/// Prepends one `<name>.dispose();` call per reactive declaration to the
-/// existing `dispose()` body's leading boundary, leaving the rest of the body
-/// untouched (SPEC §10).
-///
-/// [disposeNamesInDeclarationOrder] is the unified, source-ordered list of
-/// reactive declarations (Signal field + Effect method). Reverse-iterating
-/// it puts dependents (Effects) ahead of their dependencies (Signals) in the
-/// dispose body.
-///
-/// Throws [CodeGenerationError] if the existing `dispose()` uses an
-/// expression body (`=> …`) — the merge is only well-defined for a block.
-String _mergeDispose(
-  MethodDeclaration method,
-  List<String> disposeNamesInDeclarationOrder,
-  String source,
-  String className,
-) {
-  final body = method.body;
-  if (body is! BlockFunctionBody) {
-    throw CodeGenerationError(
-      'existing dispose() must have a block body for reactive merge',
-      null,
-      className,
-    );
-  }
-  final lbrace = body.block.leftBracket.offset;
-  // The original source after `{` already begins with `\n` (the body's first
-  // line break) on every reasonable formatting; prepending `\n<disposals>`
-  // yields a single blank-line-free splice, leaving the rest of the body
-  // byte-identical to the source. The `DartFormatter` pass normalises any
-  // residual whitespace.
-  final disposals = disposeNamesInDeclarationOrder.reversed
-      .map((name) => '    $name.dispose();')
-      .join('\n');
-  return '${source.substring(method.offset, lbrace + 1)}'
-      '\n$disposals'
-      '${source.substring(lbrace + 1, method.end)}';
 }
 
 /// Splices Effect-materialization reads (`<effectName>;`, in declaration

--- a/packages/solid_generator/lib/src/stateless_rewriter.dart
+++ b/packages/solid_generator/lib/src/stateless_rewriter.dart
@@ -23,6 +23,7 @@ RewriteResult rewriteStatelessWidget(
   List<GetterModel> solidGetters,
   List<EffectModel> solidEffects,
   List<QueryModel> solidQueries,
+  Map<String, Set<String>> classRegistry,
   String source,
 ) {
   final className = classDecl.name.lexeme;
@@ -52,6 +53,7 @@ RewriteResult rewriteStatelessWidget(
     reactiveNames,
     source,
     queryNames: queryNames,
+    classRegistry: classRegistry,
   );
 
   final reactiveBlock = _emitReactiveBlock(
@@ -327,7 +329,8 @@ String _emitStateClass({
 }) {
   final dispose = emitDispose(
     disposeNamesInDeclarationOrder,
-    inheritsDispose: true,
+    emitOverride: true,
+    emitSuperCall: true,
   );
   final fieldsPrefix = stateFieldsText.isNotEmpty ? '$stateFieldsText\n\n' : '';
   final initStateBlock = effectNamesInDeclarationOrder.isEmpty

--- a/packages/solid_generator/lib/src/value_rewriter.dart
+++ b/packages/solid_generator/lib/src/value_rewriter.dart
@@ -89,6 +89,15 @@ bool _isOnPrefixedCallbackName(String name) {
 /// byte-identical because the lowered `<name>()` resolves through
 /// `Resource<T>.call() => state` to upstream extensions on `ResourceState<T>`.
 ///
+/// [classRegistry] is the cross-class reactivity map (class name → reactive
+/// field/getter names). M6-02 ships a single-level slice of SPEC §5.1's
+/// chain-aware rule: `<param>.<reactiveField>` shapes where `<param>` is a
+/// method parameter declared with a typed annotation that names a class in
+/// [classRegistry] receive a trailing `.value`. Full chains and arbitrary
+/// receivers (locals, fields, method-call results) are M6-04 — they require
+/// the resolved-AST migration mandated by SPEC §5.4. Empty registry =
+/// no-op for the new path; existing same-class behavior unchanged.
+///
 /// [node] is typically the `build()` `MethodDeclaration` (the M1-05 path) or
 /// the body expression of a `@SolidState` getter (the M2-01 path). Both share
 /// the same identifier-rewrite contract; only `build()` consumes
@@ -105,8 +114,13 @@ ValueRewriteResult collectValueEdits(
   Set<String> reactiveFields,
   String source, {
   Set<String> queryNames = const {},
+  Map<String, Set<String>> classRegistry = const {},
 }) {
-  final visitor = _ValueRewriteVisitor(reactiveFields, queryNames);
+  final visitor = _ValueRewriteVisitor(
+    reactiveFields,
+    queryNames,
+    classRegistry,
+  );
   node.accept(visitor);
   return ValueRewriteResult(
     visitor.edits,
@@ -149,7 +163,11 @@ const String _untrackedValueGetterName = 'untrackedValue';
 /// enclosing block. M3-09 replaces this heuristic with type-driven
 /// shadowing resolution.
 class _ValueRewriteVisitor extends RecursiveAstVisitor<void> {
-  _ValueRewriteVisitor(this._reactiveFields, this._queryNames);
+  _ValueRewriteVisitor(
+    this._reactiveFields,
+    this._queryNames,
+    this._classRegistry,
+  );
 
   final Set<String> _reactiveFields;
 
@@ -157,6 +175,11 @@ class _ValueRewriteVisitor extends RecursiveAstVisitor<void> {
   /// for a non-`build` body (M5-01 query-call detection only fires on
   /// `build`'s body, where SignalBuilder placement consumes the offsets).
   final Set<String> _queryNames;
+
+  /// Cross-class reactivity map (class name → reactive field/getter names).
+  /// Drives the single-level cross-class rewrite in [visitPrefixedIdentifier]
+  /// (M6-02 slice of SPEC §5.1). Empty map → cross-class branch no-ops.
+  final Map<String, Set<String>> _classRegistry;
   final List<ValueEdit> edits = [];
   final List<int> trackedReadOffsets = [];
 
@@ -259,7 +282,69 @@ class _ValueRewriteVisitor extends RecursiveAstVisitor<void> {
       // to the prefix, corrupting the replacement just emitted.
       return;
     }
+    // SPEC §5.1 cross-class single-level slice (M6-02): if the prefix is a
+    // method-parameter `SimpleIdentifier` whose declared type names a class
+    // in [_classRegistry] AND the suffix matches a reactive field on that
+    // class, append `.value`. M6-04 promotes this to the full type-driven
+    // chain rewrite via the resolved-AST migration. We keep this branch
+    // conservative — only `<param>.<field>` shapes — so the existing
+    // same-class goldens stay byte-identical.
+    if (_classRegistry.isNotEmpty) {
+      _maybeRewriteCrossClass(node);
+    }
     super.visitPrefixedIdentifier(node);
+  }
+
+  /// Single-level `<param>.<reactiveField>` cross-class rewrite — the M6-02
+  /// slice of SPEC §5.1's chain-aware rule. Appends `.value` when the prefix
+  /// is a method-parameter `SimpleIdentifier` whose declared type names a
+  /// class in [_classRegistry] AND the suffix matches a reactive field on
+  /// that class AND no shadow is in scope AND the no-double-append guard
+  /// (SPEC §5.4) does not fire. Records the chain's outermost offset as a
+  /// tracked read.
+  void _maybeRewriteCrossClass(PrefixedIdentifier node) {
+    if (_isShadowed(node.prefix.name)) return;
+    if (_isAccessedValueProperty(node.identifier)) return;
+    final declaredTypeName = _resolveParameterTypeName(node.prefix);
+    if (declaredTypeName == null) return;
+    final fieldsOfType = _classRegistry[declaredTypeName];
+    if (fieldsOfType == null) return;
+    if (!fieldsOfType.contains(node.identifier.name)) return;
+    edits.add(ValueEdit(node.end, node.end, '.value'));
+    if (_untrackedDepth == 0) {
+      trackedReadOffsets.add(node.offset);
+    }
+  }
+
+  /// If [prefix] resolves to a method/function parameter declared with a
+  /// [NamedType] annotation, returns that type's simple name (e.g. `'Counter'`
+  /// for `Counter other`). Returns `null` for parameter shapes the visitor
+  /// cannot reason about in parsed AST: function-typed parameters,
+  /// `var`-typed parameters, generic type-parameter receivers, and identifiers
+  /// that do not resolve to a parameter at all (locals, fields, etc.).
+  ///
+  /// M6-04 will replace this with a `staticType` lookup on the resolved AST
+  /// (SPEC §5.4 — "Name-matching, regex, or string heuristics are not
+  /// acceptable"). The parameter-only fallback ships M6-02's sub-case b
+  /// without dragging the resolved-AST migration into this PR.
+  String? _resolveParameterTypeName(SimpleIdentifier prefix) {
+    final method = prefix.thisOrAncestorOfType<MethodDeclaration>();
+    final fn = prefix.thisOrAncestorOfType<FunctionExpression>();
+    final params = method?.parameters?.parameters ?? fn?.parameters?.parameters;
+    if (params == null) return null;
+    for (final param in params) {
+      final inner = param is DefaultFormalParameter ? param.parameter : param;
+      if (inner.name?.lexeme != prefix.name) continue;
+      if (inner is SimpleFormalParameter) {
+        final type = inner.type;
+        if (type is NamedType) return type.name.lexeme;
+      }
+      // FieldFormalParameter (`this.foo`), FunctionTypedFormalParameter,
+      // and SuperFormalParameter (`super.foo`) all fall through — M6-02
+      // does not need them; M6-04 widens this when resolved AST lands.
+      return null;
+    }
+    return null;
   }
 
   @override

--- a/packages/solid_generator/test/golden/inputs/m6_02_already_disposable.dart
+++ b/packages/solid_generator/test/golden/inputs/m6_02_already_disposable.dart
@@ -1,0 +1,13 @@
+// SPEC §10: a source class that names `implements Disposable` without
+// declaring `dispose()` is intentionally unresolved at the source layer —
+// the generator synthesizes `dispose()` in the lowered output. The
+// analyzer cannot see the synthesized member, so suppress the warning on
+// the input fixture.
+// ignore_for_file: non_abstract_class_inherits_abstract_member
+
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Counter implements Disposable {
+  @SolidState()
+  int value = 0;
+}

--- a/packages/solid_generator/test/golden/inputs/m6_02_extends_with_implements.dart
+++ b/packages/solid_generator/test/golden/inputs/m6_02_extends_with_implements.dart
@@ -1,0 +1,24 @@
+// `Base` and `Marker` are abstract by design — the fixture's purpose is to
+// exercise the M6-02 implements-clause merge with `extends` + `with` +
+// `implements` all present. The lints below would distract from that.
+// ignore_for_file: one_member_abstracts
+
+import 'package:solid_annotations/solid_annotations.dart';
+
+abstract class Base {
+  String describe();
+}
+
+mixin class Tagged {
+  String get tag => 'default';
+}
+
+abstract class Marker {}
+
+class Sub extends Base with Tagged implements Marker {
+  @SolidState()
+  int value = 0;
+
+  @override
+  String describe() => 'sub';
+}

--- a/packages/solid_generator/test/golden/inputs/m6_02_implements_existing.dart
+++ b/packages/solid_generator/test/golden/inputs/m6_02_implements_existing.dart
@@ -1,0 +1,9 @@
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Counter implements Comparable<Counter> {
+  @SolidState()
+  int value = 0;
+
+  @override
+  int compareTo(Counter other) => value - other.value;
+}

--- a/packages/solid_generator/test/golden/inputs/m6_02_user_dispose_body.dart
+++ b/packages/solid_generator/test/golden/inputs/m6_02_user_dispose_body.dart
@@ -1,0 +1,21 @@
+// SPEC §10 example uses `print` as the user-dispose-body sample statement.
+// ignore_for_file: avoid_print
+
+import 'dart:async';
+
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Counter implements Disposable {
+  @SolidState()
+  int value = 0;
+
+  final StreamSubscription<void> _ticker = Stream<void>.periodic(
+    const Duration(seconds: 1),
+  ).listen((_) {});
+
+  @override
+  void dispose() {
+    unawaited(_ticker.cancel());
+    print('counter cleanup');
+  }
+}

--- a/packages/solid_generator/test/golden/inputs/m6_02_user_dispose_no_override.dart
+++ b/packages/solid_generator/test/golden/inputs/m6_02_user_dispose_no_override.dart
@@ -1,0 +1,13 @@
+// SPEC §10 example uses `print` as the user-dispose-body sample statement.
+// ignore_for_file: avoid_print
+
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Counter {
+  @SolidState()
+  int value = 0;
+
+  void dispose() {
+    print('counter cleanup');
+  }
+}

--- a/packages/solid_generator/test/golden/outputs/m1_06_plain_class_no_widget.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m1_06_plain_class_no_widget.g.dart
@@ -1,10 +1,12 @@
 import 'package:solid_annotations/solid_annotations.dart';
 import 'package:flutter_solidart/flutter_solidart.dart';
 
-class Counter {
+class Counter implements Disposable {
   final value = Signal<int>(0, name: 'value');
+
   final label = Signal<String>('', name: 'label');
 
+  @override
   void dispose() {
     label.dispose();
     value.dispose();

--- a/packages/solid_generator/test/golden/outputs/m1_08_import_rewrite.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m1_08_import_rewrite.g.dart
@@ -1,9 +1,10 @@
 import 'package:solid_annotations/solid_annotations.dart';
 import 'package:flutter_solidart/flutter_solidart.dart';
 
-class Ticker {
+class Ticker implements Disposable {
   final tick = Signal<int>(0, name: 'tick');
 
+  @override
   void dispose() {
     tick.dispose();
   }

--- a/packages/solid_generator/test/golden/outputs/m5_09_query_on_plain_class.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m5_09_query_on_plain_class.g.dart
@@ -1,11 +1,13 @@
 import 'package:solid_annotations/solid_annotations.dart';
 import 'package:flutter_solidart/flutter_solidart.dart';
 
-class Counter {
+class Counter implements Disposable {
   final value = Signal<int>(0, name: 'value');
+
   late final log = Effect(() {
     print('value: ${value.value}');
   }, name: 'log');
+
   late final fetchSnapshot = Resource<int>(
     () async => 0,
     name: 'fetchSnapshot',
@@ -15,6 +17,7 @@ class Counter {
     log;
   }
 
+  @override
   void dispose() {
     fetchSnapshot.dispose();
     log.dispose();

--- a/packages/solid_generator/test/golden/outputs/m6_02_already_disposable.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m6_02_already_disposable.g.dart
@@ -4,17 +4,8 @@ import 'package:flutter_solidart/flutter_solidart.dart';
 class Counter implements Disposable {
   final value = Signal<int>(0, name: 'value');
 
-  late final log = Effect(() {
-    print('value: ${value.value}');
-  }, name: 'log');
-
-  Counter() {
-    log;
-  }
-
   @override
   void dispose() {
-    log.dispose();
     value.dispose();
   }
 }

--- a/packages/solid_generator/test/golden/outputs/m6_02_extends_with_implements.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m6_02_extends_with_implements.g.dart
@@ -1,0 +1,24 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+abstract class Base {
+  String describe();
+}
+
+mixin class Tagged {
+  String get tag => 'default';
+}
+
+abstract class Marker {}
+
+class Sub extends Base with Tagged implements Marker, Disposable {
+  final value = Signal<int>(0, name: 'value');
+
+  @override
+  String describe() => 'sub';
+
+  @override
+  void dispose() {
+    value.dispose();
+  }
+}

--- a/packages/solid_generator/test/golden/outputs/m6_02_implements_existing.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m6_02_implements_existing.g.dart
@@ -1,20 +1,14 @@
 import 'package:solid_annotations/solid_annotations.dart';
 import 'package:flutter_solidart/flutter_solidart.dart';
 
-class Counter implements Disposable {
+class Counter implements Comparable<Counter>, Disposable {
   final value = Signal<int>(0, name: 'value');
 
-  late final log = Effect(() {
-    print('value: ${value.value}');
-  }, name: 'log');
-
-  Counter() {
-    log;
-  }
+  @override
+  int compareTo(Counter other) => value.value - other.value.value;
 
   @override
   void dispose() {
-    log.dispose();
     value.dispose();
   }
 }

--- a/packages/solid_generator/test/golden/outputs/m6_02_user_dispose_body.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m6_02_user_dispose_body.g.dart
@@ -1,20 +1,18 @@
+import 'dart:async';
 import 'package:solid_annotations/solid_annotations.dart';
 import 'package:flutter_solidart/flutter_solidart.dart';
 
 class Counter implements Disposable {
   final value = Signal<int>(0, name: 'value');
 
-  late final log = Effect(() {
-    print('value: ${value.value}');
-  }, name: 'log');
-
-  Counter() {
-    log;
-  }
+  final StreamSubscription<void> _ticker = Stream<void>.periodic(
+    const Duration(seconds: 1),
+  ).listen((_) {});
 
   @override
   void dispose() {
-    log.dispose();
     value.dispose();
+    unawaited(_ticker.cancel());
+    print('counter cleanup');
   }
 }

--- a/packages/solid_generator/test/golden/outputs/m6_02_user_dispose_no_override.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m6_02_user_dispose_no_override.g.dart
@@ -1,0 +1,12 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class Counter implements Disposable {
+  final value = Signal<int>(0, name: 'value');
+
+  @override
+  void dispose() {
+    value.dispose();
+    print('counter cleanup');
+  }
+}

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -62,6 +62,7 @@ const List<String> goldenNames = <String>[
   'm6_02_extends_with_implements',
   'm6_02_already_disposable',
   'm6_02_user_dispose_body',
+  'm6_02_user_dispose_no_override',
 ];
 
 /// Memoized golden directory resolution. Resolved relative to the package

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -58,6 +58,10 @@ const List<String> goldenNames = <String>[
   'm5_11_query_with_debounce',
   'm5_11_query_with_use_refreshing_false',
   'm5_11_query_with_debounce_and_use_refreshing_false',
+  'm6_02_implements_existing',
+  'm6_02_extends_with_implements',
+  'm6_02_already_disposable',
+  'm6_02_user_dispose_body',
 ];
 
 /// Memoized golden directory resolution. Resolved relative to the package


### PR DESCRIPTION
## Summary

- Plain-class lowering (SPEC §8.3 / §10) now declares `implements Disposable`: appended after any `extends`/`with` clauses when no `implements` is present, merged into an existing list as `, Disposable`, or skipped entirely when the source already names `Disposable`. The synthesized `dispose()` always carries `@override`.
- User-defined `dispose()` bodies are now merged instead of rejected: synthesized reactive disposals (reverse-declaration order) are prepended to the user's body via the new `mergeDispose` helper extracted from `state_class_rewriter` to `signal_emitter` and shared by both rewriters. When the user wrote a plain `void dispose() { … }` (no `@override`, no `implements Disposable` — the typical pattern), `mergeDispose` auto-adds `@override` so the lowered output is lint-clean. The user's body is preserved verbatim.
- `emitDispose` API: replaced `inheritsDispose: bool` with separate `emitOverride: bool` + `emitSuperCall: bool` so a plain class with `implements Disposable` can emit `@override` without `super.dispose()` (whose supertype is `Object`).
- Plain-class member walk relaxed to mirror `state_class_rewriter`'s permissive style: non-annotated fields preserved verbatim, non-annotated user methods preserved with the SPEC §5.1 `.value` rewrite applied to their bodies. User constructors stay rejected (constructor-merge deferred).
- Single-level slice of the SPEC §5.1 cross-class chain rewrite: `<param>.<reactiveField>` expressions now receive `.value` when the prefix is a method-parameter `SimpleIdentifier` whose declared type names a class with reactive declarations. A `classRegistry` map (class name → reactive field/getter names) is built once per file and threaded through all rewriters. Full chains and arbitrary receivers remain M6-04 territory (resolved-AST migration per SPEC §5.4).
- 3 existing plain-class goldens regenerated (`m1_06`, `m1_08`, `m4_08_effect_on_plain_class`, `m5_09_query_on_plain_class`) to include `implements Disposable` + `@override`.
- 5 new sub-case goldens added: `m6_02_implements_existing` (Comparable + cross-class rewrite), `m6_02_extends_with_implements` (extends/with/implements preservation), `m6_02_already_disposable` (no-op when already declared), `m6_02_user_dispose_body` (user-body merge with user `@override`), `m6_02_user_dispose_no_override` (typical user pattern — generator auto-adds `@override`).
- SPEC §10 dispose-body-merge subsection amended to document the `@override` auto-add behavior.
- TODOS.md M6-02 entry flipped to DONE.

## Test plan

- [x] `dart test packages/solid_generator/` — 122/122 pass
- [x] `dart analyze --fatal-infos packages/solid_generator` — clean
- [x] `dart analyze --fatal-infos packages/solid_generator/test/golden/outputs/` — clean (validates `Comparable<Counter>, Disposable` typechecks, `value.value - other.value.value` is well-typed, and `annotate_overrides` is silenced on every merged dispose)
- [x] `dart format --set-exit-if-changed .` — clean
- [x] `flutter test example/` — 7/7 pass (no consumer-app behavior changed)
- [x] StatelessWidget and existing State<X> goldens byte-identical to pre-M6-02 outputs (those classes don't go through `rewritePlainClass`, so `Disposable` is not added; sub-case e's `@override`-was-already-present path is also byte-identical to its first generation, confirming the auto-add only fires when missing)