### PR TITLE
M7-01: Add GitHub Actions CI workflow with cached Flutter SDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+    paths-ignore:
+      - "**.md"
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "**.md"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dart-lang/setup-dart@v1
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+          cache: true
+      - run: flutter pub get
+      - run: dart format --set-exit-if-changed .
+      - run: dart analyze --fatal-infos
+      - run: dart analyze packages/solid_generator/test/golden/outputs/
+      - run: dart analyze packages/solid_annotations
+      - run: dart test packages/solid_generator/ -r github --fail-fast
+      - run: flutter test example/ -r github

--- a/TODOS.md
+++ b/TODOS.md
@@ -2446,3 +2446,32 @@ The static rejection conflated the legitimate override case (ancestor `Provider<
 **Status:** DONE — README gains an `## Installation` block (`flutter pub add solid_annotations flutter_solidart provider` plus `dart pub global activate solid_generator`) and an `## Annotations` bullet list naming all four shipped annotations with deep links to their guides; `getting-started.mdx` step 2 install command extended to include `provider` with a one-line rationale paragraph; `environment.mdx` rewritten end-to-end (drops the v1 `SolidProvider` examples, fixes the `@Environment()` typo, restructures into three sections — `## Usage`, `## Providing the instance` showing both the `.environment<T>()` extension and `Provider<T>` widget forms with explicit `dispose:` callbacks plus a `MultiProvider` snippet, and a new `## Disposing the injected instance` section documenting the generated-only `Disposable` marker contract and the empty `void dispose() {}` source-stub pattern). User-facing docs contain no SPEC or milestone references. No code changes; SPEC §3.6 / §13 / §14 item 5 unchanged.
 
 ---
+
+## M7 — Operational: CI workflow
+
+M7 ships the operational scaffolding deferred from SPEC §13. The v2 annotation surface (M1, M4, M5, M6) is closed; M7 adds the CI safety net that runs the M6 exit-criteria verification commands on every PR and every push to `main`.
+
+---
+
+### TODO M7-01 — GitHub Actions CI workflow with cached Flutter SDK
+
+**Goal:** Port the six M6-environment.md exit-criteria verification commands into `.github/workflows/ci.yml`. Single `build` job on `ubuntu-latest`. Triggers: `pull_request` (any branch) and `push` to `main`, both filtered by `paths-ignore: ["**.md"]` so doc-only commits skip CI. Concurrency block (`group: ${{ github.head_ref || github.run_id }}`, `cancel-in-progress: true`) cancels superseded runs on the same PR. Flutter SDK + pub cache restored on subsequent runs via `subosito/flutter-action@v2`'s `cache: true`. Both `dart-lang/setup-dart@v1` and `subosito/flutter-action@v2` installed (mirrors the developer-supplied reference workflow). Test reporter `-r github` on `dart test` and `flutter test` for inline GitHub annotations on failures; `--fail-fast` on `dart test` (`flutter test` does not accept the flag). No coverage / Codecov.
+
+**SPEC references:** Section 13 (CI workflow — the only deferred operational concern; "until GitHub Actions budget permits" — `nank1ro/solid` is public, Actions unmetered, budget non-issue).
+
+**Files to create:**
+
+- `.github/workflows/ci.yml`
+- `plans/features/m7-ci.md`
+
+**Files to modify:**
+
+- `TODOS.md` — add this `## M7` section + this M7-01 entry; flip Status to DONE in the same PR.
+
+**Acceptance:** Workflow file present and parses cleanly. A representative PR shows the `CI / build` check green with all seven step lines passing. Second push to the same PR shows `Cache hit: true` on the `Setup Flutter` step (setup completes in <10s vs ~60s on first run). Pure-`.md` commit on a separate branch does NOT trigger the workflow. Two commits pushed in quick succession on the same PR branch result in the first run being cancelled and only the second completing. Six M6 verification commands (`dart format --set-exit-if-changed .`, `dart analyze --fatal-infos`, `dart analyze packages/solid_generator/test/golden/outputs/`, `dart analyze packages/solid_annotations`, `dart test packages/solid_generator/`, `flutter test example/`) all run as workflow steps.
+
+**Dependencies:** M6-10.
+
+**Status:** DONE — `.github/workflows/ci.yml` ships with one `build` job on `ubuntu-latest`, both `dart-lang/setup-dart@v1` and `subosito/flutter-action@v2` (`channel: "stable"`, `cache: true`) installed. Triggers: `pull_request` (any branch) and `push` to `main`, both filtered with `paths-ignore: ["**.md"]`. `concurrency` block keys on `${{ github.head_ref || github.run_id }}` with `cancel-in-progress: true`. Steps run `flutter pub get` then the six M6 exit-criteria commands: `dart format --set-exit-if-changed .`, three `dart analyze` invocations (root with `--fatal-infos`, `packages/solid_generator/test/golden/outputs/`, `packages/solid_annotations`), `dart test packages/solid_generator/ -r github --fail-fast`, and `flutter test example/ -r github`. Plan doc lives at `plans/features/m7-ci.md` with M7-02 (docs build) and M7-03 (CONTRIBUTING + dependabot + status badge) flagged as candidate follow-ups. Pre-existing `unnecessary_statements` lint on `example/test/effect_widget_test.dart:114` (force-materialize pattern for late-final Effect, mirroring the generator's emitted form) suppressed in-place with `// ignore: unnecessary_statements` and an explanatory comment so `--fatal-infos` reports zero issues.
+
+---

--- a/example/test/effect_widget_test.dart
+++ b/example/test/effect_widget_test.dart
@@ -111,6 +111,10 @@ class _EffectCounterPageState extends State<_EffectCounterPage> {
   @override
   void initState() {
     super.initState();
+    // Materializes the `late final` Effect — the generator emits this exact
+    // pattern (SPEC §3.4 force-materialize) for late-final Effects. The
+    // statement is intentional even though the analyzer cannot tell.
+    // ignore: unnecessary_statements
     recordHistory;
   }
 

--- a/plans/features/m7-ci.md
+++ b/plans/features/m7-ci.md
@@ -1,0 +1,52 @@
+# M7 — Operational: GitHub Actions CI
+
+**TODOS.md items:** M7-01 (more candidate items flagged below; not yet committed to)
+**SPEC sections:** 13 (deferred operational concerns)
+**Reviewer rubric:** `plans/features/reviewer-rubric.md`
+
+## Purpose
+
+M7 ships the deferred operational concern from SPEC §13: a CI workflow that runs the verification commands on every PR and every push to `main`, instead of relying on developer discipline to run them locally. The v2 annotation surface (M1, M4, M5, M6) is closed; what remains is the operational scaffolding around the codebase — CI checks, docs deployment, contributor docs.
+
+The repo is public on GitHub, so Actions minutes are unmetered. SPEC §13's parenthetical "until GitHub Actions budget permits" is moot, and CI can run unconstrained on every event without a minute budget.
+
+The workflow is modeled on a developer-supplied reference: a single `build` job on `ubuntu-latest`, both `dart-lang/setup-dart@v1` and `subosito/flutter-action@v2` installed, `cache: true` on the Flutter action so the SDK and pub cache are restored on subsequent runs, `paths-ignore: ["**.md"]` so doc-only commits skip CI, and a `concurrency` block that cancels superseded runs on the same head ref. The reference's `--coverage` and Codecov upload steps are intentionally dropped — coverage tracking is not part of M7.
+
+A developer after M7-01 can:
+
+1. Open a PR and see a green CI check confirming the six M6-environment.md exit-criteria commands pass: `dart format --set-exit-if-changed`, three `dart analyze` invocations (root, golden outputs, annotations package), `dart test packages/solid_generator/`, and `flutter test example/`.
+2. Push a `.md`-only commit and see CI correctly skip the run.
+3. Push two commits in rapid succession and see the older run cancelled by the `concurrency` block.
+4. Trust that on a second run, the Flutter SDK is restored from cache (setup step <10s) instead of redownloaded.
+
+## TODO sequence
+
+- **M7-01** — `.github/workflows/ci.yml` with a single `build` job on `ubuntu-latest`. Triggers: `pull_request` (any branch) + `push` to `main`, both filtered by `paths-ignore: ["**.md"]`. Steps: checkout, setup-dart, flutter-action with `cache: true`, `flutter pub get`, then the six M6-exit-criteria commands. `-r github` reporter on test runs; `--fail-fast` on `dart test`. No coverage / Codecov.
+
+## Candidate follow-ups (not yet committed to)
+
+- **M7-02** — `.github/workflows/docs.yml` building the Astro site under `docs/` on every PR + push to `main`. Different toolchain (Node + `npm ci && npm run build`); cleaner as its own item with `actions/setup-node@v4` and `cache: npm`.
+- **M7-03** — `CONTRIBUTING.md`, `dependabot.yml` for Dart + GitHub Actions deps, CI status badge in README.
+
+These are listed for visibility, not scoped or estimated. They land only when the user requests them.
+
+## Cross-cutting concerns
+
+- **Pub workspace resolution.** Root `pubspec.yaml` declares `workspace: [packages/solid_annotations, packages/solid_generator, example]`. A single `flutter pub get` at the repo root resolves all three members; per-package `pub get` is unnecessary and duplicates work.
+- **Flutter SDK cache key.** `subosito/flutter-action@v2`'s `cache: true` keys on a hash of the channel + version + the action's bundled cache logic; pub-cache content is keyed on `pubspec.yaml` / `pubspec.lock` content. First run downloads the SDK (~80MB) and primes pub-cache; subsequent runs restore in seconds. No manual `actions/cache` block needed.
+- **`paths-ignore` semantics.** Both `pull_request` and `push` triggers carry the same `paths-ignore: ["**.md"]` filter. A commit that touches only `.md` files (anywhere in the tree) does not trigger CI. A commit that touches a `.md` AND a `.dart` file DOES trigger CI (paths-ignore is "all paths ignored" semantics; any non-ignored path enables the trigger).
+- **Concurrency cancellation.** `group: ${{ github.head_ref || github.run_id }}` keys on the PR head ref when triggered from a PR (so all runs on the same PR share a group), and on the unique run id otherwise (so push-to-main runs never cancel each other). `cancel-in-progress: true` aborts older runs in the same group when a new run starts.
+- **Reporter choice.** `-r github` on `dart test` and `flutter test` emits GitHub Actions workflow commands (`::error::`, `::group::`) so failures are surfaced inline in the PR diff view. Without it, failures land in the raw run log only.
+- **`--fail-fast` asymmetry.** `dart test` accepts `--fail-fast` and stops at the first failing test (useful for golden-test suites where the first divergence is usually informative). `flutter test` does not accept `--fail-fast`; the flag is omitted on that step.
+- **Branch protection (out of scope here, configured separately on GitHub).** For the CI check to actually gate merges, the repo's branch protection rules on `main` need the `build` check marked as required. That's a one-time GitHub-UI action by the repo owner; not part of the workflow file itself.
+
+## Exit criteria
+
+- `.github/workflows/ci.yml` exists and parses cleanly (YAML well-formed).
+- A representative PR shows the `CI / build` check green, with all seven step lines passing.
+- On a second push to the same PR, the `Setup Flutter` step shows `Cache hit: true` and completes in <10s.
+- A pure-`.md` commit on a separate branch does NOT trigger the workflow.
+- Two commits pushed in quick succession on the same PR branch result in the first run being cancelled and only the second completing.
+- M7-01 marked DONE in TODOS.md with a one-line summary mirroring M6-10's format.
+- Reviewer rubric passes on the M7-01 PR.
+- After M7-01 is green: the deferred operational concern from SPEC §13 is satisfied for Dart/Flutter checks. M7-02 (docs build) and M7-03 (CONTRIBUTING + dependabot + status badge) remain optional follow-ups.


### PR DESCRIPTION
## Summary

- Ships `.github/workflows/ci.yml` — single `build` job on `ubuntu-latest` running the six M6 exit-criteria verification commands (`dart format`, three `dart analyze`, `dart test packages/solid_generator/`, `flutter test example/`) on every PR and push to `main`. Modeled on the developer-supplied reference workflow.
- Flutter SDK + pub cache restored on subsequent runs via `subosito/flutter-action@v2`'s `cache: true`. `paths-ignore: ["**.md"]` skips doc-only commits. `concurrency` block cancels superseded runs.
- Suppresses one pre-existing `unnecessary_statements` info on `example/test/effect_widget_test.dart:114` so `dart analyze --fatal-infos` reports zero issues. The flagged line is the SPEC §3.4 force-materialize pattern for a late-final Effect — intentional, mirrors what the generator emits in lowered output.

Closes the only deferred operational concern from SPEC §13. M6 was the last v2-annotation milestone (all four annotations shipped); M7 starts the operational scaffolding. M7-02 (docs build) and M7-03 (CONTRIBUTING + dependabot + status badge) are flagged in `plans/features/m7-ci.md` as candidate follow-ups, not committed to.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` parses cleanly (10 steps in `build` job)
- [x] `flutter pub get` (workspace root) succeeds
- [x] `dart format --set-exit-if-changed .` — 187 files formatted, 0 changed
- [x] `dart analyze --fatal-infos` — no issues
- [x] `dart analyze packages/solid_generator/test/golden/outputs/` — no issues
- [x] `dart analyze packages/solid_annotations` — no issues
- [x] `dart test packages/solid_generator/ -r github --fail-fast` — 140 tests pass
- [x] `flutter test example/ -r github` — 9 tests pass
- [ ] CI run on this PR is green
- [ ] Second push shows `Cache hit: true` on `Setup Flutter` step (<10s setup)
- [ ] `.md`-only commit on a separate branch does NOT trigger the workflow
- [ ] Two rapid pushes to the same PR branch result in the older run being cancelled