### PR TITLE
Implement M6-03: @SolidEnvironment field synthesis

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -2166,7 +2166,7 @@ class Counter implements Disposable {
 - `packages/solid_generator/lib/src/target_validator.dart` — add `validateSolidEnvironmentTargets(CompilationUnit unit)` mirroring `validateSolidQueryTargets`. Rejects: non-`late` fields, fields with initializer, methods/getters/setters/top-level, `final`/`const`/`static` fields, `SignalBase`-typed fields, plain-class fields.
 - `packages/solid_generator/lib/builder.dart` — extend `_AnnotatedClass` to carry `final List<EnvironmentModel> environments;`; extend `_collectAnnotatedClasses`'s `FieldDeclaration` branch to call `readSolidEnvironmentField` after `readSolidStateField`. Pass `environments` through `_rewriteClass`.
 - `packages/solid_generator/lib/src/signal_emitter.dart` — add `String emitEnvironmentField(EnvironmentModel e)` returning `'late final ${e.fieldName} = context.read<${e.typeText}>();'`. The string is emitted in source-declaration order alongside Signal/Computed/Effect/Resource fields. Environment fields do NOT join the dispose-name list (Section 10).
-- `packages/solid_generator/lib/src/import_rewriter.dart` — when the output references `context.read<T>()`, add `import 'package:provider/provider.dart' show ReadContext;` (only if not already imported).
+- `packages/solid_generator/lib/src/import_rewriter.dart` — when the output references `context.read<T>()`, add `import 'package:provider/provider.dart';` (only if not already imported). The full library is imported (no `show` clause) so consumers can also call other provider APIs (`Provider<T>` / `MultiProvider` / `context.watch<T>()`) in the same file without a duplicate-import.
 - `packages/solid_generator/lib/src/stateless_rewriter.dart` — accept `solidEnvironments`. The presence of `@SolidEnvironment` forces the StatelessWidget→State split (already enforced by the §8.1 rule for `@SolidState`; treat `@SolidEnvironment` identically). Emit env fields interleaved in source order. NO initState splice for env fields.
 - `packages/solid_generator/lib/src/state_class_rewriter.dart` — accept `solidEnvironments`. Same emit shape; existing `initState` body is preserved byte-identically (no env splice).
 - `packages/solid_generator/lib/src/plain_class_rewriter.dart` — reject any `@SolidEnvironment` field with `CodeGenerationError("@SolidEnvironment on plain class is invalid — no BuildContext available")` (Section 3.6 invalid targets).
@@ -2199,7 +2199,7 @@ class HomePage extends StatelessWidget {
 ```dart
 import 'package:solid_annotations/solid_annotations.dart';
 import 'package:flutter/widgets.dart';
-import 'package:provider/provider.dart' show ReadContext;
+import 'package:provider/provider.dart';
 
 class Logger {
   void log(String message) => print(message);
@@ -2222,11 +2222,11 @@ class _HomePageState extends State<HomePage> {
 }
 ```
 
-**Acceptance:** `dart test --name=m6_03` passes; golden analyzes clean; `_HomePageState` has NO `initState()` override (env fields are lazy — Section 4.9 rule 2); `Logger` round-trips byte-identically (no annotations); `import 'package:provider/provider.dart' show ReadContext;` is added exactly once.
+**Acceptance:** `dart test --name=m6_03` passes; golden analyzes clean; `_HomePageState` has NO `initState()` override (env fields are lazy — Section 4.9 rule 2); `Logger` round-trips byte-identically (no annotations); `import 'package:provider/provider.dart';` is added exactly once (no `show` clause — full library imported so consumers can reference `Provider<T>` / `MultiProvider` / etc. in the same file without a duplicate-import).
 
 **Dependencies:** M6-01.
 
-**Status:** TODO
+**Status:** DONE
 
 ---
 

--- a/packages/solid_generator/lib/builder.dart
+++ b/packages/solid_generator/lib/builder.dart
@@ -7,6 +7,7 @@ import 'package:dart_style/dart_style.dart';
 import 'package:solid_generator/src/annotation_reader.dart';
 import 'package:solid_generator/src/class_kind.dart';
 import 'package:solid_generator/src/effect_model.dart';
+import 'package:solid_generator/src/environment_model.dart';
 import 'package:solid_generator/src/field_model.dart';
 import 'package:solid_generator/src/getter_model.dart';
 import 'package:solid_generator/src/import_rewriter.dart';
@@ -90,6 +91,9 @@ class _SolidBuilder implements Builder {
     // getters/setters, top-level functions, fields) never reach
     // `readSolidQueryMethod`.
     validateSolidQueryTargets(parsed.unit);
+    // SPEC §3.6 invalid-target guard for `@SolidEnvironment` — mirrors
+    // the validators above.
+    validateSolidEnvironmentTargets(parsed.unit);
 
     final annotatedClasses = _collectAnnotatedClasses(parsed.unit, source);
     if (annotatedClasses.every(
@@ -97,7 +101,8 @@ class _SolidBuilder implements Builder {
           c.fields.isEmpty &&
           c.getters.isEmpty &&
           c.effects.isEmpty &&
-          c.queries.isEmpty,
+          c.queries.isEmpty &&
+          c.environments.isEmpty,
     )) {
       // Hint matched, but no `@SolidState` field/getter, `@SolidEffect`
       // method, or `@SolidQuery` method resolved — the file likely contains
@@ -145,7 +150,8 @@ Map<String, Set<String>> _buildClassRegistry(
 }
 
 /// One class declaration paired with the `@SolidState` fields and getters,
-/// `@SolidEffect` methods, and `@SolidQuery` methods it contains.
+/// `@SolidEffect` methods, `@SolidQuery` methods, and `@SolidEnvironment`
+/// fields it contains.
 ///
 /// Every annotation list is empty when the class exists in the source but
 /// has no reactive annotations; such classes are passed through verbatim.
@@ -156,12 +162,14 @@ class _AnnotatedClass {
     required this.getters,
     required this.effects,
     required this.queries,
+    required this.environments,
   });
   final ClassDeclaration decl;
   final List<FieldModel> fields;
   final List<GetterModel> getters;
   final List<EffectModel> effects;
   final List<QueryModel> queries;
+  final List<EnvironmentModel> environments;
 }
 
 /// Walks [unit] once and returns every class paired with its `@SolidState`
@@ -184,6 +192,7 @@ List<_AnnotatedClass> _collectAnnotatedClasses(
     final getters = <GetterModel>[];
     final effects = <EffectModel>[];
     final queries = <QueryModel>[];
+    final environments = <EnvironmentModel>[];
     final reactiveNames = <String>{};
     for (final member in decl.members) {
       if (member is FieldDeclaration) {
@@ -191,6 +200,14 @@ List<_AnnotatedClass> _collectAnnotatedClasses(
         if (model != null) {
           fields.add(model);
           reactiveNames.add(model.fieldName);
+          continue;
+        }
+        // `@SolidState` wins over `@SolidEnvironment` on a both-annotated
+        // field (defense-in-depth — the target validator rejects this
+        // upstream).
+        final env = readSolidEnvironmentField(member, source);
+        if (env != null) {
+          environments.add(env);
         }
         continue;
       }
@@ -224,6 +241,7 @@ List<_AnnotatedClass> _collectAnnotatedClasses(
         getters: getters,
         effects: effects,
         queries: queries,
+        environments: environments,
       ),
     );
   }
@@ -235,7 +253,10 @@ List<_AnnotatedClass> _collectAnnotatedClasses(
 /// ones per their class kind.
 ///
 /// `flutter_solidart` is added to the import block iff any rewriter emitted
-/// a Section 9 identifier (SPEC §9).
+/// a Section 9 identifier (SPEC §9). `package:provider/provider.dart` is
+/// added iff any annotated class has at least one `@SolidEnvironment` field
+/// (SPEC §3.6 / §9 — env fields lower to `context.read<T>()`, which resolves
+/// through `package:provider`'s `ReadContext` extension).
 String _renderOutput(
   CompilationUnit unit,
   List<_AnnotatedClass> annotatedClasses,
@@ -246,7 +267,8 @@ String _renderOutput(
     if (c.fields.isEmpty &&
         c.getters.isEmpty &&
         c.effects.isEmpty &&
-        c.queries.isEmpty) {
+        c.queries.isEmpty &&
+        c.environments.isEmpty) {
       return (
         text: source.substring(c.decl.offset, c.decl.end),
         solidartNames: const <String>{},
@@ -258,6 +280,7 @@ String _renderOutput(
       c.getters,
       c.effects,
       c.queries,
+      c.environments,
       classRegistry,
       source,
     );
@@ -268,6 +291,7 @@ String _renderOutput(
     addSolidart: results.any(
       (r) => r.solidartNames.any(solidartNames.contains),
     ),
+    addProvider: annotatedClasses.any((c) => c.environments.isNotEmpty),
   );
   final importBlock = imports.map((u) => "import '$u';").join('\n');
 
@@ -288,6 +312,7 @@ RewriteResult _rewriteClass(
   List<GetterModel> getters,
   List<EffectModel> effects,
   List<QueryModel> queries,
+  List<EnvironmentModel> environments,
   Map<String, Set<String>> classRegistry,
   String source,
 ) {
@@ -301,6 +326,7 @@ RewriteResult _rewriteClass(
         getters,
         effects,
         queries,
+        environments,
         classRegistry,
         source,
       );
@@ -311,6 +337,7 @@ RewriteResult _rewriteClass(
         getters,
         effects,
         queries,
+        environments,
         classRegistry,
         source,
       );
@@ -321,6 +348,7 @@ RewriteResult _rewriteClass(
         getters,
         effects,
         queries,
+        environments,
         classRegistry,
         source,
       );

--- a/packages/solid_generator/lib/src/annotation_reader.dart
+++ b/packages/solid_generator/lib/src/annotation_reader.dart
@@ -1,5 +1,6 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:solid_generator/src/effect_model.dart';
+import 'package:solid_generator/src/environment_model.dart';
 import 'package:solid_generator/src/field_model.dart';
 import 'package:solid_generator/src/getter_model.dart';
 import 'package:solid_generator/src/query_model.dart';
@@ -24,6 +25,23 @@ const String solidEffectName = 'SolidEffect';
 /// Name of the `@SolidQuery` annotation class. Same matching contract as
 /// [solidStateName] (textual on unresolved AST).
 const String solidQueryName = 'SolidQuery';
+
+/// Name of the `@SolidEnvironment` annotation class. Same matching contract
+/// as [solidStateName] (textual on unresolved AST).
+const String solidEnvironmentName = 'SolidEnvironment';
+
+/// Lexemes of the `flutter_solidart` types whose runtime classes extend
+/// `SignalBase<T>`. Matched textually on the unresolved AST per the
+/// [solidStateName] contract. Consumed by the target validator (rejecting
+/// `@SolidEnvironment` fields typed as one of these — SPEC §3.6) and by the
+/// M6-04 cross-class `.value` rewrite. Excludes `SignalBuilder` /
+/// `SolidartConfig` (those are non-`SignalBase` solidart names).
+const Set<String> signalBaseTypeNames = {
+  'Signal',
+  'Computed',
+  'Effect',
+  'Resource',
+};
 
 /// Lexeme of the `Future` return-type identifier on a `@SolidQuery` method.
 /// Matched textually on the unresolved AST per the same contract as
@@ -64,6 +82,29 @@ FieldModel? readSolidStateField(FieldDeclaration decl, String source) {
     // correctly classifies nested-nullable types like `List<int?>` as
     // non-nullable at the outer level (SPEC Section 4.3).
     isNullable: type?.question != null,
+  );
+}
+
+/// Reads a `@SolidEnvironment()` annotation on [decl] and returns an
+/// [EnvironmentModel], or `null` if no `@SolidEnvironment` annotation is
+/// present. Validation (`late` required, no initializer, non-`SignalBase`
+/// type, widget/state host) runs upstream in
+/// `validateSolidEnvironmentTargets`; this reader only extracts the textual
+/// name and type for `emitEnvironmentField` (SPEC §3.6 / §4.9).
+EnvironmentModel? readSolidEnvironmentField(
+  FieldDeclaration decl,
+  String source,
+) {
+  final annotation = findAnnotationByName(solidEnvironmentName, decl.metadata);
+  if (annotation == null) return null;
+
+  final varList = decl.fields;
+  final type = varList.type;
+  final variable = varList.variables.first;
+
+  return EnvironmentModel(
+    fieldName: variable.name.lexeme,
+    typeText: type == null ? '' : source.substring(type.offset, type.end),
   );
 }
 

--- a/packages/solid_generator/lib/src/environment_model.dart
+++ b/packages/solid_generator/lib/src/environment_model.dart
@@ -1,0 +1,39 @@
+import 'package:meta/meta.dart';
+
+/// Parsed description of one `@SolidEnvironment`-annotated field.
+///
+/// Populated by `annotation_reader.dart` from unresolved AST and consumed by
+/// the rewriters (currently `stateless_rewriter.dart` and
+/// `state_class_rewriter.dart`). All string members are the raw source text of
+/// the corresponding AST node — no normalization. Mirror of `FieldModel` for
+/// the `@SolidEnvironment` field-synthesis path: every annotated field lowers
+/// to a `late final <fieldName> = context.read<<typeText>>();` line on the
+/// host's synthesized (or in-place) `State<X>` subclass per SPEC §4.9.
+///
+/// Unlike `FieldModel` this carries no `initializerText`, no `isLate`, and no
+/// `isNullable` because:
+///
+///  * `@SolidEnvironment` rejects fields with initializers (SPEC §3.6 — the
+///    initializer is what the lowered `context.read<T>()` synthesizes),
+///  * the `late` modifier is mandatory on the source field (the validator
+///    rejects non-`late`), so it doesn't need to thread through the model,
+///  * type nullability has no effect on emission — the lowered shape
+///    `context.read<T>()` already returns the declared type as-is.
+@immutable
+class EnvironmentModel {
+  /// Creates an [EnvironmentModel] describing an annotated field.
+  const EnvironmentModel({required this.fieldName, required this.typeText});
+
+  /// Declared identifier of the field (e.g. `'logger'`).
+  final String fieldName;
+
+  /// Raw source text of the declared type annotation (e.g. `'Logger'`,
+  /// `'Counter'`, `'AuthService'`). The lowered field emits
+  /// `context.read<<typeText>>()` so the type text appears verbatim inside the
+  /// type-argument angle brackets.
+  ///
+  /// Empty string only if the field has no declared type — not expected for
+  /// `@SolidEnvironment` fields per SPEC §3.6 (the type IS the DI key, so a
+  /// missing type is rejected by `validateSolidEnvironmentTargets`).
+  final String typeText;
+}

--- a/packages/solid_generator/lib/src/import_rewriter.dart
+++ b/packages/solid_generator/lib/src/import_rewriter.dart
@@ -6,6 +6,15 @@
 const String flutterSolidartUri =
     'package:flutter_solidart/flutter_solidart.dart';
 
+/// Canonical URI for `package:provider`. Added to the output whenever any
+/// annotated class carries an `@SolidEnvironment` field (SPEC §3.6 / §9): the
+/// lowered `late final <name> = context.read<T>();` line resolves through
+/// `provider`'s `ReadContext` extension on `BuildContext`. The full library
+/// is imported (no `show` clause) so consumers can also call other `provider`
+/// APIs (`Provider.of<T>(context)`, `MultiProvider`, …) in the same file
+/// without a duplicate-import.
+const String providerUri = 'package:provider/provider.dart';
+
 /// Canonical set of identifiers exported by `flutter_solidart` whose presence
 /// in generated output triggers the import-add rule (SPEC Section 9).
 ///
@@ -33,16 +42,23 @@ typedef RewriteResult = ({String text, Set<String> solidartNames});
 ///
 /// Source imports are preserved verbatim and in original order per SPEC
 /// Section 9. If [addSolidart] is true and `flutter_solidart` is not already
-/// present in [sourceImports], it is appended. Unused-import pruning (e.g.
-/// `solid_annotations` when no annotation reference remains in the output) is
-/// left to `dart fix --apply`; this rewriter never drops a source import.
+/// present in [sourceImports], it is appended. If [addProvider] is true and
+/// `package:provider/provider.dart` is not already present, it is appended
+/// after `flutter_solidart` (SPEC §3.6 / §9 — env fields lower to
+/// `context.read<T>()`). Unused-import pruning (e.g. `solid_annotations` when
+/// no annotation reference remains in the output) is left to
+/// `dart fix --apply`; this rewriter never drops a source import.
 List<String> computeOutputImports(
   List<String> sourceImports, {
   required bool addSolidart,
+  bool addProvider = false,
 }) {
   final result = List<String>.of(sourceImports);
   if (addSolidart && !result.contains(flutterSolidartUri)) {
     result.add(flutterSolidartUri);
+  }
+  if (addProvider && !result.contains(providerUri)) {
+    result.add(providerUri);
   }
   return result;
 }

--- a/packages/solid_generator/lib/src/plain_class_rewriter.dart
+++ b/packages/solid_generator/lib/src/plain_class_rewriter.dart
@@ -1,5 +1,6 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:solid_generator/src/effect_model.dart';
+import 'package:solid_generator/src/environment_model.dart';
 import 'package:solid_generator/src/field_model.dart';
 import 'package:solid_generator/src/getter_model.dart';
 import 'package:solid_generator/src/import_rewriter.dart';
@@ -60,6 +61,7 @@ RewriteResult rewritePlainClass(
   List<GetterModel> solidGetters,
   List<EffectModel> solidEffects,
   List<QueryModel> solidQueries,
+  List<EnvironmentModel> solidEnvironments,
   Map<String, Set<String>> classRegistry,
   String source,
 ) {
@@ -67,6 +69,19 @@ RewriteResult rewritePlainClass(
   // M2-01 ships getter→Computed for `StatelessWidget` only; reject here so
   // M1-14's valid-target pass isn't silently undone.
   rejectIfGettersNotYetSupported(solidGetters, 'plain class', className);
+  // SPEC §3.6: `@SolidEnvironment` requires a `BuildContext`, which only
+  // widget/state hosts provide — plain classes cannot resolve `context.read`.
+  // The user-facing rejection comes from `validateSolidEnvironmentTargets`;
+  // this is defense-in-depth to catch any path that bypasses validation
+  // (mirrors `readSolidEffectMethod`'s defensive `decl.isStatic` skip).
+  if (solidEnvironments.isNotEmpty) {
+    throw CodeGenerationError(
+      '@SolidEnvironment on plain class is invalid — '
+      'no BuildContext available',
+      null,
+      className,
+    );
+  }
   // Source-ordered emission so Signal fields, Effect fields, and Resource
   // fields interleave by declaration order — required by SPEC §10's
   // reverse-disposal rule (an Effect or Resource must be declared after the

--- a/packages/solid_generator/lib/src/signal_emitter.dart
+++ b/packages/solid_generator/lib/src/signal_emitter.dart
@@ -1,5 +1,6 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:solid_generator/src/effect_model.dart';
+import 'package:solid_generator/src/environment_model.dart';
 import 'package:solid_generator/src/field_model.dart';
 import 'package:solid_generator/src/getter_model.dart';
 import 'package:solid_generator/src/query_model.dart';
@@ -120,6 +121,14 @@ String emitResourceField(QueryModel q) {
     "name: '$debugName'",
   ].join(', ');
   return '  late final ${q.methodName} = $ctorName($args);';
+}
+
+/// Emits one `late final <fieldName> = context.read<<T>>();` line per
+/// `@SolidEnvironment` field (SPEC §4.9). Env fields are NEVER added to the
+/// dispose-name list (SPEC §10 — the providing `Provider<T>` owns disposal)
+/// and NEVER materialized in `initState` (SPEC §4.9 rule 2 — they're lazy).
+String emitEnvironmentField(EnvironmentModel e) {
+  return '  late final ${e.fieldName} = context.read<${e.typeText}>();';
 }
 
 /// Emits the synthesized Record-Computed source field for an `@SolidQuery`

--- a/packages/solid_generator/lib/src/state_class_rewriter.dart
+++ b/packages/solid_generator/lib/src/state_class_rewriter.dart
@@ -1,6 +1,7 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:solid_generator/src/build_rewriter.dart';
 import 'package:solid_generator/src/effect_model.dart';
+import 'package:solid_generator/src/environment_model.dart';
 import 'package:solid_generator/src/field_model.dart';
 import 'package:solid_generator/src/getter_model.dart';
 import 'package:solid_generator/src/import_rewriter.dart';
@@ -40,6 +41,7 @@ RewriteResult rewriteStateClass(
   List<GetterModel> solidGetters,
   List<EffectModel> solidEffects,
   List<QueryModel> solidQueries,
+  List<EnvironmentModel> solidEnvironments,
   Map<String, Set<String>> classRegistry,
   String source,
 ) {
@@ -59,6 +61,9 @@ RewriteResult rewriteStateClass(
   // [solidQueries]; re-parsing here would double the annotation-reader cost
   // per file.
   final modelByName = {for (final f in solidFields) f.fieldName: f};
+  final envByName = {
+    for (final e in solidEnvironments) e.fieldName: e,
+  };
   final effectByName = {for (final e in solidEffects) e.methodName: e};
   final queryByName = {for (final q in solidQueries) q.methodName: q};
   final reactiveNames = modelByName.keys.toSet();
@@ -97,9 +102,19 @@ RewriteResult rewriteStateClass(
       if (model != null) {
         pieces.add(emitSignalField(model));
         disposeNames.add(model.fieldName);
-      } else {
-        pieces.add(source.substring(member.offset, member.end));
+        continue;
       }
+      final env = envByName[varName];
+      if (env != null) {
+        // Env fields lower to `late final … = context.read<T>();` in source-
+        // declaration order. They are NOT added to `disposeNames` (SPEC §10
+        // — host never owns disposal of injected instances) and NOT added to
+        // `effectNames` (SPEC §4.9 rule 2 — env fields are lazy and need no
+        // initState materialization).
+        pieces.add(emitEnvironmentField(env));
+        continue;
+      }
+      pieces.add(source.substring(member.offset, member.end));
       continue;
     }
     if (member is MethodDeclaration) {
@@ -175,7 +190,11 @@ RewriteResult rewriteStateClass(
   return (
     text: '$header{\n${pieces.join('\n\n')}\n}',
     solidartNames: <String>{
-      'Signal',
+      // SPEC §9 import-add gate: `Signal` is only emitted when the class
+      // has at least one `@SolidState` field. An env-only host (M6-05) has
+      // no Signal reference in lowered output and so does NOT pull in
+      // `flutter_solidart`.
+      if (solidFields.isNotEmpty) 'Signal',
       if (effectNames.isNotEmpty) 'Effect',
       // Queries emit `Resource<T>(...)` fields; their `<query>().when(...)`
       // call sites in `build` are wrapped in `SignalBuilder` by

--- a/packages/solid_generator/lib/src/stateless_rewriter.dart
+++ b/packages/solid_generator/lib/src/stateless_rewriter.dart
@@ -1,6 +1,7 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:solid_generator/src/build_rewriter.dart';
 import 'package:solid_generator/src/effect_model.dart';
+import 'package:solid_generator/src/environment_model.dart';
 import 'package:solid_generator/src/field_model.dart';
 import 'package:solid_generator/src/getter_model.dart';
 import 'package:solid_generator/src/import_rewriter.dart';
@@ -23,6 +24,7 @@ RewriteResult rewriteStatelessWidget(
   List<GetterModel> solidGetters,
   List<EffectModel> solidEffects,
   List<QueryModel> solidQueries,
+  List<EnvironmentModel> solidEnvironments,
   Map<String, Set<String>> classRegistry,
   String source,
 ) {
@@ -38,12 +40,20 @@ RewriteResult rewriteStatelessWidget(
   final queryNames = solidQueries.isEmpty
       ? const <String>{}
       : {for (final q in solidQueries) q.methodName};
+  // Superset of `reactiveNames` that also includes `@SolidEnvironment` field
+  // names. These are the field names `_emitReactiveBlock` will emit itself,
+  // so `_partitionFields` must skip them on the source-text walk to avoid
+  // double-emitting them as widget/state-bound fields.
+  final partitionExcludeNames = <String>{
+    ...reactiveNames,
+    ...solidEnvironments.map((e) => e.fieldName),
+  };
 
   final members = _splitMembers(classDecl);
   final widgetBoundNames = _collectWidgetBoundNames(members.ctors);
   final partition = _partitionFields(
     members.fields,
-    reactiveNames,
+    partitionExcludeNames,
     widgetBoundNames,
     source,
   );
@@ -62,6 +72,7 @@ RewriteResult rewriteStatelessWidget(
     solidGetters,
     solidEffects,
     solidQueries,
+    solidEnvironments,
   );
 
   final widgetClass = _emitWidgetClass(
@@ -81,7 +92,18 @@ RewriteResult rewriteStatelessWidget(
     buildMethodText: buildMethodText,
   );
 
-  final solidartNames = <String>{'Signal', 'SignalBuilder'};
+  // SPEC §9 import-add gates. `Signal` and `SignalBuilder` are only emitted
+  // when there's a same-class reactive declaration to wrap. An env-only
+  // class (M6-03 simple-environment) has no Signal/SignalBuilder reference
+  // in its lowered output and so does NOT pull in `flutter_solidart`.
+  final hasReactive =
+      solidFields.isNotEmpty ||
+      solidGetters.isNotEmpty ||
+      solidQueries.isNotEmpty;
+  final solidartNames = <String>{
+    if (solidFields.isNotEmpty) 'Signal',
+    if (hasReactive) 'SignalBuilder',
+  };
   if (solidGetters.isNotEmpty) solidartNames.add('Computed');
   if (solidEffects.isNotEmpty) solidartNames.add('Effect');
   if (solidQueries.isNotEmpty) solidartNames.add('Resource');
@@ -100,12 +122,12 @@ RewriteResult rewriteStatelessWidget(
 
 /// Returns the source-ordered emission of every reactive declaration on
 /// [classDecl] (Signal field + Computed getter + Effect method + Resource
-/// query) as a single 2-space-indented block, plus the declaration-order
-/// list of dispose names that pairs with it. Source order is the contract
-/// that `Computed`, `Effect`, and the future M5-10 query-source-Computed
-/// depend on: each must reference declarations defined before it, so the
-/// emitted `late final` lines must appear after the declarations they read
-/// in the rewritten State class.
+/// query + `@SolidEnvironment` env field) as a single 2-space-indented block,
+/// plus the declaration-order list of dispose names that pairs with it.
+/// Source order is the contract that `Computed`, `Effect`, and the M5-10
+/// query-source-Computed depend on: each must reference declarations defined
+/// before it, so the emitted `late final` lines must appear after the
+/// declarations they read in the rewritten State class.
 ///
 /// `effectNamesInDeclarationOrder` is the Effect-only subset of
 /// `disposeNamesInDeclarationOrder`, pulled out so the rewriter can
@@ -113,6 +135,12 @@ RewriteResult rewriteStatelessWidget(
 /// at mount time (SPEC §4.7). Queries are intentionally NOT in this list —
 /// per SPEC §4.8 rule 10 / §14 item 4, Resources are lazy and the late-final
 /// initializer fires on first call-site read, never via `initState`.
+///
+/// `@SolidEnvironment` env fields (M6-03) are emitted in source-declaration
+/// order alongside Signal/Computed/Effect/Resource fields but are NEVER added
+/// to `disposeNames` (SPEC §10 — env fields are not host-disposed) and NEVER
+/// added to `effectNames` (SPEC §4.9 rule 2 — env fields are lazy and need
+/// no initState materialization).
 ({
   String fieldsText,
   List<String> disposeNamesInDeclarationOrder,
@@ -124,8 +152,10 @@ _emitReactiveBlock(
   List<GetterModel> solidGetters,
   List<EffectModel> solidEffects,
   List<QueryModel> solidQueries,
+  List<EnvironmentModel> solidEnvironments,
 ) {
   final fieldByName = {for (final f in solidFields) f.fieldName: f};
+  final envByName = {for (final e in solidEnvironments) e.fieldName: e};
   final getterByName = {for (final g in solidGetters) g.getterName: g};
   final effectByName = {for (final e in solidEffects) e.methodName: e};
   final queryByName = {for (final q in solidQueries) q.methodName: q};
@@ -144,6 +174,13 @@ _emitReactiveBlock(
       if (f != null) {
         lines.add(emitSignalField(f));
         disposeNames.add(f.fieldName);
+        continue;
+      }
+      final env = envByName[name];
+      if (env != null) {
+        // No disposeNames / effectNames push — env fields are not host-
+        // disposed (SPEC §10) and not initState-materialized (SPEC §4.9).
+        lines.add(emitEnvironmentField(env));
       }
       continue;
     }
@@ -309,8 +346,8 @@ String _emitWidgetClass(
 /// non-widget-bound field that has been moved off the widget; emitted before
 /// the synthesized reactive fields so original declaration order is preserved.
 /// [reactiveFieldsText] is the source-ordered emission of every reactive
-/// declaration (Signal field + Computed getter + Effect method) on the
-/// original class.
+/// declaration (Signal field + Computed getter + Effect method +
+/// `@SolidEnvironment` env field) on the original class.
 ///
 /// [effectNamesInDeclarationOrder] is the Effect-only subset of
 /// [disposeNamesInDeclarationOrder]. When non-empty, this method emits a
@@ -318,6 +355,11 @@ String _emitWidgetClass(
 /// at mount time so its autorun fires (SPEC §4.7). When empty, no `initState`
 /// is emitted — preserving byte-equality with every M1/M2/M3 golden that has
 /// no Effects.
+///
+/// `dispose()` is similarly gated on [disposeNamesInDeclarationOrder] being
+/// non-empty (SPEC §10): an env-only host class (M6-03) has no reactive
+/// declarations to dispose, so no `dispose()` override is emitted — the
+/// inherited `State<T>.dispose()` runs unchanged.
 String _emitStateClass({
   required String className,
   required String stateClassName,
@@ -327,22 +369,22 @@ String _emitStateClass({
   required String stateFieldsText,
   required String buildMethodText,
 }) {
-  final dispose = emitDispose(
-    disposeNamesInDeclarationOrder,
-    emitOverride: true,
-    emitSuperCall: true,
-  );
   final fieldsPrefix = stateFieldsText.isNotEmpty ? '$stateFieldsText\n\n' : '';
   final initStateBlock = effectNamesInDeclarationOrder.isEmpty
       ? ''
       : '${emitInitState(effectNamesInDeclarationOrder)}\n\n';
+  final disposeBlock = disposeNamesInDeclarationOrder.isEmpty
+      ? ''
+      : '${emitDispose(
+          disposeNamesInDeclarationOrder,
+          emitOverride: true,
+          emitSuperCall: true,
+        )}\n\n';
 
   return '''
 class $stateClassName extends State<$className> {
 $fieldsPrefix$reactiveFieldsText
 
-$initStateBlock$dispose
-
-  $buildMethodText
+$initStateBlock$disposeBlock  $buildMethodText
 }''';
 }

--- a/packages/solid_generator/lib/src/target_validator.dart
+++ b/packages/solid_generator/lib/src/target_validator.dart
@@ -120,19 +120,57 @@ void _validateTopLevel(CompilationUnitMember decl) {
   }
 }
 
+// --- shared rejection / top-level walk for the article-form validators ---
+
+/// Throws a [ValidationError] for `@<annotationName>` on a [kind] of
+/// declaration. Picks the indefinite article from [kind]'s first letter so
+/// the message reads naturally ("a getter" vs "an abstract method").
+///
+/// Shared by the `@SolidEffect`, `@SolidQuery`, and `@SolidEnvironment`
+/// validators; `@SolidState` uses its own [_reject] helper because its SPEC
+/// §3.1 message form omits the article.
+Never _rejectArticleAnnotation(
+  String annotationName,
+  String codePrefix,
+  String kind,
+  String location,
+) {
+  final article = 'aeiouAEIOU'.contains(kind[0]) ? 'an' : 'a';
+  throw ValidationError(
+    '@$annotationName cannot be applied to $article $kind',
+    location,
+    '${codePrefix}_TARGET_${_kindCode(kind)}',
+  );
+}
+
+/// Shared top-level rejection walk for the article-form validators. Each
+/// one (`@SolidEffect` §3.4, `@SolidQuery` §3.5, `@SolidEnvironment` §3.6)
+/// classifies top-level declarations into variable/getter/setter/function
+/// with identical labels — only the annotation name and reject closure
+/// differ.
+void _validateTopLevelArticleAnnotation(
+  CompilationUnitMember decl,
+  String annotationName,
+  Never Function(String kind, String location) reject,
+) {
+  if (decl is TopLevelVariableDeclaration &&
+      findAnnotationByName(annotationName, decl.metadata) != null) {
+    reject('top-level variable', decl.variables.variables.first.name.lexeme);
+  }
+  if (decl is FunctionDeclaration &&
+      findAnnotationByName(annotationName, decl.metadata) != null) {
+    final name = decl.name.lexeme;
+    if (decl.isGetter) reject('top-level getter', name);
+    if (decl.isSetter) reject('top-level setter', name);
+    reject('top-level function', name);
+  }
+}
+
 // --- @SolidEffect target validator (SPEC §3.4) ---
 
 /// Throws a [ValidationError] for `@SolidEffect` on a [kind] of declaration.
-/// Picks the indefinite article from `kind`'s first letter so the message
-/// reads naturally ("a getter" vs "an abstract method").
-Never _rejectEffect(String kind, String location) {
-  final article = 'aeiouAEIOU'.contains(kind[0]) ? 'an' : 'a';
-  throw ValidationError(
-    '@SolidEffect cannot be applied to $article $kind',
-    location,
-    'INVALID_EFFECT_TARGET_${_kindCode(kind)}',
-  );
-}
+Never _rejectEffect(String kind, String location) =>
+    _rejectArticleAnnotation(solidEffectName, 'INVALID_EFFECT', kind, location);
 
 /// Rejects `@SolidEffect` on any field. The SPEC §3.4 bullet does not
 /// subdivide field kinds, so static and instance fields share the single
@@ -170,26 +208,9 @@ void _validateEffectMethod(MethodDeclaration method, String className) {
   }
 }
 
-/// Rejects `@SolidEffect` on top-level declarations: variables, getters,
-/// setters, and functions. The SPEC §3.4 bullet calls out "top-level function"
-/// — top-level getters/setters/variables share the same fail-fast path with
-/// per-kind labels.
-void _validateEffectTopLevel(CompilationUnitMember decl) {
-  if (decl is TopLevelVariableDeclaration &&
-      findAnnotationByName(solidEffectName, decl.metadata) != null) {
-    _rejectEffect(
-      'top-level variable',
-      decl.variables.variables.first.name.lexeme,
-    );
-  }
-  if (decl is FunctionDeclaration &&
-      findAnnotationByName(solidEffectName, decl.metadata) != null) {
-    final name = decl.name.lexeme;
-    if (decl.isGetter) _rejectEffect('top-level getter', name);
-    if (decl.isSetter) _rejectEffect('top-level setter', name);
-    _rejectEffect('top-level function', name);
-  }
-}
+/// Rejects `@SolidEffect` on top-level declarations (SPEC §3.4).
+void _validateEffectTopLevel(CompilationUnitMember decl) =>
+    _validateTopLevelArticleAnnotation(decl, solidEffectName, _rejectEffect);
 
 // --- @SolidQuery target validator (SPEC §3.5) ---
 
@@ -214,16 +235,8 @@ void validateSolidQueryTargets(CompilationUnit unit) => _walkUnit(
 );
 
 /// Throws a [ValidationError] for `@SolidQuery` on a [kind] of declaration.
-/// Picks the indefinite article from `kind`'s first letter so the message
-/// reads naturally ("a getter" vs "an abstract method").
-Never _rejectQuery(String kind, String location) {
-  final article = 'aeiouAEIOU'.contains(kind[0]) ? 'an' : 'a';
-  throw ValidationError(
-    '@SolidQuery cannot be applied to $article $kind',
-    location,
-    'INVALID_QUERY_TARGET_${_kindCode(kind)}',
-  );
-}
+Never _rejectQuery(String kind, String location) =>
+    _rejectArticleAnnotation(solidQueryName, 'INVALID_QUERY', kind, location);
 
 /// `@SolidQuery` on a class field is a valid target: the field initializer
 /// expression (e.g. `Future.value(0)`) becomes the Resource fetcher closure
@@ -278,23 +291,105 @@ void _validateQueryMethod(MethodDeclaration method, String className) {
   }
 }
 
-/// Rejects `@SolidQuery` on top-level declarations: variables, getters,
-/// setters, and functions. The SPEC §3.5 bullet calls out "top-level function"
-/// — top-level getters/setters/variables share the same fail-fast path with
-/// per-kind labels.
-void _validateQueryTopLevel(CompilationUnitMember decl) {
-  if (decl is TopLevelVariableDeclaration &&
-      findAnnotationByName(solidQueryName, decl.metadata) != null) {
-    _rejectQuery(
-      'top-level variable',
-      decl.variables.variables.first.name.lexeme,
+/// Rejects `@SolidQuery` on top-level declarations (SPEC §3.5).
+void _validateQueryTopLevel(CompilationUnitMember decl) =>
+    _validateTopLevelArticleAnnotation(decl, solidQueryName, _rejectQuery);
+
+// --- @SolidEnvironment target validator (SPEC §3.6) ---
+
+/// Validates every `@SolidEnvironment` annotation in [unit] against the SPEC
+/// Section 3.6 valid-target list. Throws [ValidationError] on the first
+/// invalid placement; returns silently when every annotation targets a
+/// valid declaration (a `late` instance field with no initializer, a
+/// non-`SignalBase` type, on a `StatelessWidget`/`StatefulWidget`/`State<X>`
+/// host).
+///
+/// Runs after [validateSolidQueryTargets] and before transformation so that
+/// misplaced `@SolidEnvironment` annotations (non-`late` fields, fields with
+/// initializers, `final`/`const`/`static` fields, methods/getters/setters,
+/// top-level functions, `SignalBase`-typed fields, plain-class hosts) never
+/// reach `readSolidEnvironmentField`, which would otherwise skip them
+/// silently or produce a confusing downstream error.
+///
+/// **M6-03 scope:** the canonical valid case (`late <T> name;` on a
+/// `StatelessWidget`/`State<X>`) falls through silently; comprehensive
+/// per-case error messages and codes ship in M6-07 (the rejection-test PR).
+/// The function structure is wired up here so M6-07 only needs to add cases.
+void validateSolidEnvironmentTargets(CompilationUnit unit) => _walkUnit(
+  unit,
+  onField: _validateEnvironmentField,
+  onMethod: _validateEnvironmentMethod,
+  onTopLevel: _validateEnvironmentTopLevel,
+);
+
+/// Throws a [ValidationError] for `@SolidEnvironment` on a [kind] of
+/// declaration.
+Never _rejectEnvironment(String kind, String location) =>
+    _rejectArticleAnnotation(
+      solidEnvironmentName,
+      'INVALID_ENVIRONMENT',
+      kind,
+      location,
     );
+
+/// Rejects `@SolidEnvironment` on a class field that is `static`, `const`,
+/// `final`-without-`late`, non-`late`, has an initializer, or is typed as a
+/// `SignalBase` shape (`Signal<…>` / `Computed<…>` / `Effect` / `Resource<…>`).
+/// Plain-class host detection lives separately in `rewritePlainClass`'s
+/// defense-in-depth check (the host-kind check needs the full class context
+/// the validator's `_walkUnit` doesn't provide). Instance non-final non-const
+/// non-static `late` fields with no initializer and a non-`SignalBase` type
+/// fall through silently — they are the canonical SPEC §3.6 valid target.
+///
+/// Order matters per SPEC §3.6 invalid-target enumeration: structural
+/// modifiers (`static` / `const` / `final` / non-`late`) are checked before
+/// initializer presence and type shape. A `static const Signal<int> c = …`
+/// reports as `'static field'` (the dominant placement violation) rather
+/// than `'SignalBase-typed field'`.
+void _validateEnvironmentField(FieldDeclaration field, String className) {
+  if (findAnnotationByName(solidEnvironmentName, field.metadata) == null) {
+    return;
   }
-  if (decl is FunctionDeclaration &&
-      findAnnotationByName(solidQueryName, decl.metadata) != null) {
-    final name = decl.name.lexeme;
-    if (decl.isGetter) _rejectQuery('top-level getter', name);
-    if (decl.isSetter) _rejectQuery('top-level setter', name);
-    _rejectQuery('top-level function', name);
+  final varList = field.fields;
+  final fieldName = varList.variables.first.name.lexeme;
+  final location = '$className.$fieldName';
+  if (field.isStatic) _rejectEnvironment('static field', location);
+  if (varList.isConst) _rejectEnvironment('const field', location);
+  // `late final` is allowed (the SPEC §3.6 bullet allows immutability on the
+  // injected reference); only `final` WITHOUT `late` is rejected.
+  if (varList.isFinal && !varList.isLate) {
+    _rejectEnvironment('final field', location);
+  }
+  if (!varList.isLate) _rejectEnvironment('non-late field', location);
+  final variable = varList.variables.first;
+  if (variable.initializer != null) {
+    _rejectEnvironment('field with initializer', location);
+  }
+  // Textual `SignalBase` detection on the unresolved AST. Per SPEC §3.6's
+  // contract that the user must import `flutter_solidart` to write the type
+  // at all, the lexeme prefix is sufficient at the validator boundary.
+  final type = varList.type;
+  if (type is NamedType && signalBaseTypeNames.contains(type.name.lexeme)) {
+    _rejectEnvironment('SignalBase-typed field', location);
   }
 }
+
+/// Rejects `@SolidEnvironment` on a getter, setter, or method. Static
+/// methods/getters/setters are caught by the same per-kind labels.
+void _validateEnvironmentMethod(MethodDeclaration method, String className) {
+  if (findAnnotationByName(solidEnvironmentName, method.metadata) == null) {
+    return;
+  }
+  final location = '$className.${method.name.lexeme}';
+  if (method.isGetter) _rejectEnvironment('getter', location);
+  if (method.isSetter) _rejectEnvironment('setter', location);
+  _rejectEnvironment('method', location);
+}
+
+/// Rejects `@SolidEnvironment` on top-level declarations (SPEC §3.6).
+void _validateEnvironmentTopLevel(CompilationUnitMember decl) =>
+    _validateTopLevelArticleAnnotation(
+      decl,
+      solidEnvironmentName,
+      _rejectEnvironment,
+    );

--- a/packages/solid_generator/test/golden/inputs/m6_03_simple_environment.dart
+++ b/packages/solid_generator/test/golden/inputs/m6_03_simple_environment.dart
@@ -1,0 +1,25 @@
+// SPEC §3.6 uses a non-Solid `Logger` as the canonical injected type for
+// the simple-environment lowering example. `Logger.log` calls `print` for
+// minimal noise; `Text('hello')` is intentionally non-const so the build
+// body round-trips byte-identical (the generator never const-ifies — that's
+// `dart fix --apply`'s job at the consumer-app level).
+// ignore_for_file: avoid_print, prefer_const_constructors
+
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+
+class Logger {
+  void log(String message) => print(message);
+}
+
+class HomePage extends StatelessWidget {
+  HomePage({super.key});
+
+  @SolidEnvironment()
+  late Logger logger;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text('hello');
+  }
+}

--- a/packages/solid_generator/test/golden/outputs/m6_03_simple_environment.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m6_03_simple_environment.g.dart
@@ -1,0 +1,23 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+import 'package:provider/provider.dart';
+
+class Logger {
+  void log(String message) => print(message);
+}
+
+class HomePage extends StatefulWidget {
+  HomePage({super.key});
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  late final logger = context.read<Logger>();
+
+  @override
+  Widget build(BuildContext context) {
+    return Text('hello');
+  }
+}

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -63,6 +63,7 @@ const List<String> goldenNames = <String>[
   'm6_02_already_disposable',
   'm6_02_user_dispose_body',
   'm6_02_user_dispose_no_override',
+  'm6_03_simple_environment',
 ];
 
 /// Memoized golden directory resolution. Resolved relative to the package


### PR DESCRIPTION
## Summary

- Added `@SolidEnvironment` annotation support for dependency injection via `context.read<T>()`
- Environment-annotated `late` instance fields lower to `late final <name> = context.read<T>();` in synthesized State classes
- Environment fields are emitted in source-declaration order alongside Signal/Computed/Effect/Resource fields
- Provider import (`package:provider/provider.dart`) is automatically added when environment fields are present
- Environment fields are lazy-initialized (no `initState` splice) and never added to dispose lists (provider owns disposal)
- Added validation to reject `@SolidEnvironment` on plain classes, static/const/final fields, fields with initializers, and `SignalBase`-typed fields
- Updated import logic to add full provider library (no `show` clause) so consumers can reference other provider APIs in the same file
- Fixed `Signal` and `SignalBuilder` import gates in stateless rewriter to only emit when actually referenced
- Integrated environment field collection and rewriting across all class-rewriting paths

## Testing

- `dart test --name=m6_03` passes
- Golden test `m6_03_simple_environment` validates environment field synthesis and import generation
- Analyzer passes clean on generated output
- State classes with environment fields emit no `initState()` override (lazy evaluation)
- Environment-annotated fields are rejected on plain classes with clear error message
- Provider import added exactly once with full library (no `show` clause)