### PR TITLE
M8-04: Add const to constructor call sites

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,8 @@
 import 'package:example/counter.dart';
 import 'package:flutter/material.dart';
 
-void main() => runApp(const MaterialApp(home: CounterPage()));
+void main() => runApp(
+  const MaterialApp(
+    home: CounterPage(),
+  ),
+);

--- a/example/source/main.dart
+++ b/example/source/main.dart
@@ -1,4 +1,8 @@
 import 'package:example/counter.dart';
 import 'package:flutter/material.dart';
 
-void main() => runApp(const MaterialApp(home: CounterPage()));
+void main() => runApp(
+  const MaterialApp(
+    home: CounterPage(),
+  ),
+);

--- a/packages/solid_generator/lib/builder.dart
+++ b/packages/solid_generator/lib/builder.dart
@@ -6,6 +6,7 @@ import 'package:dart_style/dart_style.dart';
 
 import 'package:solid_generator/src/annotation_reader.dart';
 import 'package:solid_generator/src/class_kind.dart';
+import 'package:solid_generator/src/const_call_site_rewriter.dart';
 import 'package:solid_generator/src/effect_model.dart';
 import 'package:solid_generator/src/environment_model.dart';
 import 'package:solid_generator/src/field_model.dart';
@@ -308,7 +309,16 @@ String _renderOutput(
   final importBlock = imports.map((u) => "import '$u';").join('\n');
 
   final combined = '$importBlock\n\n$body\n';
-  return _formatter.format(combined);
+  // SPEC §14 item 7 follow-up. M8-03 adds `const` to widget-ctor declarations;
+  // this pass adds `const` to call sites of those declarations elsewhere in
+  // the assembled output (top-level `main()`, rewritten `build` bodies,
+  // passthrough classes — every scope), so `prefer_const_constructors` lint
+  // stays silent end-to-end.
+  final constCtorNames = <String>{
+    for (final r in results) ...r.constCtorNames,
+  };
+  final withConst = addConstAtCallSites(combined, constCtorNames);
+  return _formatter.format(withConst);
 }
 
 /// Returns a [RewriteResult] for [c]: a verbatim slice when the class has
@@ -339,6 +349,7 @@ RewriteResult _passthroughResult(AstNode node, String source) {
     text: source.substring(node.offset, node.end),
     solidartNames: const <String>{},
     emitsDisposable: false,
+    constCtorNames: const <String>{},
   );
 }
 

