### PR TITLE
M6-05 golden test for @SolidEnvironment on State class

### DIFF
--- a/packages/solid_generator/test/golden/inputs/m6_05_environment_on_state_class.dart
+++ b/packages/solid_generator/test/golden/inputs/m6_05_environment_on_state_class.dart
@@ -1,0 +1,55 @@
+// Mirror of M1-07 / M4-08 for `@SolidEnvironment`. An existing
+// `State<HomePage>` already hosts a hand-written `initState` (calls
+// `super.initState()` then `debugPrint('init')`) and a hand-written
+// `dispose` (cancels a stream subscription, calls `super.dispose()`). It
+// also has one `@SolidEnvironment` field and one `@SolidState` field. The
+// golden locks SPEC §4.9 rule 2 (env fields are lazy and never spliced
+// into `initState`) and §4.9 rule 5 / §10 (env fields never enter the
+// host's dispose-name list — disposal belongs to the `Provider<T>`
+// owner). The `@SolidState counter` field IS prepended to the existing
+// dispose body, per the §10 rule the host already follows for its own
+// reactive members.
+// ignore_for_file: avoid_print
+
+import 'dart:async';
+
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+
+class Logger {
+  void log(String message) => print(message);
+}
+
+class HomePage extends StatefulWidget {
+  const HomePage({super.key});
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  @SolidEnvironment()
+  late Logger logger;
+
+  @SolidState()
+  int counter = 0;
+
+  final StreamSubscription<void> _subscription = Stream<void>.periodic(
+    const Duration(seconds: 1),
+  ).listen((_) {});
+
+  @override
+  void initState() {
+    super.initState();
+    debugPrint('init');
+  }
+
+  @override
+  void dispose() {
+    unawaited(_subscription.cancel());
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/golden/outputs/m6_05_environment_on_state_class.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m6_05_environment_on_state_class.g.dart
@@ -1,0 +1,42 @@
+import 'dart:async';
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:provider/provider.dart';
+
+class Logger {
+  void log(String message) => print(message);
+}
+
+class HomePage extends StatefulWidget {
+  const HomePage({super.key});
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  late final logger = context.read<Logger>();
+
+  final counter = Signal<int>(0, name: 'counter');
+
+  final StreamSubscription<void> _subscription = Stream<void>.periodic(
+    const Duration(seconds: 1),
+  ).listen((_) {});
+
+  @override
+  void initState() {
+    super.initState();
+    debugPrint('init');
+  }
+
+  @override
+  void dispose() {
+    counter.dispose();
+    unawaited(_subscription.cancel());
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -65,6 +65,7 @@ const List<String> goldenNames = <String>[
   'm6_02_user_dispose_no_override',
   'm6_03_simple_environment',
   'm6_04_cross_class_value_read',
+  'm6_05_environment_on_state_class',
 ];
 
 /// Memoized golden directory resolution. Resolved relative to the package


### PR DESCRIPTION
## Summary

- Adds golden test case for M6-05, validating `@SolidEnvironment` field behavior on `State` classes
- Tests that environment fields are lazily initialized via `context.read<T>()` and never included in `dispose`
- Validates that `@SolidState` fields in the same class are still properly disposed while preserving existing hand-written `initState` and `dispose` methods
- Locks behavior per SPEC §4.9 rules 2 and 5, and §10 disposal semantics

## Testing

- Golden test files added to `test/golden/inputs/` and `test/golden/outputs/`
- Test registered in `golden_helpers.dart` goldenNames list
- Run `dart test` in `solid_generator` package to verify golden outputs match generated code