### PR TITLE
M6-09: Add `.environment<T>()` end-to-end example with widget tests

### DIFF
--- a/example/lib/m6_09_environment_app.dart
+++ b/example/lib/m6_09_environment_app.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:provider/provider.dart';
+
+class Counter implements Disposable {
+  final value = Signal<int>(0, name: 'value');
+
+  @override
+  void dispose() {
+    value.dispose();
+  }
+}
+
+class CounterDisplay extends StatefulWidget {
+  const CounterDisplay({super.key});
+
+  @override
+  State<CounterDisplay> createState() => _CounterDisplayState();
+}
+
+class _CounterDisplayState extends State<CounterDisplay> {
+  late final Counter counter = context.read<Counter>();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: SignalBuilder(
+          builder: (context, child) {
+            return Text('Counter is ${counter.value.value}');
+          },
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => counter.value.value++,
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_solidart: ^2.7.3
+  provider: ^6.1.0
   solid_annotations:
     path: ../packages/solid_annotations
 

--- a/example/source/m6_09_environment_app.dart
+++ b/example/source/m6_09_environment_app.dart
@@ -1,0 +1,39 @@
+// M6-09 — end-to-end source for the `.environment<T>()` + `@SolidEnvironment`
+// + dispose widget test. Mirrors the M6-04 cross-class read shape (golden
+// input `m6_04_cross_class_value_read.dart`) extended with a FAB so the test
+// can drive a tap, plus an empty `dispose()` stub on `Counter` (M6-02
+// `user_dispose_no_override` shape with empty body) so the source-layer
+// analyzer can resolve `c.dispose()` in the `.environment` callback.
+
+import 'package:flutter/material.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Counter {
+  @SolidState()
+  int value = 0;
+
+  // Empty stub. The source-layer analyzer needs to resolve `c.dispose()` in
+  // the `.environment<Counter>(... dispose: (_, c) => c.dispose())` callback;
+  // it cannot see the `Disposable` interface that the generator emits in
+  // `lib/`. The generator merges the synthesized `value.dispose()` into this
+  // body per SPEC §10 (M6-02 dispose-body merge for plain classes).
+  void dispose() {}
+}
+
+class CounterDisplay extends StatelessWidget {
+  CounterDisplay({super.key});
+
+  @SolidEnvironment()
+  late Counter counter;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(child: Text('Counter is ${counter.value}')),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => counter.value++,
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/example/test/m6_09_environment_widget_test.dart
+++ b/example/test/m6_09_environment_widget_test.dart
@@ -1,0 +1,100 @@
+// M6-09 — fences SPEC §3.6 (`.environment<T>()` extension, source-side
+// `dispose()` stub requirement), §7 (`SignalBuilder` placement on cross-class
+// chain read), and §10 (synthesized reactive disposal merged into the user's
+// empty `dispose()` body for plain classes) at runtime.
+//
+// `Counter` and `CounterDisplay` are imported from the generator-lowered
+// `package:example/m6_09_environment_app.dart` — this is the first widget
+// test that runs against generated `lib/` code (M1-10 / M3-04 / M4-07 / M5-07
+// all inline a test-local mirror of the lowered shape). The widget under
+// test is therefore the actual production output of the source app at
+// `example/source/m6_09_environment_app.dart`.
+//
+// The dispose assertion uses a closure-counted `dispose:` callback (rather
+// than `Counter.value.onDispose`) because the M6-09 acceptance criterion is
+// specifically the user-passed callback firing exactly once on provider
+// teardown. The internal Signal disposal is fenced by M6-02's user-dispose
+// merge golden + M1-11's runtime onDispose test.
+
+import 'dart:async';
+
+import 'package:example/m6_09_environment_app.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+void main() {
+  testWidgets('FAB tap mutates provided Counter and rebuilds consumer', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: const CounterDisplay().environment<Counter>(
+          (_) => Counter(),
+          dispose: (_, c) => c.dispose(),
+        ),
+      ),
+    );
+
+    expect(find.text('Counter is 0'), findsOneWidget);
+
+    for (var i = 0; i < 3; i++) {
+      await tester.tap(find.byType(FloatingActionButton));
+      await tester.pump();
+      expect(
+        find.text('Counter is ${i + 1}'),
+        findsOneWidget,
+        reason:
+            'SignalBuilder must rebuild on cross-class signal mutation '
+            '#${i + 1}',
+      );
+    }
+  });
+
+  testWidgets(
+    'Tearing down provider scope invokes user dispose callback exactly once',
+    (tester) async {
+      final navigatorKey = GlobalKey<NavigatorState>();
+      var disposeCallbackCount = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorKey: navigatorKey,
+          home: const SizedBox.shrink(),
+        ),
+      );
+
+      unawaited(
+        navigatorKey.currentState!.push(
+          MaterialPageRoute<void>(
+            builder: (_) => const CounterDisplay().environment<Counter>(
+              (_) => Counter(),
+              dispose: (_, c) {
+                disposeCallbackCount++;
+                c.dispose();
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        disposeCallbackCount,
+        0,
+        reason: 'Counter alive while page mounted',
+      );
+
+      navigatorKey.currentState!.pop();
+      await tester.pumpAndSettle();
+
+      expect(
+        disposeCallbackCount,
+        1,
+        reason:
+            'Navigator pop tears down the .environment Provider, invoking '
+            'its user-passed dispose callback exactly once',
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- Adds an end-to-end example app demonstrating `.environment<T>()` extension with `@SolidEnvironment` field injection
- Implements a simple counter app that provides a `Counter` instance to `CounterDisplay` via `.environment<Counter>()`
- Adds two widget tests validating:
  - Reactive updates propagate across the class boundary via `SignalBuilder` on FAB taps
  - User-provided `dispose` callback fires exactly once on provider scope teardown
- Validates SPEC §3.6 (`.environment<T>()` extension and source-side `dispose()` stub), §7 (`SignalBuilder` placement), and §10 (synthesized disposal merge)
- This is the first widget test running against generated `lib/` code (prior M-series tests mirrored the lowered shape inline)
- Adds `provider: ^6.1.0` dependency to support `.environment` Provider wrapping

## Testing

- Widget tests pass: FAB increments counter and triggers rebuilds
- Dispose callback fires exactly once when provider scope is torn down
- No regressions in existing tests