--- a/packages/solid_generator/lib/src/const_call_site_rewriter.dart
+++ b/packages/solid_generator/lib/src/const_call_site_rewriter.dart
@@ -1,0 +1,153 @@
+import 'package:analyzer/dart/analysis/features.dart';
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:solid_generator/src/value_rewriter.dart';
+
+/// Returns [text] with `const ` prepended to every constructor invocation
+/// whose constructor name is in [constCtorNames] and whose arguments are all
+/// statically const-evaluable.
+///
+/// SPEC §14 item 7 follow-up: M8-03 added `const` to the constructor
+/// *declaration* of an eligible lowered widget. This pass closes the gap on
+/// the call site — `runApp(CounterDisplay())` becomes
+/// `runApp(const CounterDisplay())` so the analyzer's
+/// `prefer_const_constructors` lint stays silent without requiring the user
+/// to run `dart fix --apply` after every build.
+///
+/// The pass parses [text] without resolution, so a bare constructor call like
+/// `Foo()` (no `const` / `new` keyword) appears in the AST as
+/// `MethodInvocation`, not `InstanceCreationExpression` (the latter only
+/// shows up when an explicit keyword is present, or under resolved
+/// analysis). Both forms are handled — the visitor walks each, computes the
+/// full constructor name as `"$Type"` (unnamed) or `"$Type.$name"` (named),
+/// and matches against [constCtorNames] populated by the rewriters that
+/// emit const-eligible widget constructors.
+///
+/// `const` is added only at the OUTERMOST const-eligible position in any
+/// expression tree. Once the outer call becomes a const constructor
+/// invocation, Dart's const-context elision makes the explicit `const`
+/// redundant on every nested const-eligible call (and would trip
+/// `unnecessary_const`). The visitor implements this by short-circuiting
+/// the recursion at every promoted node — children are not visited, so they
+/// cannot accumulate their own `const` insertions.
+///
+/// Argument const-evaluability is conservative — accepts only the literal
+/// forms `_isLiteralRhs` accepted in M8-03 plus already-`const`
+/// `InstanceCreationExpression`s and constructor-call sites whose class is
+/// in [constCtorNames] (i.e., would *also* be made const by this pass).
+/// Identifier reads, method invocations of non-class names, operators,
+/// string interpolations, list/map/set literals, and explicitly-`new`
+/// expressions are rejected. This is the smallest rule that lints clean for
+/// the M1-13 (`Counter(title: 'count=$value')` — rejected because of string
+/// interpolation) and M1-14 + M8-04 (`CounterDisplay()` /
+/// `Outer(child: Inner())` — accepted) cases without requiring resolved-AST
+/// analysis. Identifier-RHS, `AdjacentStrings`, and list/map literal
+/// const-evaluability are tractable future extensions.
+String addConstAtCallSites(String text, Set<String> constCtorNames) {
+  if (constCtorNames.isEmpty) return text;
+
+  final parsed = parseString(
+    content: text,
+    featureSet: FeatureSet.latestLanguageVersion(),
+    throwIfDiagnostics: false,
+  );
+  final visitor = _ConstCallSiteVisitor(constCtorNames);
+  parsed.unit.accept(visitor);
+  if (visitor.insertOffsets.isEmpty) return text;
+
+  final edits = [
+    for (final offset in visitor.insertOffsets)
+      ValueEdit(offset, offset, 'const '),
+  ];
+  return applyEditsToRange(text, edits, 0);
+}
+
+class _ConstCallSiteVisitor extends RecursiveAstVisitor<void> {
+  _ConstCallSiteVisitor(this._constCtorNames);
+
+  final Set<String> _constCtorNames;
+  final List<int> insertOffsets = [];
+
+  @override
+  void visitInstanceCreationExpression(InstanceCreationExpression node) {
+    final keyword = node.keyword?.lexeme;
+    // Already-const / explicit-new expressions are left alone — adding our
+    // own `const` would be either redundant or incorrect.
+    if (keyword == 'const' || keyword == 'new') {
+      super.visitInstanceCreationExpression(node);
+      return;
+    }
+    final fullName = node.constructorName.toString();
+    if (_constCtorNames.contains(fullName) &&
+        _argsAreConstEvaluable(node.argumentList)) {
+      insertOffsets.add(node.offset);
+      return;
+    }
+    super.visitInstanceCreationExpression(node);
+  }
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    final fullName = _ctorNameFromMethodInvocation(node);
+    if (fullName != null &&
+        _constCtorNames.contains(fullName) &&
+        _argsAreConstEvaluable(node.argumentList)) {
+      insertOffsets.add(node.offset);
+      return;
+    }
+    super.visitMethodInvocation(node);
+  }
+
+  /// Computes the constructor-name string for a [MethodInvocation] that
+  /// could be a bare (unresolved) constructor call. Returns null when the
+  /// shape is incompatible with a constructor invocation — typically a
+  /// non-`SimpleIdentifier` target (e.g., a chained property access or
+  /// another invocation).
+  String? _ctorNameFromMethodInvocation(MethodInvocation node) {
+    final target = node.target;
+    if (target == null) return node.methodName.name;
+    if (target is SimpleIdentifier) {
+      return '${target.name}.${node.methodName.name}';
+    }
+    return null;
+  }
+
+  bool _argsAreConstEvaluable(ArgumentList args) {
+    for (final arg in args.arguments) {
+      final inner = arg is NamedExpression ? arg.expression : arg;
+      if (!_isConstEvaluable(inner)) return false;
+    }
+    return true;
+  }
+
+  bool _isConstEvaluable(Expression expr) {
+    if (expr is BooleanLiteral ||
+        expr is DoubleLiteral ||
+        expr is IntegerLiteral ||
+        expr is NullLiteral ||
+        expr is SimpleStringLiteral ||
+        expr is SymbolLiteral) {
+      return true;
+    }
+    if (expr is InstanceCreationExpression) {
+      final keyword = expr.keyword?.lexeme;
+      if (keyword == 'const') return true;
+      // `new Foo(42)` is explicitly non-const — rejecting here keeps
+      // `_isConstEvaluable` symmetric with `visitInstanceCreationExpression`,
+      // so an outer site never gets promoted on the strength of a `new` arg.
+      if (keyword == 'new') return false;
+      if (!_constCtorNames.contains(expr.constructorName.toString())) {
+        return false;
+      }
+      return _argsAreConstEvaluable(expr.argumentList);
+    }
+    if (expr is MethodInvocation) {
+      final fullName = _ctorNameFromMethodInvocation(expr);
+      if (fullName == null) return false;
+      if (!_constCtorNames.contains(fullName)) return false;
+      return _argsAreConstEvaluable(expr.argumentList);
+    }
+    return false;
+  }
+}

