### PR TITLE
M6-07 rejection tests for invalid @SolidEnvironment targets

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -2392,7 +2392,7 @@ class _CounterDisplayState extends State<CounterDisplay> {
 
 **Dependencies:** M6-03.
 
-**Status:** TODO
+**Status:** DONE — parametric rejection suite added at `packages/solid_generator/test/rejections/m6_07_invalid_environment_targets_test.dart` covering all 10 invalid-target cases (field with initializer, non-`late`, `final`-without-`late`, `static`, method, getter, setter, top-level variable, `SignalBase`-typed field, plain-class host). Each case has a minimal input fixture under `packages/solid_generator/test/golden/inputs/m6_07_*.dart`. No production-code changes — `validateSolidEnvironmentTargets` (target_validator.dart §3.6) and the plain-class defense-in-depth guard (plain_class_rewriter.dart) were already wired in M6-03. The `m6_07_final_field` fixture intentionally omits `= Counter()`: `late final` is the valid shape per SPEC §3.6, so the realistic mistake is forgetting `late` (`final Counter c;`); the `final && !isLate` check fires before the initializer check, so no synthetic value is needed. All prior goldens + rejection tests remain byte-identical.
 
 ---
 

--- a/packages/solid_generator/test/golden/inputs/m6_07_field_with_initializer.dart
+++ b/packages/solid_generator/test/golden/inputs/m6_07_field_with_initializer.dart
@@ -1,0 +1,8 @@
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Counter {}
+
+class Foo {
+  @SolidEnvironment()
+  late Counter c = Counter();
+}

--- a/packages/solid_generator/test/golden/inputs/m6_07_field_without_late.dart
+++ b/packages/solid_generator/test/golden/inputs/m6_07_field_without_late.dart
@@ -1,0 +1,13 @@
+// The non-nullable, non-`late`, uninitialized field IS the rejection target —
+// the M6-07 validator flags it as `'non-late field'`. Suppress the
+// corresponding analyzer error so `dart analyze` stays clean on this fixture.
+// ignore_for_file: not_initialized_non_nullable_instance_field
+
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Counter {}
+
+class Foo {
+  @SolidEnvironment()
+  Counter c;
+}

--- a/packages/solid_generator/test/golden/inputs/m6_07_final_field.dart
+++ b/packages/solid_generator/test/golden/inputs/m6_07_final_field.dart
@@ -1,0 +1,17 @@
+// The `final`-without-`late`, uninitialized field IS the rejection target —
+// the M6-07 validator flags it as `'final field'` (the `isFinal && !isLate`
+// check fires before the initializer-presence check). `late final Counter c;`
+// is the *valid* shape per SPEC §3.6; the realistic user mistake is
+// forgetting `late`, with no manual constructor call (`@SolidEnvironment` is
+// the initialization). Suppress the corresponding analyzer error so
+// `dart analyze` stays clean on this fixture.
+// ignore_for_file: final_not_initialized
+
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Counter {}
+
+class Foo {
+  @SolidEnvironment()
+  final Counter c;
+}

--- a/packages/solid_generator/test/golden/inputs/m6_07_getter.dart
+++ b/packages/solid_generator/test/golden/inputs/m6_07_getter.dart
@@ -1,0 +1,8 @@
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Counter {}
+
+class Foo {
+  @SolidEnvironment()
+  Counter get c => Counter();
+}

--- a/packages/solid_generator/test/golden/inputs/m6_07_method.dart
+++ b/packages/solid_generator/test/golden/inputs/m6_07_method.dart
@@ -1,0 +1,6 @@
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Foo {
+  @SolidEnvironment()
+  void doStuff() {}
+}

--- a/packages/solid_generator/test/golden/inputs/m6_07_plain_class.dart
+++ b/packages/solid_generator/test/golden/inputs/m6_07_plain_class.dart
@@ -1,0 +1,8 @@
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Counter {}
+
+class Foo {
+  @SolidEnvironment()
+  late Counter counter;
+}

--- a/packages/solid_generator/test/golden/inputs/m6_07_setter.dart
+++ b/packages/solid_generator/test/golden/inputs/m6_07_setter.dart
@@ -1,0 +1,8 @@
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Counter {}
+
+class Foo {
+  @SolidEnvironment()
+  set c(Counter v) {}
+}

--- a/packages/solid_generator/test/golden/inputs/m6_07_signalbase_typed.dart
+++ b/packages/solid_generator/test/golden/inputs/m6_07_signalbase_typed.dart
@@ -1,0 +1,14 @@
+// The `Signal<int>` type IS the rejection target — the M6-07 validator flags
+// any field whose declared type's lexeme is in `signalBaseTypeNames`
+// (`Signal` / `Computed` / `Effect` / `Resource`). The validator works on the
+// unresolved AST, so no `flutter_solidart` import is needed; suppress the
+// resulting `undefined_class` diagnostic so `dart analyze` stays clean on
+// this fixture.
+// ignore_for_file: undefined_class
+
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Foo {
+  @SolidEnvironment()
+  late Signal<int> c;
+}

--- a/packages/solid_generator/test/golden/inputs/m6_07_static_field.dart
+++ b/packages/solid_generator/test/golden/inputs/m6_07_static_field.dart
@@ -1,0 +1,8 @@
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Counter {}
+
+class Foo {
+  @SolidEnvironment()
+  static late Counter c;
+}

--- a/packages/solid_generator/test/golden/inputs/m6_07_top_level.dart
+++ b/packages/solid_generator/test/golden/inputs/m6_07_top_level.dart
@@ -1,0 +1,6 @@
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Counter {}
+
+@SolidEnvironment()
+late Counter c;

--- a/packages/solid_generator/test/rejections/m6_07_invalid_environment_targets_test.dart
+++ b/packages/solid_generator/test/rejections/m6_07_invalid_environment_targets_test.dart
@@ -1,0 +1,65 @@
+// Rejection suite for M6-07: invalid `@SolidEnvironment` placements per
+// SPEC §3.6.
+//
+// Cases ordered to mirror the SPEC §3.6 invalid-target enumeration and the
+// validator's own check order in `_validateEnvironmentField`:
+//   field with initializer → non-late field → final field → static field →
+//   method → getter → setter → top-level variable → SignalBase-typed field →
+//   plain-class host.
+//
+// The plain-class case is the only one whose rejection comes from
+// `plain_class_rewriter.dart` (`CodeGenerationError`) rather than
+// `target_validator.dart` (`ValidationError`); all others share the
+// `@SolidEnvironment cannot be applied to a <kind>` message shape.
+
+import '../integration/golden_helpers.dart';
+
+const List<({String name, String errorContains})> _cases = [
+  (
+    name: 'm6_07_field_with_initializer',
+    errorContains:
+        '@SolidEnvironment cannot be applied to a field with initializer',
+  ),
+  (
+    name: 'm6_07_field_without_late',
+    errorContains: '@SolidEnvironment cannot be applied to a non-late field',
+  ),
+  (
+    name: 'm6_07_final_field',
+    errorContains: '@SolidEnvironment cannot be applied to a final field',
+  ),
+  (
+    name: 'm6_07_static_field',
+    errorContains: '@SolidEnvironment cannot be applied to a static field',
+  ),
+  (
+    name: 'm6_07_method',
+    errorContains: '@SolidEnvironment cannot be applied to a method',
+  ),
+  (
+    name: 'm6_07_getter',
+    errorContains: '@SolidEnvironment cannot be applied to a getter',
+  ),
+  (
+    name: 'm6_07_setter',
+    errorContains: '@SolidEnvironment cannot be applied to a setter',
+  ),
+  (
+    name: 'm6_07_top_level',
+    errorContains:
+        '@SolidEnvironment cannot be applied to a top-level variable',
+  ),
+  (
+    name: 'm6_07_signalbase_typed',
+    errorContains:
+        '@SolidEnvironment cannot be applied to a SignalBase-typed field',
+  ),
+  (
+    name: 'm6_07_plain_class',
+    errorContains: '@SolidEnvironment on plain class is invalid',
+  ),
+];
+
+void main() {
+  runRejectionCases('m6_07 invalid @SolidEnvironment targets', _cases);
+}


### PR DESCRIPTION
## Summary

- Parametric rejection suite covering all 10 invalid `@SolidEnvironment` placements per SPEC §3.6: field with initializer, non-`late`, `final`-without-`late`, `static`, method, getter, setter, top-level variable, `SignalBase`-typed field, and plain-class host. Mirrors the M5-05 / M4-04 patterns.
- **No production-code changes** — `validateSolidEnvironmentTargets` (`target_validator.dart`) and the plain-class defense-in-depth guard (`plain_class_rewriter.dart`) were already wired in M6-03. This PR is purely additive test coverage.
- The `m6_07_final_field` fixture intentionally omits `= Counter()`: `late final` is the valid shape per SPEC §3.6, so the realistic mistake is forgetting `late` (`final Counter c;`); the validator's `isFinal && !isLate` check fires before the initializer check, so no synthetic value is needed.

## Test plan

- [x] `dart test packages/solid_generator/test/rejections/m6_07_invalid_environment_targets_test.dart` — 10/10 cases green
- [x] `dart test packages/solid_generator/` — 140/140 tests pass (no prior golden / rejection regressed)
- [x] `dart format --set-exit-if-changed .` — 0 changed
- [x] `dart analyze --fatal-infos` — clean on M6-07 files (analyzer-inherent diagnostics on the 3 syntax-corner fixtures suppressed via `// ignore_for_file:` per the existing pattern in `m4_04_abstract.dart`, `m5_05_abstract.dart`, etc.)