### PR TITLE
M6-06 golden test for multiple @SolidEnvironment fields

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -2359,7 +2359,7 @@ class _CounterDisplayState extends State<CounterDisplay> {
 
 **Dependencies:** M6-04.
 
-**Status:** TODO
+**Status:** DONE — golden fixture pair added; `_CounterDisplayState` emits `late final counter = context.read<Counter>();` then `late final logger = context.read<Logger>();` in source-declaration order. Per-field §5.1 cross-class rewrite locks `counter.value` → `counter.value.value` (wrapped in `SignalBuilder` per §7) while `logger.log('build')` is left untouched (non-`SignalBase` prefix). No generator code changes — covered by M6-03's source-order emission and M6-04's `_environmentFields` plumbing in `value_rewriter.dart`.
 
 ---
 

--- a/packages/solid_generator/test/golden/inputs/m6_06_multi_environment.dart
+++ b/packages/solid_generator/test/golden/inputs/m6_06_multi_environment.dart
@@ -1,0 +1,38 @@
+// Multi-`@SolidEnvironment` golden — `Counter` (Solid-lowered, carries
+// `@SolidState int value`) and `Logger` (plain class) are both injected
+// into `CounterDisplay`. Locks SPEC §3.6 + §4.9 rule 2: two independent
+// `late final ... = context.read<T>();` field declarations in source-
+// declaration order, no `initState` splice. Locks §5.1 per-field cross-
+// class rewrite (counter gets `.value` appended; logger left alone — `log`
+// is not in `Logger`'s reactive-field set). Locks §7 SignalBuilder
+// placement (wraps only the tracked `Text` expression; `logger.log(...)`
+// stays outside the builder closure).
+// ignore_for_file: avoid_print
+
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+
+class Counter {
+  @SolidState()
+  int value = 0;
+}
+
+class Logger {
+  void log(String message) => print(message);
+}
+
+class CounterDisplay extends StatelessWidget {
+  CounterDisplay({super.key});
+
+  @SolidEnvironment()
+  late Counter counter;
+
+  @SolidEnvironment()
+  late Logger logger;
+
+  @override
+  Widget build(BuildContext context) {
+    logger.log('build');
+    return Text(counter.value.toString());
+  }
+}

--- a/packages/solid_generator/test/golden/outputs/m6_06_multi_environment.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m6_06_multi_environment.g.dart
@@ -1,0 +1,39 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:provider/provider.dart';
+
+class Counter implements Disposable {
+  final value = Signal<int>(0, name: 'value');
+
+  @override
+  void dispose() {
+    value.dispose();
+  }
+}
+
+class Logger {
+  void log(String message) => print(message);
+}
+
+class CounterDisplay extends StatefulWidget {
+  CounterDisplay({super.key});
+
+  @override
+  State<CounterDisplay> createState() => _CounterDisplayState();
+}
+
+class _CounterDisplayState extends State<CounterDisplay> {
+  late final counter = context.read<Counter>();
+  late final logger = context.read<Logger>();
+
+  @override
+  Widget build(BuildContext context) {
+    logger.log('build');
+    return SignalBuilder(
+      builder: (context, child) {
+        return Text(counter.value.value.toString());
+      },
+    );
+  }
+}

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -66,6 +66,7 @@ const List<String> goldenNames = <String>[
   'm6_03_simple_environment',
   'm6_04_cross_class_value_read',
   'm6_05_environment_on_state_class',
+  'm6_06_multi_environment',
 ];
 
 /// Memoized golden directory resolution. Resolved relative to the package


### PR DESCRIPTION
## Summary

- Adds `m6_06_multi_environment` golden: a `StatelessWidget` with two `@SolidEnvironment` fields — `Counter` (Solid-lowered, carries `@SolidState int value`) and `Logger` (plain class).
- Locks SPEC §3.6 + §4.9 rule 2 (two `late final ... = context.read<T>();` declarations in source-declaration order; no `initState` splice), §5.1 per-field cross-class rewrite (`counter.value` → `counter.value.value`; `logger.log('build')` left alone — `log` is not in `Logger`'s reactive-field set), and §7 `SignalBuilder` placement (wraps only the tracked `Text` expression; the non-Solid call stays outside the builder closure).
- Pure golden-test PR — no generator code changes. The multi-env case is naturally covered by M6-03's source-order emission, and the per-field cross-class rewrite landed in M6-04 via the `_environmentFields` map threaded through `value_rewriter.dart::collectValueEdits`.
- Mirrors M6-05's structure (golden-only) and composes M6-03 + M6-04.

## Test plan

- [x] `dart test --name=m6_06` (new golden + idempotency case)
- [x] `dart test packages/solid_generator/` — full regression (130 tests, all M-series goldens + rejections still pass byte-identically)
- [x] `dart analyze packages/solid_generator/test/golden/outputs/` — zero issues
- [x] `dart format --set-exit-if-changed .` — zero diff
- [x] `dart analyze --fatal-infos` — only the pre-existing `unnecessary_statements` info in `example/test/effect_widget_test.dart:114` (last touched in commit `652ce9d`, M4-06; unrelated to this PR)
- [x] `TODOS.md` M6-06 status flipped TODO → DONE