--- a/packages/solid_generator/lib/src/import_rewriter.dart
+++ b/packages/solid_generator/lib/src/import_rewriter.dart
@@ -48,10 +48,20 @@ const Set<String> solidartNames = {
 /// into the lowered class header (SPEC §10 marker rule). The builder unions
 /// this flag across results to decide whether to keep the `solid_annotations`
 /// import.
+///
+/// `constCtorNames` is the set of constructor invocation names (matching
+/// `InstanceCreationExpression.constructorName.toString()`) that this
+/// rewriter emitted with a `const` keyword on their declaration — `"Counter"`
+/// for the unnamed ctor, `"Counter.named"` for a named ctor. The builder
+/// unions these across all results and runs a post-emit pass that prepends
+/// `const ` to matching call sites elsewhere in the assembled output (SPEC
+/// §14 item 7 — keeps `prefer_const_constructors` silent end-to-end without
+/// requiring the user to run `dart fix`).
 typedef RewriteResult = ({
   String text,
   Set<String> solidartNames,
   bool emitsDisposable,
+  Set<String> constCtorNames,
 });
 
 /// Returns the import URIs that should appear at the top of the generated

--- a/packages/solid_generator/lib/src/plain_class_rewriter.dart
+++ b/packages/solid_generator/lib/src/plain_class_rewriter.dart
@@ -197,6 +197,7 @@ RewriteResult rewritePlainClass(
       if (solidQueries.any((q) => q.needsSourceComputed)) 'Computed',
     },
     emitsDisposable: true,
+    constCtorNames: const <String>{},
   );
 }
 

--- a/packages/solid_generator/lib/src/state_class_rewriter.dart
+++ b/packages/solid_generator/lib/src/state_class_rewriter.dart
@@ -212,6 +212,7 @@ RewriteResult rewriteStateClass(
       if (solidQueries.any((q) => q.needsSourceComputed)) 'Computed',
     },
     emitsDisposable: false,
+    constCtorNames: const <String>{},
   );
 }
 

--- a/packages/solid_generator/lib/src/stateless_rewriter.dart
+++ b/packages/solid_generator/lib/src/stateless_rewriter.dart
@@ -62,10 +62,11 @@ RewriteResult rewriteStatelessWidget(
     widgetBoundNames,
     partitionExcludeNames,
   );
-  final ctorsBlock = _emitCtors(
+  final emittedCtors = _emitCtors(
     members.ctors,
     source,
     classFieldsAreConstSafe,
+    className,
   );
   // SPEC §5.1 M6-04 cross-class env-field receiver type map.
   final environmentFields = solidEnvironments.isEmpty
@@ -101,7 +102,7 @@ RewriteResult rewriteStatelessWidget(
   final widgetClass = _emitWidgetClass(
     className,
     stateClassName,
-    ctorsBlock,
+    emittedCtors.text,
     partition.widgetFieldsText,
   );
   final stateClass = _emitStateClass(
@@ -141,6 +142,7 @@ RewriteResult rewriteStatelessWidget(
     text: '$widgetClass\n\n$stateClass\n',
     solidartNames: solidartNames,
     emitsDisposable: false,
+    constCtorNames: emittedCtors.constCtorNames,
   );
 }
 
@@ -338,7 +340,7 @@ _FieldPartition _partitionFields(
 
 /// Emits every constructor 2-space indented and joined by blank lines,
 /// prefixing `const ` on each ctor that is statically determinable
-/// const-eligible per SPEC §14 item 7. Returns an empty string when [ctors]
+/// const-eligible per SPEC §14 item 7. Returns an empty `text` when [ctors]
 /// is empty (Dart synthesises the implicit default constructor on the
 /// rewritten class).
 ///
@@ -347,19 +349,32 @@ _FieldPartition _partitionFields(
 /// (and non-static / non-const), in which case NO ctor on the class can
 /// be const regardless of its own shape. When true, each ctor is checked
 /// individually via [_isConstEligibleCtor].
-String _emitCtors(
+///
+/// `constCtorNames` enumerates the constructor invocation names that gained
+/// `const` — `"$className"` for the unnamed ctor, `"$className.<name>"` for
+/// named ctors — used by the post-emit call-site rewriter to decide which
+/// `InstanceCreationExpression`s elsewhere in the output to promote.
+({String text, Set<String> constCtorNames}) _emitCtors(
   List<ConstructorDeclaration> ctors,
   String source,
   bool classFieldsAreConstSafe,
+  String className,
 ) {
-  if (ctors.isEmpty) return '';
-  return ctors
-      .map((c) {
-        final text = source.substring(c.offset, c.end);
-        final addConst = classFieldsAreConstSafe && _isConstEligibleCtor(c);
-        return addConst ? '  const $text' : '  $text';
-      })
-      .join('\n\n');
+  if (ctors.isEmpty) return (text: '', constCtorNames: const <String>{});
+  final constCtorNames = <String>{};
+  final pieces = <String>[];
+  for (final c in ctors) {
+    final ctorText = source.substring(c.offset, c.end);
+    final addConst = classFieldsAreConstSafe && _isConstEligibleCtor(c);
+    if (addConst) {
+      final name = c.name?.lexeme;
+      constCtorNames.add(name == null ? className : '$className.$name');
+      pieces.add('  const $ctorText');
+    } else {
+      pieces.add('  $ctorText');
+    }
+  }
+  return (text: pieces.join('\n\n'), constCtorNames: constCtorNames);
 }
 
 /// Returns true iff [ctor] alone meets the per-ctor const-eligibility

--- a/packages/solid_generator/test/golden/inputs/m8_04_const_call_site_top_level.dart
+++ b/packages/solid_generator/test/golden/inputs/m8_04_const_call_site_top_level.dart
@@ -1,0 +1,45 @@
+// SPEC §14 item 7 follow-up — `const` at call sites of generator-emitted
+// const-eligible widget classes. After M8-03 added `const` to the constructor
+// declaration, this rewrite adds `const` to invocations of those constructors
+// elsewhere in the output so `prefer_const_constructors` stays silent
+// end-to-end.
+//
+// Validates three cases in one fixture:
+//   (a) top-level `main()` body — passthrough scope.
+//   (b) inside another widget's rewritten `build()` body — the post-emit pass
+//       walks the assembled output, so it catches sites that survived the
+//       value-rewriter.
+//   (c) const elision — when both the outer and an inner `InstanceCreation`
+//       are const-eligible, only the outermost gains an explicit `const`;
+//       Dart's const-context elision covers the nested one.
+
+import 'package:flutter/widgets.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+void main() => runApp(Outer(child: Inner()));
+
+class Inner extends StatelessWidget {
+  Inner({super.key});
+
+  @SolidState()
+  int n = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text('$n');
+  }
+}
+
+class Outer extends StatelessWidget {
+  Outer({super.key, required this.child});
+
+  final Widget child;
+
+  @SolidState()
+  int m = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(children: [Text('$m'), child, Inner()]);
+  }
+}

--- a/packages/solid_generator/test/golden/outputs/m1_14_top_level_function_preserved.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m1_14_top_level_function_preserved.g.dart
@@ -4,7 +4,9 @@ import 'package:provider/provider.dart';
 import 'package:solid_annotations/solid_annotations.dart';
 
 void main() {
-  runApp(MaterialApp(home: CounterDisplay().environment((_) => Counter())));
+  runApp(
+    MaterialApp(home: const CounterDisplay().environment((_) => Counter())),
+  );
 }
 
 class Counter implements Disposable {

--- a/packages/solid_generator/test/golden/outputs/m8_04_const_call_site_top_level.g.dart
+++ b/packages/solid_generator/test/golden/outputs/m8_04_const_call_site_top_level.g.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+void main() => runApp(const Outer(child: Inner()));
+
+class Inner extends StatefulWidget {
+  const Inner({super.key});
+
+  @override
+  State<Inner> createState() => _InnerState();
+}
+
+class _InnerState extends State<Inner> {
+  final n = Signal<int>(0, name: 'n');
+
+  @override
+  void dispose() {
+    n.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SignalBuilder(
+      builder: (context, child) {
+        return Text('${n.value}');
+      },
+    );
+  }
+}
+
+class Outer extends StatefulWidget {
+  const Outer({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  State<Outer> createState() => _OuterState();
+}
+
+class _OuterState extends State<Outer> {
+  final m = Signal<int>(0, name: 'm');
+
+  @override
+  void dispose() {
+    m.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        SignalBuilder(
+          builder: (context, child) {
+            return Text('${m.value}');
+          },
+        ),
+        widget.child,
+        const Inner(),
+      ],
+    );
+  }
+}

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -72,6 +72,7 @@ const List<String> goldenNames = <String>[
   'm8_03_const_ctor_field_formal',
   'm8_03_const_ctor_literal_initializer',
   'm8_03_const_ctor_assert_preserved',
+  'm8_04_const_call_site_top_level',
   'm1_14_top_level_function_preserved',
   'm1_15_top_level_variable_preserved',
   'm1_16_top_level_extension_preserved',


### PR DESCRIPTION
## Summary

- Adds `const` keyword to constructor invocation call sites whose declarations were made const in M8-03
- Implements `const_call_site_rewriter.dart` — a post-emit pass that walks the assembled output and promotes const-eligible constructor invocations
- Handles both explicit `InstanceCreationExpression` forms and bare `MethodInvocation` forms (unresolved constructor calls)
- Promotes only the outermost const-eligible position in any expression tree — nested calls benefit from Dart's const-context elision, avoiding `unnecessary_const` lint warnings
- Conservative const-evaluability check for arguments: accepts literals, already-const constructors, and constructors marked const by this pass
- Closes the gap from M8-03 so `prefer_const_constructors` lint stays silent end-to-end without requiring `dart fix` from the user

## Testing

- [x] New golden test input/output `m8_04_const_call_site_top_level` validates three cases: top-level `main()` body passthrough, nested widget calls in `build()` bodies, and const elision (outermost call only)
- [x] Updated golden `m1_14_top_level_function_preserved` to verify call-site const propagation in existing M1-14 case
- [x] Example project `main.dart` and source updated to reflect const promotion
- [x] Argument const-evaluability conservative and well-defined — rejects identifiers, method calls, interpolations, `new` expressions, and collection literals