### PR TITLE
Add collection signals and plain class constructor support

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -568,6 +568,39 @@ Output:
 final counter = Signal<int>(0, name: 'myCounter');
 ```
 
+### 4.4b Collection field → ListSignal / SetSignal / MapSignal
+
+When a `@SolidState` field's declared type is `List<T>`, `Set<T>`, or `Map<K, V>` and the field has an initializer (not `late`, not nullable), the generator emits `ListSignal<T>(<init>, name: '…')`, `SetSignal<T>(<init>, name: '…')`, or `MapSignal<K, V>(<init>, name: '…')` respectively.
+
+Input:
+
+```dart
+@SolidState()
+List<int> xs = const [];
+
+@SolidState()
+Set<String> tags = const {};
+
+@SolidState()
+Map<String, int> scores = const {};
+```
+
+Output:
+
+```dart
+final xs = ListSignal<int>(const [], name: 'xs');
+final tags = SetSignal<String>(const {}, name: 'tags');
+final scores = MapSignal<String, int>(const {}, name: 'scores');
+```
+
+`ListSignal<T>` / `SetSignal<T>` / `MapSignal<K, V>` extend `Signal<List<T>>` / `Signal<Set<T>>` / `Signal<Map<K, V>>` and mix in `ListMixin<T>` / `SetMixin<T>` / `MapMixin<K, V>`, exposing the full collection API directly on the signal. Chain reads (`xs.length`, `xs.where(...)`, `xs[i]`, `scores.containsKey(...)`) and direct mutations (`xs.add`, `xs.removeAt`, `xs[i] = v`, `scores[k] = v`) do not receive a `.value` insertion — the rewriter recognises collection fields and leaves the chain verbatim. Writes through the bare field name (`xs = newList`) still rewrite to `xs.value = newList` so the underlying Signal setter notifies subscribers.
+
+Fallbacks (matching the scalar paths so the existing `late` / nullable rules still apply):
+- `@SolidState() late List<T> xs;` (no initializer) → `Signal<List<T>>.lazy(name: 'xs')` — collection signals have no `.lazy` constructor.
+- `@SolidState() List<T>? xs;` (nullable) → `Signal<List<T>?>(null, name: 'xs')` — collection signals reject null at the signal level.
+
+Cross-class rule: when a `@SolidEnvironment late T x;` field's receiver type carries a `@SolidState` collection field on a sibling class (same file OR another file resolved via the import-pass), the cross-class chain rewrite skips the `.value` insertion between receiver and field — `controller.todos.length` resolves through `ListSignal<Todo>.length` directly. Tracking still fires so the surrounding widget subtree is wrapped in `SignalBuilder`.
+
 ### 4.5 Getter → Computed
 
 Input:
@@ -1344,7 +1377,16 @@ No class rewriting. Reactive declarations and build rewriting happen in-place on
 
 ### 8.3 Plain class (no Widget superclass) with `@SolidState`
 
-Reactive declarations are applied in-place. A `dispose()` method is synthesized that disposes every generated Signal/Computed. The class header gains `implements Disposable` per the Section 10 merge rule, and the synthesized `dispose()` carries `@override`. No State wrapper.
+Reactive declarations are applied in-place. A `dispose()` method is synthesized that disposes every generated Signal / ListSignal / SetSignal / MapSignal / Computed / Effect / Resource. The class header gains `implements Disposable` per the Section 10 merge rule, and the synthesized `dispose()` carries `@override`. No State wrapper.
+
+Supported member shapes on a plain class:
+- `@SolidState` field (scalar + collection — see §4.1, §4.4b).
+- `@SolidState` getter → `late final … = Computed<T>(…)`, identical lowering to the StatelessWidget case (§4.5–4.6).
+- `@SolidEffect` method → `late final … = Effect(…)`, materialised in a synthesized no-arg constructor body (the plain-class analogue of `initState()`).
+- `@SolidQuery` method → `late final … = Resource<T>(…)`.
+- User-declared constructor(s) — see the "Constructor body merge" subsection of §10.
+- User-declared `dispose()` — see the "`dispose()` body merge" subsection of §10.
+- Non-annotated user methods — bodies receive the §5.1 same-class `.value` rewrite plus the single-level cross-class slice from `[classRegistry]`.
 
 Source:
 
@@ -1509,6 +1551,60 @@ class Counter implements Disposable {
 ```
 
 Plain classes have no `super.dispose()` to relocate (no superclass dispose chain unless the user wrote `extends Foo`, in which case the user's body already includes whatever super call they wrote, and the generator preserves it untouched).
+
+### Constructor body merge (plain classes with user-defined constructor)
+
+When the source plain class has a user-declared constructor (zero or more, unnamed and/or named) AND reactive declarations, the generator preserves each generative constructor verbatim and:
+
+1. Strips a leading `const ` modifier from each ctor header — the lowered class holds mutable `Signal<T>` / `Computed<T>` / `Effect` instances, so `const` is no longer compile-valid.
+2. Applies the §5.1 type-driven `.value` rewrite to the body. Same-class assignments to a `@SolidState` field become `<name>.value = …` (the Signal setter) so the mutation notifies subscribers. Collection-field writes inside the body follow the §4.4b rule (`xs.add(item)` stays verbatim; `xs = newList` rewrites to `xs.value = newList`).
+3. If the class declares any `@SolidEffect`, appends one `<effectName>;` line per effect at the END of each generative ctor's body — the same Effect-materialization splice the State class's `initState()` performs. This force-touches each `late final Effect` field so its factory runs during construction.
+
+Factory constructors round-trip verbatim — their body is a delegating return, not a host-state initialiser, so spliced Effect reads would never fire.
+
+When the user has NOT declared any constructor AND the class has at least one `@SolidEffect`, the generator synthesises a no-arg constructor whose body is just the Effect-materialization reads (unchanged from the pre-merge behaviour).
+
+Source:
+
+```dart
+class Counter {
+  Counter({int init = 0}) {
+    value = init;
+  }
+
+  @SolidState()
+  late int value;
+
+  @SolidEffect()
+  void log() {
+    print('value: $value');
+  }
+}
+```
+
+Output:
+
+```dart
+class Counter implements Disposable {
+  Counter({int init = 0}) {
+    value.value = init;
+
+    log;
+  }
+
+  late final value = Signal<int>.lazy(name: 'value');
+
+  late final log = Effect(() {
+    print('value: ${value.value}');
+  }, name: 'log');
+
+  @override
+  void dispose() {
+    log.dispose();
+    value.dispose();
+  }
+}
+```
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -570,7 +570,7 @@ final counter = Signal<int>(0, name: 'myCounter');
 
 ### 4.4b Collection field → ListSignal / SetSignal / MapSignal
 
-When a `@SolidState` field's declared type is `List<T>`, `Set<T>`, or `Map<K, V>` and the field has an initializer (not `late`, not nullable), the generator emits `ListSignal<T>(<init>, name: '…')`, `SetSignal<T>(<init>, name: '…')`, or `MapSignal<K, V>(<init>, name: '…')` respectively.
+When a `@SolidState` field's declared type is `List<T>`, `Set<T>`, or `Map<K, V>` and the field is non-nullable, the generator emits `ListSignal<T>(<init>, name: '…')`, `SetSignal<T>(<init>, name: '…')`, or `MapSignal<K, V>(<init>, name: '…')` respectively. The `late` and `final` modifiers are not barriers: collection signals are mutated in place through their mixin (`ListMixin` / `SetMixin` / `MapMixin`) methods, so the reference being final — or its construction being lazy — doesn't affect reactivity.
 
 Input:
 
@@ -583,6 +583,16 @@ Set<String> tags = const {};
 
 @SolidState()
 Map<String, int> scores = const {};
+
+// late — no initializer — emitter supplies an empty literal for each.
+@SolidState()
+late List<int> ys;
+
+@SolidState()
+late Set<String> markers;
+
+@SolidState()
+late Map<String, int> hits;
 ```
 
 Output:
@@ -591,13 +601,16 @@ Output:
 final xs = ListSignal<int>(const [], name: 'xs');
 final tags = SetSignal<String>(const {}, name: 'tags');
 final scores = MapSignal<String, int>(const {}, name: 'scores');
+late final ys = ListSignal<int>(const <int>[], name: 'ys');
+late final markers = SetSignal<String>(const <String>{}, name: 'markers');
+late final hits = MapSignal<String, int>(const <String, int>{}, name: 'hits');
 ```
 
-`ListSignal<T>` / `SetSignal<T>` / `MapSignal<K, V>` extend `Signal<List<T>>` / `Signal<Set<T>>` / `Signal<Map<K, V>>` and mix in `ListMixin<T>` / `SetMixin<T>` / `MapMixin<K, V>`, exposing the full collection API directly on the signal. Chain reads (`xs.length`, `xs.where(...)`, `xs[i]`, `scores.containsKey(...)`) and direct mutations (`xs.add`, `xs.removeAt`, `xs[i] = v`, `scores[k] = v`) do not receive a `.value` insertion — the rewriter recognises collection fields and leaves the chain verbatim. Writes through the bare field name (`xs = newList`) still rewrite to `xs.value = newList` so the underlying Signal setter notifies subscribers.
+When the source has no `= …` clause, the emitter splices an empty literal (`const <T>[]` for `List`, `const <T>{}` for `Set`, `const <K, V>{}` for `Map`). The source `late` modifier is preserved on the emitted field so signal construction still defers to first access.
 
-Fallbacks (matching the scalar paths so the existing `late` / nullable rules still apply):
-- `@SolidState() late List<T> xs;` (no initializer) → `Signal<List<T>>.lazy(name: 'xs')` — collection signals have no `.lazy` constructor.
-- `@SolidState() List<T>? xs;` (nullable) → `Signal<List<T>?>(null, name: 'xs')` — collection signals reject null at the signal level.
+`ListSignal<T>` / `SetSignal<T>` / `MapSignal<K, V>` extend `Signal<List<T>>` / `Signal<Set<T>>` / `Signal<Map<K, V>>` and mix in `ListMixin<T>` / `SetMixin<T>` / `MapMixin<K, V>`, exposing the full collection API directly on the signal. Chain reads (`xs.length`, `xs.where(...)`, `xs[i]`, `scores.containsKey(...)`), direct mutations (`xs.add`, `xs.removeAt`, `xs[i] = v`, `scores[k] = v`), and cascades (`xs..add(1)..add(2)..sort()`) do not receive a `.value` insertion — the rewriter recognises collection fields and leaves the chain verbatim. Writes through the bare field name (`xs = newList`) still rewrite to `xs.value = newList` so the underlying Signal setter notifies subscribers.
+
+Nullable fallback: `T?` collection types fall back to plain `Signal<List<T>?>(null, name: 'xs')` — collection signals reject null at the signal level.
 
 Cross-class rule: when a `@SolidEnvironment late T x;` field's receiver type carries a `@SolidState` collection field on a sibling class (same file OR another file resolved via the import-pass), the cross-class chain rewrite skips the `.value` insertion between receiver and field — `controller.todos.length` resolves through `ListSignal<Todo>.length` directly. Tracking still fires so the surrounding widget subtree is wrapped in `SignalBuilder`.
 

--- a/examples/todos/analysis_options.yaml
+++ b/examples/todos/analysis_options.yaml
@@ -1,0 +1,20 @@
+include: package:very_good_analysis/analysis_options.yaml
+analyzer:
+  # `source/` is the user-written input to the Solid generator. The
+  # analyzer resolves `package:todos_example/...` imports to the generated
+  # `lib/` types (post-transformation), so cross-class chain reads in
+  # `source/` appear as type errors against `Signal<T>` / `ListSignal<T>`
+  # — which the generator rewrites in lib/. Excluding the directory keeps
+  # the IDE focused on the actual runnable output without losing source
+  # control of the inputs (still under git).
+  exclude:
+    - source/**
+  errors:
+    must_be_immutable: ignore
+    always_put_required_named_parameters_first: ignore
+    invalid_annotation_target: ignore
+    avoid_print: ignore
+    unnecessary_statements: ignore
+linter:
+  rules:
+    public_member_api_docs: false

--- a/examples/todos/analysis_options.yaml
+++ b/examples/todos/analysis_options.yaml
@@ -15,6 +15,17 @@ analyzer:
     invalid_annotation_target: ignore
     avoid_print: ignore
     unnecessary_statements: ignore
+    # Generated `lib/` interpolated tab labels like
+    # `'incomplete (${todosController.incompleteTodos.value.length})'`
+    # exceed 80 chars after `dart format` chooses a single-line wrap.
+    # The text is intentionally not split (interpolation contents are not
+    # line-breakable); suppress at the example level.
+    lines_longer_than_80_chars: ignore
+    # Generated env-injection fields are `late final foo =
+    # context.read<Foo>();` (no explicit type). The Dart analyzer infers
+    # `Foo` from the generic call but `very_good_analysis` treats this as
+    # non-obvious. The type IS clear from the receiver; suppress here.
+    specify_nonobvious_property_types: ignore
 linter:
   rules:
     public_member_api_docs: false

--- a/examples/todos/build.yaml
+++ b/examples/todos/build.yaml
@@ -1,0 +1,6 @@
+targets:
+  $default:
+    sources:
+      - source/**
+      - lib/**
+      - $package$

--- a/examples/todos/lib/controllers/filter.dart
+++ b/examples/todos/lib/controllers/filter.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:todos_example/domain/todo.dart';
+
+class FilterController implements Disposable {
+  final filter = Signal<TodosFilter>(TodosFilter.all, name: 'filter');
+
+  @override
+  void dispose() {
+    filter.dispose();
+  }
+}

--- a/examples/todos/lib/controllers/todos.dart
+++ b/examples/todos/lib/controllers/todos.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:todos_example/domain/todo.dart';
+
+class TodosController implements Disposable {
+  TodosController({List<Todo> initialTodos = const []}) {
+    todos.addAll(initialTodos);
+  }
+
+  final todos = ListSignal<Todo>(const [], name: 'todos');
+
+  late final completedTodos = Computed<List<Todo>>(
+    () => todos.value.where((t) => t.completed).toList(),
+    name: 'completedTodos',
+  );
+
+  late final incompleteTodos = Computed<List<Todo>>(
+    () => todos.value.where((t) => !t.completed).toList(),
+    name: 'incompleteTodos',
+  );
+
+  void add(Todo todo) => todos.add(todo);
+
+  void remove(String id) => todos.removeWhere((t) => t.id == id);
+
+  void toggle(String id) {
+    final i = todos.indexWhere((t) => t.id == id);
+    todos[i] = todos[i].copyWith(completed: !todos[i].completed);
+  }
+
+  @override
+  void dispose() {
+    incompleteTodos.dispose();
+    completedTodos.dispose();
+    todos.dispose();
+  }
+}

--- a/examples/todos/lib/controllers/todos.dart
+++ b/examples/todos/lib/controllers/todos.dart
@@ -10,12 +10,12 @@ class TodosController implements Disposable {
   final todos = ListSignal<Todo>(const [], name: 'todos');
 
   late final completedTodos = Computed<List<Todo>>(
-    () => todos.value.where((t) => t.completed).toList(),
+    () => todos.where((t) => t.completed).toList(),
     name: 'completedTodos',
   );
 
   late final incompleteTodos = Computed<List<Todo>>(
-    () => todos.value.where((t) => !t.completed).toList(),
+    () => todos.where((t) => !t.completed).toList(),
     name: 'incompleteTodos',
   );
 

--- a/examples/todos/lib/domain/todo.dart
+++ b/examples/todos/lib/domain/todo.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/foundation.dart';
+import 'package:uuid/uuid.dart';
+
+@immutable
+class Todo {
+  const Todo({
+    required this.id,
+    required this.task,
+    required this.completed,
+  });
+
+  factory Todo.create(String task) {
+    return Todo(id: const Uuid().v4(), task: task, completed: false);
+  }
+
+  final String id;
+  final String task;
+  final bool completed;
+
+  static List<Todo> get sample {
+    return [
+      Todo.create('Learn Solid'),
+      Todo.create('Wash the car'),
+      Todo.create('Go shopping'),
+    ];
+  }
+
+  Todo copyWith({bool? completed}) {
+    return Todo(id: id, task: task, completed: completed ?? this.completed);
+  }
+}
+
+enum TodosFilter { all, incomplete, completed }

--- a/examples/todos/lib/main.dart
+++ b/examples/todos/lib/main.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:todos_example/controllers/filter.dart';
+import 'package:todos_example/controllers/todos.dart';
+import 'package:todos_example/domain/todo.dart';
+import 'package:todos_example/pages/todos.dart';
+
+void main() {
+  SolidartConfig.autoDispose = false;
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Todos Example',
+      home: const TodosPage()
+          .environment(
+            (_) => TodosController(initialTodos: Todo.sample),
+            dispose: (context, provider) => provider.dispose(),
+          )
+          .environment(
+            (_) => FilterController(),
+            dispose: (context, provider) => provider.dispose(),
+          ),
+    );
+  }
+}

--- a/examples/todos/lib/pages/todos.dart
+++ b/examples/todos/lib/pages/todos.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:todos_example/widgets/todos_body.dart';
+
+class TodosPage extends StatelessWidget {
+  const TodosPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Todos')),
+      body: const Padding(
+        padding: EdgeInsets.all(8),
+        child: TodosBody(),
+      ),
+    );
+  }
+}

--- a/examples/todos/lib/widgets/todo_item.dart
+++ b/examples/todos/lib/widgets/todo_item.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:todos_example/controllers/todos.dart';
+import 'package:todos_example/domain/todo.dart';
+
+class TodoItem extends StatefulWidget {
+  const TodoItem({super.key, required this.todo});
+
+  final Todo todo;
+
+  @override
+  State<TodoItem> createState() => _TodoItemState();
+}
+
+class _TodoItemState extends State<TodoItem> {
+  late final todosController = context.read<TodosController>();
+
+  @override
+  Widget build(BuildContext context) {
+    return Dismissible(
+      key: ValueKey(widget.todo.id),
+      direction: DismissDirection.endToStart,
+      onDismissed: (_) => todosController.remove(widget.todo.id),
+      background: Container(
+        decoration: const BoxDecoration(color: Colors.red),
+        alignment: Alignment.centerRight,
+        padding: const EdgeInsets.only(right: 8),
+        child: const Icon(Icons.delete, color: Colors.white),
+      ),
+      child: CheckboxListTile(
+        title: Text(widget.todo.task),
+        value: widget.todo.completed,
+        onChanged: (_) => todosController.toggle(widget.todo.id),
+      ),
+    );
+  }
+}

--- a/examples/todos/lib/widgets/todos_body.dart
+++ b/examples/todos/lib/widgets/todos_body.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:todos_example/controllers/todos.dart';
+import 'package:todos_example/domain/todo.dart';
+import 'package:todos_example/widgets/todos_list.dart';
+import 'package:todos_example/widgets/toolbar.dart';
+
+class TodosBody extends StatefulWidget {
+  const TodosBody({super.key});
+
+  @override
+  State<TodosBody> createState() => _TodosBodyState();
+}
+
+class _TodosBodyState extends State<TodosBody> {
+  late final todosController = context.read<TodosController>();
+
+  final _textController = TextEditingController();
+
+  @override
+  void dispose() {
+    _textController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        TextFormField(
+          controller: _textController,
+          decoration: const InputDecoration(hintText: 'Write new todo'),
+          validator: (v) {
+            if (v == null || v.isEmpty) return 'Cannot be empty';
+            return null;
+          },
+          onFieldSubmitted: (task) {
+            if (task.isEmpty) return;
+            todosController.add(Todo.create(task));
+            _textController.clear();
+          },
+        ),
+        const SizedBox(height: 16),
+        const Toolbar(),
+        const SizedBox(height: 16),
+        const Expanded(child: TodoList()),
+      ],
+    );
+  }
+}

--- a/examples/todos/lib/widgets/todos_list.dart
+++ b/examples/todos/lib/widgets/todos_list.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:provider/provider.dart';
+import 'package:todos_example/controllers/filter.dart';
+import 'package:todos_example/controllers/todos.dart';
+import 'package:todos_example/domain/todo.dart';
+import 'package:todos_example/widgets/todo_item.dart';
+
+class TodoList extends StatefulWidget {
+  const TodoList({super.key});
+
+  @override
+  State<TodoList> createState() => _TodoListState();
+}
+
+class _TodoListState extends State<TodoList> {
+  late final todosController = context.read<TodosController>();
+  late final filterController = context.read<FilterController>();
+  late final filteredTodos = Computed<List<Todo>>(() {
+    switch (filterController.filter.value) {
+      case TodosFilter.all:
+        // `.toList()` returns a fresh copy so the Computed's default
+        // `identical` comparator sees a new reference whenever the
+        // underlying `ListSignal` mutates (in-place adds keep the same
+        // reference, which would suppress invalidation).
+        return todosController.todos.toList();
+      case TodosFilter.incomplete:
+        return todosController.incompleteTodos.value;
+      case TodosFilter.completed:
+        return todosController.completedTodos.value;
+    }
+  }, name: 'filteredTodos');
+
+  @override
+  void dispose() {
+    filteredTodos.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SignalBuilder(
+      builder: (context, child) {
+        return ListView(
+          children: [
+            for (final todo in filteredTodos.value) TodoItem(todo: todo),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/examples/todos/lib/widgets/toolbar.dart
+++ b/examples/todos/lib/widgets/toolbar.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:provider/provider.dart';
+import 'package:todos_example/controllers/filter.dart';
+import 'package:todos_example/controllers/todos.dart';
+import 'package:todos_example/domain/todo.dart';
+
+class Toolbar extends StatefulWidget {
+  const Toolbar({super.key});
+
+  @override
+  State<Toolbar> createState() => _ToolbarState();
+}
+
+class _ToolbarState extends State<Toolbar> {
+  late final todosController = context.read<TodosController>();
+  late final filterController = context.read<FilterController>();
+
+  @override
+  Widget build(BuildContext context) {
+    return DefaultTabController(
+      length: TodosFilter.values.length,
+      child: TabBar(
+        labelColor: Colors.black,
+        tabs: [
+          SignalBuilder(
+            builder: (context, child) {
+              return Tab(text: 'all (${todosController.todos.length})');
+            },
+          ),
+          SignalBuilder(
+            builder: (context, child) {
+              return Tab(
+                text:
+                    'incomplete (${todosController.incompleteTodos.value.length})',
+              );
+            },
+          ),
+          SignalBuilder(
+            builder: (context, child) {
+              return Tab(
+                text:
+                    'completed (${todosController.completedTodos.value.length})',
+              );
+            },
+          ),
+        ],
+        onTap: (index) {
+          filterController.filter.value = TodosFilter.values[index];
+        },
+      ),
+    );
+  }
+}

--- a/examples/todos/pubspec.yaml
+++ b/examples/todos/pubspec.yaml
@@ -18,9 +18,9 @@ dependencies:
   uuid: ^4.5.1
 
 dev_dependencies:
+  build_runner: ^2.14.0
   flutter_test:
     sdk: flutter
-  build_runner: ^2.14.0
   solid_generator:
     path: ../../packages/solid_generator
   very_good_analysis: ^10.0.0

--- a/examples/todos/pubspec.yaml
+++ b/examples/todos/pubspec.yaml
@@ -1,0 +1,29 @@
+name: todos_example
+description: A Todos example app demonstrating Solid v2.
+publish_to: 'none'
+version: 0.0.1
+
+environment:
+  sdk: ^3.9.2
+
+resolution: workspace
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_solidart: ^2.7.3
+  provider: ^6.1.0
+  solid_annotations:
+    path: ../../packages/solid_annotations
+  uuid: ^4.5.1
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  build_runner: ^2.14.0
+  solid_generator:
+    path: ../../packages/solid_generator
+  very_good_analysis: ^10.0.0
+
+flutter:
+  uses-material-design: true

--- a/examples/todos/source/controllers/filter.dart
+++ b/examples/todos/source/controllers/filter.dart
@@ -1,0 +1,7 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:todos_example/domain/todo.dart';
+
+class FilterController {
+  @SolidState()
+  TodosFilter filter = TodosFilter.all;
+}

--- a/examples/todos/source/controllers/todos.dart
+++ b/examples/todos/source/controllers/todos.dart
@@ -10,12 +10,10 @@ class TodosController {
   List<Todo> todos = const [];
 
   @SolidState()
-  List<Todo> get completedTodos =>
-      todos.where((t) => t.completed).toList();
+  List<Todo> get completedTodos => todos.where((t) => t.completed).toList();
 
   @SolidState()
-  List<Todo> get incompleteTodos =>
-      todos.where((t) => !t.completed).toList();
+  List<Todo> get incompleteTodos => todos.where((t) => !t.completed).toList();
 
   void add(Todo todo) => todos.add(todo);
 

--- a/examples/todos/source/controllers/todos.dart
+++ b/examples/todos/source/controllers/todos.dart
@@ -1,0 +1,28 @@
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:todos_example/domain/todo.dart';
+
+class TodosController {
+  TodosController({List<Todo> initialTodos = const []}) {
+    todos.addAll(initialTodos);
+  }
+
+  @SolidState()
+  List<Todo> todos = const [];
+
+  @SolidState()
+  List<Todo> get completedTodos =>
+      todos.where((t) => t.completed).toList();
+
+  @SolidState()
+  List<Todo> get incompleteTodos =>
+      todos.where((t) => !t.completed).toList();
+
+  void add(Todo todo) => todos.add(todo);
+
+  void remove(String id) => todos.removeWhere((t) => t.id == id);
+
+  void toggle(String id) {
+    final i = todos.indexWhere((t) => t.id == id);
+    todos[i] = todos[i].copyWith(completed: !todos[i].completed);
+  }
+}

--- a/examples/todos/source/domain/todo.dart
+++ b/examples/todos/source/domain/todo.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/foundation.dart';
+import 'package:uuid/uuid.dart';
+
+@immutable
+class Todo {
+  const Todo({
+    required this.id,
+    required this.task,
+    required this.completed,
+  });
+
+  factory Todo.create(String task) {
+    return Todo(id: const Uuid().v4(), task: task, completed: false);
+  }
+
+  final String id;
+  final String task;
+  final bool completed;
+
+  static List<Todo> get sample {
+    return [
+      Todo.create('Learn Solid'),
+      Todo.create('Wash the car'),
+      Todo.create('Go shopping'),
+    ];
+  }
+
+  Todo copyWith({bool? completed}) {
+    return Todo(id: id, task: task, completed: completed ?? this.completed);
+  }
+}
+
+enum TodosFilter { all, incomplete, completed }

--- a/examples/todos/source/main.dart
+++ b/examples/todos/source/main.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:todos_example/controllers/filter.dart';
+import 'package:todos_example/controllers/todos.dart';
+import 'package:todos_example/domain/todo.dart';
+import 'package:todos_example/pages/todos.dart';
+
+void main() {
+  SolidartConfig.autoDispose = false;
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Todos Example',
+      home: const TodosPage()
+          .environment((_) => TodosController(initialTodos: Todo.sample))
+          .environment((_) => FilterController()),
+    );
+  }
+}

--- a/examples/todos/source/pages/todos.dart
+++ b/examples/todos/source/pages/todos.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:todos_example/widgets/todos_body.dart';
+
+class TodosPage extends StatelessWidget {
+  const TodosPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Todos')),
+      body: const Padding(
+        padding: EdgeInsets.all(8),
+        child: TodosBody(),
+      ),
+    );
+  }
+}

--- a/examples/todos/source/widgets/todo_item.dart
+++ b/examples/todos/source/widgets/todo_item.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:todos_example/controllers/todos.dart';
+import 'package:todos_example/domain/todo.dart';
+
+class TodoItem extends StatelessWidget {
+  TodoItem({super.key, required this.todo});
+
+  final Todo todo;
+
+  @SolidEnvironment()
+  late TodosController todosController;
+
+  @override
+  Widget build(BuildContext context) {
+    return Dismissible(
+      key: ValueKey(todo.id),
+      direction: DismissDirection.endToStart,
+      onDismissed: (_) => todosController.remove(todo.id),
+      background: Container(
+        decoration: const BoxDecoration(color: Colors.red),
+        alignment: Alignment.centerRight,
+        padding: const EdgeInsets.only(right: 8),
+        child: const Icon(Icons.delete, color: Colors.white),
+      ),
+      child: CheckboxListTile(
+        title: Text(todo.task),
+        value: todo.completed,
+        onChanged: (_) => todosController.toggle(todo.id),
+      ),
+    );
+  }
+}

--- a/examples/todos/source/widgets/todos_body.dart
+++ b/examples/todos/source/widgets/todos_body.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:todos_example/controllers/todos.dart';
+import 'package:todos_example/domain/todo.dart';
+import 'package:todos_example/widgets/todos_list.dart';
+import 'package:todos_example/widgets/toolbar.dart';
+
+class TodosBody extends StatefulWidget {
+  const TodosBody({super.key});
+
+  @override
+  State<TodosBody> createState() => _TodosBodyState();
+}
+
+class _TodosBodyState extends State<TodosBody> {
+  @SolidEnvironment()
+  late TodosController todosController;
+
+  final _textController = TextEditingController();
+
+  @override
+  void dispose() {
+    _textController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        TextFormField(
+          controller: _textController,
+          decoration: const InputDecoration(hintText: 'Write new todo'),
+          validator: (v) {
+            if (v == null || v.isEmpty) return 'Cannot be empty';
+            return null;
+          },
+          onFieldSubmitted: (task) {
+            if (task.isEmpty) return;
+            todosController.add(Todo.create(task));
+            _textController.clear();
+          },
+        ),
+        const SizedBox(height: 16),
+        const Toolbar(),
+        const SizedBox(height: 16),
+        const Expanded(child: TodoList()),
+      ],
+    );
+  }
+}

--- a/examples/todos/source/widgets/todos_list.dart
+++ b/examples/todos/source/widgets/todos_list.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:todos_example/controllers/filter.dart';
+import 'package:todos_example/controllers/todos.dart';
+import 'package:todos_example/domain/todo.dart';
+import 'package:todos_example/widgets/todo_item.dart';
+
+class TodoList extends StatelessWidget {
+  TodoList({super.key});
+
+  @SolidEnvironment()
+  late TodosController todosController;
+
+  @SolidEnvironment()
+  late FilterController filterController;
+
+  @SolidState()
+  List<Todo> get filteredTodos {
+    switch (filterController.filter) {
+      case TodosFilter.all:
+        // `.toList()` returns a fresh copy so the Computed's default
+        // `identical` comparator sees a new reference whenever the
+        // underlying `ListSignal` mutates (in-place adds keep the same
+        // reference, which would suppress invalidation).
+        return todosController.todos.toList();
+      case TodosFilter.incomplete:
+        return todosController.incompleteTodos;
+      case TodosFilter.completed:
+        return todosController.completedTodos;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      children: [
+        for (final todo in filteredTodos) TodoItem(todo: todo),
+      ],
+    );
+  }
+}

--- a/examples/todos/source/widgets/toolbar.dart
+++ b/examples/todos/source/widgets/toolbar.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:todos_example/controllers/filter.dart';
+import 'package:todos_example/controllers/todos.dart';
+import 'package:todos_example/domain/todo.dart';
+
+class Toolbar extends StatelessWidget {
+  Toolbar({super.key});
+
+  @SolidEnvironment()
+  late TodosController todosController;
+
+  @SolidEnvironment()
+  late FilterController filterController;
+
+  @override
+  Widget build(BuildContext context) {
+    return DefaultTabController(
+      length: TodosFilter.values.length,
+      child: TabBar(
+        labelColor: Colors.black,
+        tabs: [
+          Tab(text: 'all (${todosController.todos.length})'),
+          Tab(text: 'incomplete (${todosController.incompleteTodos.length})'),
+          Tab(text: 'completed (${todosController.completedTodos.length})'),
+        ],
+        onTap: (index) {
+          filterController.filter = TodosFilter.values[index];
+        },
+      ),
+    );
+  }
+}

--- a/examples/todos/test/controller_test.dart
+++ b/examples/todos/test/controller_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:todos_example/controllers/todos.dart';
+import 'package:todos_example/domain/todo.dart';
+
+void main() {
+  group('TodosController -', () {
+    test('When providing initialTodos, `todos` emits the correct state', () {
+      const initialTodos = [
+        Todo(id: '1', task: 'mock1', completed: false),
+        Todo(id: '2', task: 'mock2', completed: false),
+      ];
+      final controller = TodosController(initialTodos: initialTodos);
+      addTearDown(controller.dispose);
+
+      expect(controller.todos, hasLength(2));
+    });
+
+    test('Add a todo', () {
+      final controller = TodosController();
+      addTearDown(controller.dispose);
+
+      expect(controller.todos, isEmpty);
+
+      controller.add(const Todo(id: '1', task: 'mock1', completed: false));
+
+      expect(controller.todos, hasLength(1));
+    });
+
+    test('Remove a todo', () {
+      const initialTodos = [
+        Todo(id: '1', task: 'mock1', completed: false),
+        Todo(id: '2', task: 'mock2', completed: false),
+      ];
+      final controller = TodosController(initialTodos: initialTodos);
+      addTearDown(controller.dispose);
+
+      expect(controller.todos, hasLength(2));
+
+      controller.remove('1');
+
+      expect(controller.todos, hasLength(1));
+      expect(controller.todos.first.id, '2');
+    });
+
+    test('Toggle a todo', () {
+      const initialTodos = [
+        Todo(id: '1', task: 'mock1', completed: false),
+      ];
+      final controller = TodosController(initialTodos: initialTodos);
+      addTearDown(controller.dispose);
+
+      expect(controller.todos.first.completed, false);
+
+      controller.toggle('1');
+
+      expect(controller.todos.first.completed, true);
+    });
+  });
+}

--- a/examples/todos/test/widget_test.dart
+++ b/examples/todos/test/widget_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:todos_example/controllers/filter.dart';
+import 'package:todos_example/controllers/todos.dart';
+import 'package:todos_example/domain/todo.dart';
+import 'package:todos_example/pages/todos.dart';
+import 'package:todos_example/widgets/todo_item.dart';
+
+Widget makeApp(TodosController todosController) {
+  return MaterialApp(
+    home: const TodosPage()
+        .environment<TodosController>((_) => todosController)
+        .environment((_) => FilterController()),
+  );
+}
+
+void main() {
+  testWidgets('Todos with initial value', (tester) async {
+    final initialTodos = List.generate(
+      3,
+      (i) => Todo(id: i.toString(), task: 'mock$i', completed: false),
+    );
+    await tester.pumpWidget(
+      makeApp(TodosController(initialTodos: initialTodos)),
+    );
+
+    expect(tester.widgetList(find.byType(TodoItem)).length, 3);
+    expect(find.text('mock0'), findsOneWidget);
+    expect(find.text('mock1'), findsOneWidget);
+    expect(find.text('mock2'), findsOneWidget);
+  });
+
+  testWidgets('Add a todo', (tester) async {
+    await tester.pumpWidget(makeApp(TodosController()));
+
+    expect(tester.widgetList(find.byType(TodoItem)).length, 0);
+
+    await tester.enterText(find.byType(TextFormField), 'test todo');
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pump();
+
+    expect(tester.widgetList(find.byType(TodoItem)).length, 1);
+    expect(find.text('test todo'), findsOneWidget);
+  });
+
+  testWidgets('Remove a todo', (tester) async {
+    final initialTodos = List.generate(
+      3,
+      (i) => Todo(id: i.toString(), task: 'mock$i', completed: false),
+    );
+    await tester.pumpWidget(
+      makeApp(TodosController(initialTodos: initialTodos)),
+    );
+
+    expect(tester.widgetList(find.byType(TodoItem)).length, 3);
+
+    final firstTodoItem = find.byType(TodoItem).first;
+    await tester.fling(firstTodoItem, const Offset(-300, 0), 1000);
+    await tester.pumpAndSettle();
+
+    expect(tester.widgetList(find.byType(TodoItem)).length, 2);
+    expect(find.text('mock0'), findsNothing);
+  });
+
+  testWidgets('Toggle a todo', (tester) async {
+    final initialTodos = List.generate(
+      2,
+      (i) => Todo(id: '$i', task: 'mock$i', completed: false),
+    );
+    await tester.pumpWidget(
+      makeApp(TodosController(initialTodos: initialTodos)),
+    );
+
+    expect(find.text('completed (0)'), findsOneWidget);
+
+    await tester.tap(find.byType(CheckboxListTile).first);
+    await tester.pump();
+
+    expect(find.text('completed (1)'), findsOneWidget);
+
+    await tester.tap(find.text('completed (1)'));
+    await tester.pump();
+
+    expect(find.text('mock0'), findsOneWidget);
+    expect(find.text('mock1'), findsNothing);
+  });
+}

--- a/packages/integration_tests/analysis_options.yaml
+++ b/packages/integration_tests/analysis_options.yaml
@@ -1,5 +1,12 @@
 include: package:very_good_analysis/analysis_options.yaml
 analyzer:
+  # `source/` is generator input — the analyzer resolves
+  # `package:integration_tests/...` imports to the generated `lib/` types,
+  # so cross-file source files appear as type errors against `Signal<T>`
+  # / `ListSignal<T>` (which the generator rewrites in lib/). Exclude the
+  # directory to keep the IDE focused on the actual runnable output.
+  exclude:
+    - source/**
   errors:
     must_be_immutable: ignore
     always_put_required_named_parameters_first: ignore

--- a/packages/integration_tests/lib/cross_file_env/counter_controller.dart
+++ b/packages/integration_tests/lib/cross_file_env/counter_controller.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Counter implements Disposable {
+  final value = Signal<int>(0, name: 'value');
+
+  final history = ListSignal<int>(const [], name: 'history');
+
+  @override
+  void dispose() {
+    history.dispose();
+    value.dispose();
+  }
+}

--- a/packages/integration_tests/lib/cross_file_env/counter_display.dart
+++ b/packages/integration_tests/lib/cross_file_env/counter_display.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:integration_tests/cross_file_env/counter_controller.dart';
+import 'package:provider/provider.dart';
+
+class CounterDisplay extends StatefulWidget {
+  const CounterDisplay({super.key});
+
+  @override
+  State<CounterDisplay> createState() => _CounterDisplayState();
+}
+
+class _CounterDisplayState extends State<CounterDisplay> {
+  late final counter = context.read<Counter>();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          SignalBuilder(
+            builder: (context, child) {
+              return Text('value: ${counter.value.value}');
+            },
+          ),
+          SignalBuilder(
+            builder: (context, child) {
+              return Text('history-len: ${counter.history.length}');
+            },
+          ),
+        ],
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          counter.value.value++;
+          counter.history.add(counter.value.value);
+        },
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/packages/integration_tests/source/cross_file_env/counter_controller.dart
+++ b/packages/integration_tests/source/cross_file_env/counter_controller.dart
@@ -1,0 +1,20 @@
+// Cross-file env-injection runtime fence — the `Counter` plain class side.
+// Defines `@SolidState` scalar AND collection fields so the runtime suite
+// exercises both the scalar `.value.value` chain rewrite AND the
+// collection no-`.value` chain rewrite when the receiver is an env field
+// resolved across file boundaries.
+
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Counter {
+  @SolidState()
+  int value = 0;
+
+  @SolidState()
+  List<int> history = const [];
+
+  // Empty stub — the source-layer analyzer needs to resolve `c.dispose()` in
+  // the `.environment<Counter>(... dispose: (_, c) => c.dispose())` callback.
+  // The generator merges synthesized disposals into this body.
+  void dispose() {}
+}

--- a/packages/integration_tests/source/cross_file_env/counter_display.dart
+++ b/packages/integration_tests/source/cross_file_env/counter_display.dart
@@ -1,0 +1,36 @@
+// Cross-file env-injection consumer — imports `Counter` from a sibling
+// source file via `package:integration_tests/cross_file_env/...`. The
+// generator's resolver pass redirects same-package `lib/` URIs back to
+// `source/` so the `@SolidState` annotations are visible to the rewriter
+// even though the import resolves to `lib/cross_file_env/...` post-build.
+
+import 'package:flutter/material.dart';
+import 'package:integration_tests/cross_file_env/counter_controller.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+class CounterDisplay extends StatelessWidget {
+  CounterDisplay({super.key});
+
+  @SolidEnvironment()
+  late Counter counter;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text('value: ${counter.value}'),
+          Text('history-len: ${counter.history.length}'),
+        ],
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          counter.value++;
+          counter.history.add(counter.value);
+        },
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/packages/integration_tests/test/cross_file_environment_test.dart
+++ b/packages/integration_tests/test/cross_file_environment_test.dart
@@ -1,0 +1,58 @@
+// Runtime fence for the cross-file `@SolidEnvironment` chain rewrite.
+// `Counter` is declared in `source/cross_file_env/counter_controller.dart`
+// and consumed by `CounterDisplay` in `source/cross_file_env/counter_display.dart`
+// via `package:integration_tests/cross_file_env/...`. The two files are
+// generated independently — the generator's resolver pass redirects the
+// same-package `lib/` URI back to `source/` so the rewriter sees the
+// pre-transformation `@SolidState` annotations even though Dart resolves
+// the import to `lib/`.
+//
+// This test asserts that the SignalBuilder placements emitted in
+// `counter_display.dart` actually subscribe to the live ListSignal/Signal
+// in `counter_controller.dart` and rebuild on cross-class mutation.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_tests/cross_file_env/counter_controller.dart';
+import 'package:integration_tests/cross_file_env/counter_display.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+void main() {
+  testWidgets(
+    'cross-file @SolidEnvironment: FAB tap rebuilds both scalar and '
+    'collection consumers',
+    (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: const CounterDisplay().environment<Counter>(
+            (_) => Counter(),
+            dispose: (_, c) => c.dispose(),
+          ),
+        ),
+      );
+
+      expect(find.text('value: 0'), findsOneWidget);
+      expect(find.text('history-len: 0'), findsOneWidget);
+
+      for (var i = 0; i < 3; i++) {
+        await tester.tap(find.byType(FloatingActionButton));
+        await tester.pump();
+        expect(
+          find.text('value: ${i + 1}'),
+          findsOneWidget,
+          reason:
+              'SignalBuilder on `counter.value` must rebuild on cross-FILE '
+              'scalar signal mutation #${i + 1}',
+        );
+        expect(
+          find.text('history-len: ${i + 1}'),
+          findsOneWidget,
+          reason:
+              'SignalBuilder on `counter.history.length` must rebuild on '
+              'cross-FILE ListSignal mutation #${i + 1} — the rewriter must '
+              'have OMITTED `.value` between `counter.history` and `.length`',
+        );
+      }
+    },
+  );
+}

--- a/packages/solid_generator/lib/builder.dart
+++ b/packages/solid_generator/lib/builder.dart
@@ -323,6 +323,16 @@ List<_AnnotatedClass> _collectAnnotatedClasses(
     final queries = <QueryModel>[];
     final environments = <EnvironmentModel>[];
     final reactiveNames = <String>{};
+    // Subset of [reactiveNames] whose emitter produces a collection signal
+    // (`ListSignal<T>` / `SetSignal<T>` / `MapSignal<K, V>`). Built
+    // incrementally so a `@SolidState` getter / `@SolidEffect` /
+    // `@SolidQuery` body declared LATER in the class can skip the
+    // `.value` insertion on chain reads of an EARLIER collection field —
+    // the collection signal's mixin already tracks reads natively, so
+    // `xs.where(...)` / `xs.length` / `xs[i]` resolve through the
+    // ListMixin / SetMixin / MapMixin without `.value`. Getters never go
+    // into this set (they lower to `Computed<T>`, no mixin contract).
+    final collectionFieldsSeen = <String>{};
     // Local view of the cross-class registries that excludes the enclosing
     // class itself — the reader pipeline already provides same-class
     // `@SolidState` field/getter names through [reactiveNames], so threading
@@ -355,6 +365,9 @@ List<_AnnotatedClass> _collectAnnotatedClasses(
         if (model != null) {
           fields.add(model);
           reactiveNames.add(model.fieldName);
+          if (isCollectionSignalField(model)) {
+            collectionFieldsSeen.add(model.fieldName);
+          }
           continue;
         }
         // `@SolidState` wins over `@SolidEnvironment` on a both-annotated
@@ -375,6 +388,7 @@ List<_AnnotatedClass> _collectAnnotatedClasses(
           classRegistry: crossClassRegistry,
           classCollectionFields: crossClassCollections,
           environmentFields: environmentFieldsForBody,
+          collectionFields: collectionFieldsSeen,
         );
         if (getter != null) {
           getters.add(getter);
@@ -395,6 +409,7 @@ List<_AnnotatedClass> _collectAnnotatedClasses(
           classRegistry: crossClassRegistry,
           classCollectionFields: crossClassCollections,
           environmentFields: environmentFieldsForBody,
+          collectionFields: collectionFieldsSeen,
         );
         if (effect != null) {
           effects.add(effect);
@@ -408,6 +423,7 @@ List<_AnnotatedClass> _collectAnnotatedClasses(
           classRegistry: crossClassRegistry,
           classCollectionFields: crossClassCollections,
           environmentFields: environmentFieldsForBody,
+          collectionFields: collectionFieldsSeen,
         );
         if (query != null) {
           queries.add(query);

--- a/packages/solid_generator/lib/builder.dart
+++ b/packages/solid_generator/lib/builder.dart
@@ -20,6 +20,7 @@ import 'package:solid_generator/src/plain_class_rewriter.dart';
 import 'package:solid_generator/src/provider_dispose_rewriter.dart';
 import 'package:solid_generator/src/query_model.dart';
 import 'package:solid_generator/src/reserved_annotation_validator.dart';
+import 'package:solid_generator/src/signal_emitter.dart';
 import 'package:solid_generator/src/state_class_rewriter.dart';
 import 'package:solid_generator/src/stateless_rewriter.dart';
 import 'package:solid_generator/src/target_validator.dart';
@@ -142,7 +143,31 @@ class _SolidBuilder implements Builder {
     // above.
     validateSolidEnvironmentTargets(parsed.unit);
 
-    final annotatedClasses = _collectAnnotatedClasses(parsed.unit, source);
+    // Same-file class registry, built from a fast member-scan before any
+    // body rewrites run. The body-rewriter relies on it to recognise
+    // cross-class `.value` chains (`controller.todos`) even when the body
+    // being rewritten is a `@SolidState` getter / `@SolidEffect` /
+    // `@SolidQuery` on a sibling class in the same file.
+    final sameFileRegistry = _prescanClassRegistry(parsed.unit);
+    final sameFileCollections = _prescanClassCollectionFields(parsed.unit);
+    // Cross-file resolver: walks every `package:`/relative import of the
+    // current source file, redirecting same-package imports from `lib/` to
+    // `source/`, and pulls in `@SolidState` member names for every class
+    // referenced by a `@SolidEnvironment` field type — same contract as the
+    // same-file pass, but for types declared in other source files.
+    await _populateCrossFileTypes(
+      parsed.unit,
+      buildStep,
+      sameFileRegistry,
+      sameFileCollections,
+    );
+
+    final annotatedClasses = _collectAnnotatedClasses(
+      parsed.unit,
+      source,
+      sameFileRegistry,
+      sameFileCollections,
+    );
     if (annotatedClasses.every((c) => c.hasNoAnnotations)) {
       // No reactive annotations resolved. The file may still contain a
       // `Provider(...)` or `.environment<T>()` call site that the auto-dispose
@@ -163,38 +188,83 @@ class _SolidBuilder implements Builder {
       return;
     }
 
-    final classRegistry = _buildClassRegistry(annotatedClasses);
+    // Reuse the same-file + cross-file registry from the prescan above
+    // (rather than rebuilding from `annotatedClasses`) — they encode the
+    // same data but the prescan version is the authority because the
+    // reader pipeline already consumed it.
     final transformed = _renderOutput(
       parsed.unit,
       annotatedClasses,
-      classRegistry,
+      sameFileRegistry,
+      sameFileCollections,
       source,
     );
     await buildStep.writeAsString(outputId, transformed);
   }
 }
 
-/// Builds the cross-class reactivity map: class name → set of `@SolidState`
-/// field/getter names declared on that class. Consumed by `value_rewriter`
-/// to detect `<receiver>.<field>` reads where the receiver's declared type
-/// names a class with reactive declarations (cross-class chain rewrite —
-/// currently a single-level subset; full chains will land alongside the
-/// resolved-AST migration).
+/// Pre-scans every `ClassDeclaration` in [unit] and returns the cross-class
+/// reactivity map (class name → set of `@SolidState` field / getter names).
+/// Runs BEFORE `_collectAnnotatedClasses` so the produced registry can be
+/// threaded into the reader pipeline, letting cross-class `.value` rewrites
+/// fire even when the body being rewritten is a `@SolidState` getter /
+/// `@SolidEffect` / `@SolidQuery` on a sibling class.
 ///
-/// `@SolidEffect` and `@SolidQuery` names are intentionally excluded — an
-/// Effect lowers to a `void`-returning `Effect` field with no observable
-/// `.value`, and a Query lowers to a `Resource<T>` whose call sites resolve
-/// through `Resource.call()` → `state` (no `.value` rewrite).
-Map<String, Set<String>> _buildClassRegistry(
-  List<_AnnotatedClass> annotatedClasses,
-) {
+/// The scan is annotation-name-only (no body parsing) and intentionally
+/// excludes `@SolidEffect` / `@SolidQuery` names for the same reason
+/// `_buildClassRegistry` did: Effects have no observable `.value`, and
+/// Queries lower to `Resource<T>` whose call sites resolve through
+/// `Resource.call() → state`.
+Map<String, Set<String>> _prescanClassRegistry(CompilationUnit unit) {
   final registry = <String, Set<String>>{};
-  for (final c in annotatedClasses) {
-    final names = <String>{
-      for (final f in c.fields) f.fieldName,
-      for (final g in c.getters) g.getterName,
-    };
-    if (names.isNotEmpty) registry[c.decl.name.lexeme] = names;
+  for (final decl in unit.declarations) {
+    if (decl is! ClassDeclaration) continue;
+    final names = <String>{};
+    for (final member in decl.members) {
+      if (member is FieldDeclaration) {
+        if (member.metadata.any((a) => a.name.name == solidStateName)) {
+          names.add(member.fields.variables.first.name.lexeme);
+        }
+      } else if (member is MethodDeclaration && member.isGetter) {
+        if (member.metadata.any((a) => a.name.name == solidStateName)) {
+          names.add(member.name.lexeme);
+        }
+      }
+    }
+    if (names.isNotEmpty) registry[decl.name.lexeme] = names;
+  }
+  return registry;
+}
+
+/// Pre-scans every `ClassDeclaration` in [unit] and returns the cross-class
+/// collection-fields map (class name → set of `@SolidState` field names
+/// whose emitter would produce a collection signal). Strict subset of
+/// [_prescanClassRegistry] — getters are excluded because a `@SolidState`
+/// getter always lowers to `Computed<T>` (no collection-mixin contract).
+///
+/// Mirrors the collection-detection rule in `signal_emitter.dart` so the
+/// cross-file scan agrees with same-file emission: a field qualifies iff
+/// (a) the declared type matches `parseCollectionTypeText`, (b) it has an
+/// initializer (collection signals have no `.lazy` ctor), and (c) it is
+/// non-nullable (collection signals reject null).
+Map<String, Set<String>> _prescanClassCollectionFields(CompilationUnit unit) {
+  final registry = <String, Set<String>>{};
+  for (final decl in unit.declarations) {
+    if (decl is! ClassDeclaration) continue;
+    final names = <String>{};
+    for (final member in decl.members) {
+      if (member is! FieldDeclaration) continue;
+      if (!member.metadata.any((a) => a.name.name == solidStateName)) continue;
+      final variable = member.fields.variables.first;
+      final type = member.fields.type;
+      if (type == null) continue;
+      if (member.fields.isLate) continue;
+      if (type.question != null) continue;
+      if (variable.initializer == null) continue;
+      if (parseCollectionTypeText(type.toSource()) == null) continue;
+      names.add(variable.name.lexeme);
+    }
+    if (names.isNotEmpty) registry[decl.name.lexeme] = names;
   }
   return registry;
 }
@@ -241,6 +311,8 @@ class _AnnotatedClass {
 List<_AnnotatedClass> _collectAnnotatedClasses(
   CompilationUnit unit,
   String source,
+  Map<String, Set<String>> classRegistry,
+  Map<String, Set<String>> classCollectionFields,
 ) {
   final result = <_AnnotatedClass>[];
   for (final decl in unit.declarations) {
@@ -251,6 +323,25 @@ List<_AnnotatedClass> _collectAnnotatedClasses(
     final queries = <QueryModel>[];
     final environments = <EnvironmentModel>[];
     final reactiveNames = <String>{};
+    // Local view of the cross-class registries that excludes the enclosing
+    // class itself — the reader pipeline already provides same-class
+    // `@SolidState` field/getter names through [reactiveNames], so threading
+    // them through the cross-class branch a second time would double-count
+    // (the chain rewrite would fire on `this.field.value` too). For env
+    // injection lookups we still need the receiver-class info, hence the
+    // map-of-other-classes shape.
+    final selfClass = decl.name.lexeme;
+    final crossClassRegistry = Map<String, Set<String>>.from(classRegistry)
+      ..remove(selfClass);
+    final crossClassCollections = Map<String, Set<String>>.from(
+      classCollectionFields,
+    )..remove(selfClass);
+    // Pre-scan members once for `@SolidEnvironment` so each reader sees the
+    // host class's env-field map (fieldName → typeText) up-front. The
+    // env-field receiver shape (`<envField>.<reactiveField>`) needs this
+    // mapping to look up the receiver's declared type in the cross-class
+    // registry.
+    final environmentFieldsForBody = _collectEnvironmentFields(decl);
     // A query / effect / state-getter body MAY invoke same-class `@SolidQuery`
     // methods to compose its result; the body-rewrite visitor needs the
     // per-class name set up-front to detect these cross-query reads. Pre-scan
@@ -281,6 +372,9 @@ List<_AnnotatedClass> _collectAnnotatedClasses(
           reactiveNames,
           source,
           queryNames: queryNames,
+          classRegistry: crossClassRegistry,
+          classCollectionFields: crossClassCollections,
+          environmentFields: environmentFieldsForBody,
         );
         if (getter != null) {
           getters.add(getter);
@@ -298,6 +392,9 @@ List<_AnnotatedClass> _collectAnnotatedClasses(
           reactiveNames,
           source,
           queryNames: queryNames,
+          classRegistry: crossClassRegistry,
+          classCollectionFields: crossClassCollections,
+          environmentFields: environmentFieldsForBody,
         );
         if (effect != null) {
           effects.add(effect);
@@ -308,6 +405,9 @@ List<_AnnotatedClass> _collectAnnotatedClasses(
           reactiveNames,
           source,
           queryNames: queryNames,
+          classRegistry: crossClassRegistry,
+          classCollectionFields: crossClassCollections,
+          environmentFields: environmentFieldsForBody,
         );
         if (query != null) {
           queries.add(query);
@@ -326,6 +426,26 @@ List<_AnnotatedClass> _collectAnnotatedClasses(
     );
   }
   return result;
+}
+
+/// Pre-scans [decl]'s members for `@SolidEnvironment` fields and returns
+/// the `fieldName → typeText` map used by the cross-class chain rewrite
+/// when the receiver is a host-class env field. Returns the shared empty
+/// map when no env fields are present so the env-only path is allocation-
+/// free.
+Map<String, String> _collectEnvironmentFields(ClassDeclaration decl) {
+  Map<String, String>? fields;
+  for (final member in decl.members) {
+    if (member is! FieldDeclaration) continue;
+    if (!member.metadata.any((a) => a.name.name == solidEnvironmentName)) {
+      continue;
+    }
+    final type = member.fields.type;
+    if (type == null) continue;
+    final fieldName = member.fields.variables.first.name.lexeme;
+    (fields ??= <String, String>{})[fieldName] = type.toSource();
+  }
+  return fields ?? const <String, String>{};
 }
 
 /// Pre-scans [decl]'s members for `@SolidQuery`-annotated methods and
@@ -361,6 +481,7 @@ String _renderOutput(
   CompilationUnit unit,
   List<_AnnotatedClass> annotatedClasses,
   Map<String, Set<String>> classRegistry,
+  Map<String, Set<String>> classCollectionFields,
   String source,
 ) {
   // Walk `unit.declarations` in source order. Class declarations are paired
@@ -373,7 +494,12 @@ String _renderOutput(
   final results = <RewriteResult>[
     for (final decl in unit.declarations)
       if (decl is ClassDeclaration)
-        _resultForClass(annotatedClasses[classIdx++], classRegistry, source)
+        _resultForClass(
+          annotatedClasses[classIdx++],
+          classRegistry,
+          classCollectionFields,
+          source,
+        )
       else
         _passthroughResult(decl, source),
   ];
@@ -424,6 +550,7 @@ String _renderOutput(
 RewriteResult _resultForClass(
   _AnnotatedClass c,
   Map<String, Set<String>> classRegistry,
+  Map<String, Set<String>> classCollectionFields,
   String source,
 ) {
   if (c.hasNoAnnotations) return _passthroughResult(c.decl, source);
@@ -435,6 +562,7 @@ RewriteResult _resultForClass(
     c.queries,
     c.environments,
     classRegistry,
+    classCollectionFields,
     source,
   );
 }
@@ -464,6 +592,7 @@ RewriteResult _rewriteClass(
   List<QueryModel> queries,
   List<EnvironmentModel> environments,
   Map<String, Set<String>> classRegistry,
+  Map<String, Set<String>> classCollectionFields,
   String source,
 ) {
   final kind = classKindOf(decl);
@@ -478,6 +607,7 @@ RewriteResult _rewriteClass(
         queries,
         environments,
         classRegistry,
+        classCollectionFields,
         source,
       );
     case ClassKind.plainClass:
@@ -489,6 +619,7 @@ RewriteResult _rewriteClass(
         queries,
         environments,
         classRegistry,
+        classCollectionFields,
         source,
       );
     case ClassKind.stateClass:
@@ -500,6 +631,7 @@ RewriteResult _rewriteClass(
         queries,
         environments,
         classRegistry,
+        classCollectionFields,
         source,
       );
     case ClassKind.statefulWidget:
@@ -514,3 +646,150 @@ RewriteResult _rewriteClass(
 /// Returns the URI string of an `import '…';` directive, or the empty string
 /// if the directive has no URI (should not happen for well-formed source).
 String _importUri(ImportDirective d) => d.uri.stringValue ?? '';
+
+/// Resolver pass for the cross-file slice of the chain-aware rule. For each
+/// `@SolidEnvironment` field whose declared type is NOT defined in the
+/// current source file, walk the imported `source/<path>.dart` file(s) via
+/// `BuildStep.resolver.compilationUnitFor` and merge any `@SolidState`
+/// members of the matching class declaration into [classRegistry] (and the
+/// collection-subset into [classCollectionFields]).
+///
+/// The two registries are mutated in place. Same-file types take precedence:
+/// when a type name is already present, the cross-file pass does NOT
+/// overwrite it (in-file source is always the source of truth for the
+/// current build).
+///
+/// `package:` imports of the **current package** are redirected from `lib/`
+/// to `source/` because the user's `@SolidState` annotations live on the
+/// pre-transformation source — the `lib/` output has already been lowered
+/// (e.g. `final value = Signal<int>(0, name: 'value');`, no annotation).
+/// Other-package imports (Flutter, flutter_solidart, third-party) are read
+/// as-is; they have no Solid annotations and contribute nothing.
+///
+/// `dart:` imports are skipped — the Dart SDK contains no Solid annotations.
+Future<void> _populateCrossFileTypes(
+  CompilationUnit unit,
+  BuildStep step,
+  Map<String, Set<String>> classRegistry,
+  Map<String, Set<String>> classCollectionFields,
+) async {
+  // Walk every `@SolidEnvironment` field declaration in the unit. The
+  // builder pre-scan does NOT pre-build env-field models — the readers do
+  // that downstream — so this loop reads metadata directly off the AST.
+  // Resolution is keyed on the declared `typeText`; same-file types already
+  // present in [classRegistry] are skipped (the same-file pass is the
+  // source of truth there).
+  final wantedTypes = <String>{};
+  for (final decl in unit.declarations) {
+    if (decl is! ClassDeclaration) continue;
+    for (final member in decl.members) {
+      if (member is! FieldDeclaration) continue;
+      if (!member.metadata.any((a) => a.name.name == solidEnvironmentName)) {
+        continue;
+      }
+      final type = member.fields.type;
+      if (type == null) continue;
+      final typeText = type.toSource();
+      if (typeText.isEmpty) continue;
+      if (classRegistry.containsKey(typeText)) continue;
+      wantedTypes.add(typeText);
+    }
+  }
+  if (wantedTypes.isEmpty) return;
+
+  for (final directive in unit.directives.whereType<ImportDirective>()) {
+    if (wantedTypes.isEmpty) break;
+    final uri = directive.uri.stringValue;
+    if (uri == null || uri.startsWith('dart:')) continue;
+    final assetId = _resolveImportToSourceAsset(uri, step.inputId);
+    if (assetId == null) continue;
+    if (!assetId.path.endsWith('.dart')) continue;
+    // Skip if the asset doesn't exist (e.g. an import that resolves to a
+    // path the build context cannot access — pub packages without source/,
+    // etc.). `canRead` is a cheap existence probe; `compilationUnitFor`
+    // raises on missing assets, so this guards us before the parse.
+    bool exists;
+    try {
+      exists = await step.canRead(assetId);
+    } on Object {
+      continue;
+    }
+    if (!exists) continue;
+    final CompilationUnit imported;
+    try {
+      imported = await step.resolver.compilationUnitFor(assetId);
+    } on Object {
+      continue;
+    }
+    for (final decl in imported.declarations) {
+      if (decl is! ClassDeclaration) continue;
+      final className = decl.name.lexeme;
+      if (!wantedTypes.contains(className)) continue;
+      final scalarNames = <String>{};
+      final collectionNames = <String>{};
+      for (final member in decl.members) {
+        if (member is FieldDeclaration) {
+          final isSolidState = member.metadata.any(
+            (a) => a.name.name == solidStateName,
+          );
+          if (!isSolidState) continue;
+          final variable = member.fields.variables.first;
+          final fieldName = variable.name.lexeme;
+          scalarNames.add(fieldName);
+          // Mirror the collection-detection rule in signal_emitter.dart so
+          // the cross-file collection set agrees with the same-file one.
+          final type = member.fields.type;
+          if (type == null) continue;
+          final isNullable = type.question != null;
+          final hasInitializer = variable.initializer != null;
+          final isLate = member.fields.isLate;
+          if (isLate || isNullable || !hasInitializer) continue;
+          if (parseCollectionTypeText(type.toSource()) != null) {
+            collectionNames.add(fieldName);
+          }
+        } else if (member is MethodDeclaration && member.isGetter) {
+          final isSolidState = member.metadata.any(
+            (a) => a.name.name == solidStateName,
+          );
+          if (isSolidState) scalarNames.add(member.name.lexeme);
+        }
+      }
+      if (scalarNames.isNotEmpty) {
+        classRegistry[className] = scalarNames;
+        if (collectionNames.isNotEmpty) {
+          classCollectionFields[className] = collectionNames;
+        }
+      }
+      wantedTypes.remove(className);
+    }
+  }
+}
+
+/// Maps an `import '<uri>';` URI to the `AssetId` of its source-side input,
+/// or `null` when the import cannot be resolved.
+///
+/// Within the **current package**, `package:foo/path.dart` and `lib/path.dart`
+/// relative imports are redirected to `source/path.dart` — the user's
+/// `@SolidState` annotations live in `source/`, not the post-transformation
+/// `lib/`. Other-package imports stay as-is.
+AssetId? _resolveImportToSourceAsset(String uri, AssetId from) {
+  final Uri parsed;
+  try {
+    parsed = Uri.parse(uri);
+  } on Object {
+    return null;
+  }
+  final AssetId resolved;
+  try {
+    resolved = AssetId.resolve(parsed, from: from);
+  } on Object {
+    return null;
+  }
+  if (resolved.package == from.package && resolved.path.startsWith('lib/')) {
+    return AssetId(
+      resolved.package,
+      'source/${resolved.path.substring('lib/'.length)}',
+    );
+  }
+  return resolved;
+}

--- a/packages/solid_generator/lib/builder.dart
+++ b/packages/solid_generator/lib/builder.dart
@@ -244,9 +244,9 @@ Map<String, Set<String>> _prescanClassRegistry(CompilationUnit unit) {
 ///
 /// Mirrors the collection-detection rule in `signal_emitter.dart` so the
 /// cross-file scan agrees with same-file emission: a field qualifies iff
-/// (a) the declared type matches `parseCollectionTypeText`, (b) it has an
-/// initializer (collection signals have no `.lazy` ctor), and (c) it is
-/// non-nullable (collection signals reject null).
+/// the declared type matches `parseCollectionTypeText` AND it is
+/// non-nullable. `late` is irrelevant — collection signals are emitted
+/// even for `late` fields (with an empty default literal).
 Map<String, Set<String>> _prescanClassCollectionFields(CompilationUnit unit) {
   final registry = <String, Set<String>>{};
   for (final decl in unit.declarations) {
@@ -258,9 +258,7 @@ Map<String, Set<String>> _prescanClassCollectionFields(CompilationUnit unit) {
       final variable = member.fields.variables.first;
       final type = member.fields.type;
       if (type == null) continue;
-      if (member.fields.isLate) continue;
       if (type.question != null) continue;
-      if (variable.initializer == null) continue;
       if (parseCollectionTypeText(type.toSource()) == null) continue;
       names.add(variable.name.lexeme);
     }
@@ -753,13 +751,12 @@ Future<void> _populateCrossFileTypes(
           final fieldName = variable.name.lexeme;
           scalarNames.add(fieldName);
           // Mirror the collection-detection rule in signal_emitter.dart so
-          // the cross-file collection set agrees with the same-file one.
+          // the cross-file collection set agrees with the same-file one:
+          // collection signals are emitted for any non-nullable `List<T>`
+          // / `Set<T>` / `Map<K, V>` field — `late` does not exclude.
           final type = member.fields.type;
           if (type == null) continue;
-          final isNullable = type.question != null;
-          final hasInitializer = variable.initializer != null;
-          final isLate = member.fields.isLate;
-          if (isLate || isNullable || !hasInitializer) continue;
+          if (type.question != null) continue;
           if (parseCollectionTypeText(type.toSource()) != null) {
             collectionNames.add(fieldName);
           }

--- a/packages/solid_generator/lib/src/annotation_reader.dart
+++ b/packages/solid_generator/lib/src/annotation_reader.dart
@@ -124,6 +124,9 @@ GetterModel? readSolidStateGetter(
   Set<String> reactiveFields,
   String source, {
   Set<String> queryNames = const {},
+  Map<String, Set<String>> classRegistry = const {},
+  Map<String, Set<String>> classCollectionFields = const {},
+  Map<String, String> environmentFields = const {},
 }) {
   if (!decl.isGetter || decl.isStatic) return null;
   final annotation = findAnnotationByName(solidStateName, decl.metadata);
@@ -158,6 +161,9 @@ GetterModel? readSolidStateGetter(
         '@SolidState getter must have an expression body (=> ...) or a '
         'block body ({ ... }); abstract and native bodies are not supported',
     queryNames: queryNames,
+    classRegistry: classRegistry,
+    classCollectionFields: classCollectionFields,
+    environmentFields: environmentFields,
   );
 
   return GetterModel(
@@ -207,6 +213,9 @@ _readReactiveBody(
   required String unsupportedBodyError,
   Set<String> queryNames = const {},
   String? currentMember,
+  Map<String, Set<String>> classRegistry = const {},
+  Map<String, Set<String>> classCollectionFields = const {},
+  Map<String, String> environmentFields = const {},
 }) {
   final AstNode node;
   final bool isBlockBody;
@@ -225,14 +234,19 @@ _readReactiveBody(
     source,
     queryNames: queryNames,
     currentMember: currentMember,
+    classRegistry: classRegistry,
+    classCollectionFields: classCollectionFields,
+    environmentFields: environmentFields,
   );
   // Zero-deps Effect / Computed are rejected. A reactive dep is either a
-  // `.value`-rewritten state read OR a tracked query-call invocation.
-  // Queries pass `null` here because the deps requirement is waived for
-  // them.
+  // `.value`-rewritten state read, a tracked query-call invocation, OR a
+  // cross-class read that produced a tracked-read offset (cross-class reads
+  // record offsets even when the rewrite emits no edit — e.g. `xs.length`
+  // on a ListSignal field reached via env-injection).
   if (emptyDepsError != null &&
       result.edits.isEmpty &&
-      result.trackedQueryNames.isEmpty) {
+      result.trackedQueryNames.isEmpty &&
+      result.trackedReadOffsets.isEmpty) {
     throw CodeGenerationError(emptyDepsError, null, memberName);
   }
   final bodyText = applyEditsToRange(
@@ -269,6 +283,9 @@ EffectModel? readSolidEffectMethod(
   Set<String> reactiveFields,
   String source, {
   Set<String> queryNames = const {},
+  Map<String, Set<String>> classRegistry = const {},
+  Map<String, Set<String>> classCollectionFields = const {},
+  Map<String, String> environmentFields = const {},
 }) {
   if (decl.isGetter || decl.isSetter || decl.isStatic) return null;
   final annotation = findAnnotationByName(solidEffectName, decl.metadata);
@@ -297,6 +314,9 @@ EffectModel? readSolidEffectMethod(
         '@SolidEffect method must have an expression body (=> ...) or a '
         'block body ({ ... }); abstract and native bodies are not supported',
     queryNames: queryNames,
+    classRegistry: classRegistry,
+    classCollectionFields: classCollectionFields,
+    environmentFields: environmentFields,
   );
 
   return EffectModel(
@@ -328,6 +348,9 @@ QueryModel? readSolidQueryMethod(
   Set<String> reactiveFields,
   String source, {
   Set<String> queryNames = const {},
+  Map<String, Set<String>> classRegistry = const {},
+  Map<String, Set<String>> classCollectionFields = const {},
+  Map<String, String> environmentFields = const {},
 }) {
   if (decl.isGetter || decl.isSetter || decl.isStatic) return null;
   final annotation = findAnnotationByName(solidQueryName, decl.metadata);
@@ -365,6 +388,9 @@ QueryModel? readSolidQueryMethod(
         'block body ({ ... }); abstract and native bodies are not supported',
     queryNames: queryNames,
     currentMember: methodName,
+    classRegistry: classRegistry,
+    classCollectionFields: classCollectionFields,
+    environmentFields: environmentFields,
   );
 
   // A self-cycle is rejected at codegen — solidart would re-run

--- a/packages/solid_generator/lib/src/annotation_reader.dart
+++ b/packages/solid_generator/lib/src/annotation_reader.dart
@@ -127,6 +127,7 @@ GetterModel? readSolidStateGetter(
   Map<String, Set<String>> classRegistry = const {},
   Map<String, Set<String>> classCollectionFields = const {},
   Map<String, String> environmentFields = const {},
+  Set<String> collectionFields = const {},
 }) {
   if (!decl.isGetter || decl.isStatic) return null;
   final annotation = findAnnotationByName(solidStateName, decl.metadata);
@@ -164,6 +165,7 @@ GetterModel? readSolidStateGetter(
     classRegistry: classRegistry,
     classCollectionFields: classCollectionFields,
     environmentFields: environmentFields,
+    collectionFields: collectionFields,
   );
 
   return GetterModel(
@@ -216,6 +218,7 @@ _readReactiveBody(
   Map<String, Set<String>> classRegistry = const {},
   Map<String, Set<String>> classCollectionFields = const {},
   Map<String, String> environmentFields = const {},
+  Set<String> collectionFields = const {},
 }) {
   final AstNode node;
   final bool isBlockBody;
@@ -237,6 +240,7 @@ _readReactiveBody(
     classRegistry: classRegistry,
     classCollectionFields: classCollectionFields,
     environmentFields: environmentFields,
+    collectionFields: collectionFields,
   );
   // Zero-deps Effect / Computed are rejected. A reactive dep is either a
   // `.value`-rewritten state read, a tracked query-call invocation, OR a
@@ -286,6 +290,7 @@ EffectModel? readSolidEffectMethod(
   Map<String, Set<String>> classRegistry = const {},
   Map<String, Set<String>> classCollectionFields = const {},
   Map<String, String> environmentFields = const {},
+  Set<String> collectionFields = const {},
 }) {
   if (decl.isGetter || decl.isSetter || decl.isStatic) return null;
   final annotation = findAnnotationByName(solidEffectName, decl.metadata);
@@ -317,6 +322,7 @@ EffectModel? readSolidEffectMethod(
     classRegistry: classRegistry,
     classCollectionFields: classCollectionFields,
     environmentFields: environmentFields,
+    collectionFields: collectionFields,
   );
 
   return EffectModel(
@@ -351,6 +357,7 @@ QueryModel? readSolidQueryMethod(
   Map<String, Set<String>> classRegistry = const {},
   Map<String, Set<String>> classCollectionFields = const {},
   Map<String, String> environmentFields = const {},
+  Set<String> collectionFields = const {},
 }) {
   if (decl.isGetter || decl.isSetter || decl.isStatic) return null;
   final annotation = findAnnotationByName(solidQueryName, decl.metadata);
@@ -391,6 +398,7 @@ QueryModel? readSolidQueryMethod(
     classRegistry: classRegistry,
     classCollectionFields: classCollectionFields,
     environmentFields: environmentFields,
+    collectionFields: collectionFields,
   );
 
   // A self-cycle is rejected at codegen — solidart would re-run

--- a/packages/solid_generator/lib/src/build_rewriter.dart
+++ b/packages/solid_generator/lib/src/build_rewriter.dart
@@ -64,6 +64,18 @@ class SourceEdit {
 /// config object. Empty set → no-op for callers whose `build` body does not
 /// change scope (state-class / plain-class).
 ///
+/// [collectionFields] is the subset of [reactiveFields] whose emitted ctor
+/// is a collection signal (`ListSignal<T>` / `SetSignal<T>` /
+/// `MapSignal<K, V>`). Threaded through to the value-rewrite visitor so
+/// chain accesses and bare reads on these fields skip the `.value` append
+/// (they resolve through the collection-signal mixin directly). Writes
+/// still rewrite to `.value =`.
+///
+/// [classCollectionFields] is the cross-class collection-field map (class
+/// name → collection field names). Mirrors [classRegistry] for the
+/// collection-signal slice: `<envField>.<collectionField>` shapes skip
+/// `.value` and resolve through the mixin on the receiver chain directly.
+///
 /// [source] is the full source text of the input file. The returned string
 /// is the rewritten build method (from `@override` through the closing `}`),
 /// ready for the caller to embed into the emitted `State` class.
@@ -75,6 +87,8 @@ String rewriteBuildMethod(
   Map<String, Set<String>> classRegistry = const {},
   Map<String, String> environmentFields = const {},
   Set<String> widgetBoundFields = const {},
+  Set<String> collectionFields = const {},
+  Map<String, Set<String>> classCollectionFields = const {},
 }) {
   final methodStart = buildMethod.offset;
   final methodEnd = buildMethod.end;
@@ -88,6 +102,8 @@ String rewriteBuildMethod(
     classRegistry: classRegistry,
     environmentFields: environmentFields,
     widgetBoundFields: widgetBoundFields,
+    collectionFields: collectionFields,
+    classCollectionFields: classCollectionFields,
   );
   final wrapNodes = computeWrapSet(
     buildMethod,

--- a/packages/solid_generator/lib/src/import_rewriter.dart
+++ b/packages/solid_generator/lib/src/import_rewriter.dart
@@ -36,6 +36,12 @@ const Set<String> solidartNames = {
   'Resource',
   'SignalBuilder',
   'SolidartConfig',
+  // Collection-typed `@SolidState` fields lower to one of these
+  // (`List<T>` → ListSignal, `Set<T>` → SetSignal, `Map<K, V>` → MapSignal)
+  // via `parseCollectionTypeText` in `signal_emitter.dart`.
+  'ListSignal',
+  'SetSignal',
+  'MapSignal',
 };
 
 /// One annotated class's contribution to the generated output.

--- a/packages/solid_generator/lib/src/plain_class_rewriter.dart
+++ b/packages/solid_generator/lib/src/plain_class_rewriter.dart
@@ -58,12 +58,14 @@ RewriteResult rewritePlainClass(
   List<QueryModel> solidQueries,
   List<EnvironmentModel> solidEnvironments,
   Map<String, Set<String>> classRegistry,
+  Map<String, Set<String>> classCollectionFields,
   String source,
 ) {
   final className = classDecl.name.lexeme;
-  // getter→Computed only ships for `StatelessWidget`; reject here so the
-  // valid-target pass isn't silently undone.
-  rejectIfGettersNotYetSupported(solidGetters, 'plain class', className);
+  // `@SolidState` getters on plain classes (Computed lowering) ARE supported
+  // via the same `emitComputedField` path the stateless rewriter uses — see
+  // the source-ordered walk below. The previous rejection is dropped now
+  // that the walk handles getter members.
   // `@SolidEnvironment` requires a `BuildContext`, which only widget/state
   // hosts provide — plain classes cannot resolve `context.read`. The
   // user-facing rejection comes from `validateSolidEnvironmentTargets`; this
@@ -77,24 +79,36 @@ RewriteResult rewritePlainClass(
       className,
     );
   }
-  // Source-ordered emission so Signal fields, Effect fields, and Resource
-  // fields interleave by declaration order — required for reverse-disposal
-  // correctness (an Effect or Resource must be declared after the Signals it
-  // reads, so reverse order disposes dependents before their dependencies).
+  // Source-ordered emission so Signal fields, Computed getters, Effect
+  // fields, and Resource fields interleave by declaration order — required
+  // for reverse-disposal correctness (an Effect, Computed, or Resource must
+  // be declared after the Signals it reads, so reverse order disposes
+  // dependents before their dependencies).
   final fieldByName = {for (final f in solidFields) f.fieldName: f};
+  final getterByName = {for (final g in solidGetters) g.getterName: g};
   final effectByName = {for (final e in solidEffects) e.methodName: e};
   final queryByName = {for (final q in solidQueries) q.methodName: q};
-  // Fields-only: getters are rejected on this rewriter today
-  // (`rejectIfGettersNotYetSupported`).
   final reactiveTypeTexts = <String, String>{
     for (final f in solidFields) f.fieldName: f.typeText,
+    for (final g in solidGetters) g.getterName: g.typeText,
   };
   // Cross-query deps: each upstream's inner `T` is needed to emit
   // `ResourceState<T>` elements in the synthesized source-Computed.
   final queryInnerTypeTexts = solidQueries.isEmpty
       ? const <String, String>{}
       : {for (final q in solidQueries) q.methodName: q.innerTypeText};
-  final reactiveNames = fieldByName.keys.toSet();
+  final reactiveNames = <String>{
+    ...fieldByName.keys,
+    ...getterByName.keys,
+  };
+  // Subset of `reactiveNames` whose emitter produces a collection signal
+  // — drives the no-`.value`-on-chain rule in the user-method body
+  // rewrite below (and in any future computed-getter / constructor-merge
+  // body rewrites).
+  final collectionNames = <String>{
+    for (final f in solidFields)
+      if (isCollectionSignalField(f)) f.fieldName,
+  };
 
   final pieces = <String>[];
   final disposeNames = <String>[];
@@ -106,16 +120,21 @@ RewriteResult rewritePlainClass(
   // synthesized fields.
   MethodDeclaration? disposeMethod;
   var disposeSlot = -1;
+  // User-declared constructors (zero or more) are recorded for a merged
+  // emit after the walk — the merge needs `effectNames` populated to
+  // splice in the Effect-materialization reads at the end of each user
+  // body. Slot indices preserve source-order position. Only generative
+  // constructors get the merge; factory constructors round-trip verbatim
+  // (they synthesise via a delegate, not by running this ctor's body).
+  final userCtors = <ConstructorDeclaration>[];
+  final userCtorSlots = <int>[];
 
   for (final member in classDecl.members) {
     if (member is ConstructorDeclaration) {
-      // Constructor-merge would need to gate the synthesized Effect-
-      // materialization constructor; deferred to a later milestone.
-      throw CodeGenerationError(
-        'plain class with constructor is not yet supported',
-        null,
-        className,
-      );
+      userCtors.add(member);
+      userCtorSlots.add(pieces.length);
+      pieces.add('');
+      continue;
     }
     if (member is FieldDeclaration) {
       final varName = member.fields.variables.first.name.lexeme;
@@ -130,7 +149,14 @@ RewriteResult rewritePlainClass(
     }
     if (member is MethodDeclaration) {
       final name = member.name.lexeme;
-      if (name == 'dispose') {
+      if (member.isGetter && getterByName.containsKey(name)) {
+        // `@SolidState` getter on a plain class → `late final … = Computed<T>(…)`.
+        // Source-order disposal puts the Computed after its dependencies so
+        // the reverse-iteration `dispose()` body tears it down first.
+        final getter = getterByName[name]!;
+        pieces.add(emitComputedField(getter));
+        disposeNames.add(getter.getterName);
+      } else if (name == 'dispose') {
         disposeMethod = member;
         disposeSlot = pieces.length;
         pieces.add('');
@@ -152,7 +178,14 @@ RewriteResult rewritePlainClass(
         );
       } else {
         pieces.add(
-          _rewriteUserMethod(member, reactiveNames, classRegistry, source),
+          _rewriteUserMethod(
+            member,
+            reactiveNames,
+            classRegistry,
+            source,
+            collectionFields: collectionNames,
+            classCollectionFields: classCollectionFields,
+          ),
         );
       }
       continue;
@@ -160,6 +193,48 @@ RewriteResult rewritePlainClass(
     pieces.add(source.substring(member.offset, member.end));
   }
 
+  // User-declared constructors: merge each one to splice Effect-
+  // materialization reads after the user's body, apply `.value` rewrites
+  // to any same-class reactive field writes (`this.signal = …` lowers to
+  // `this.signal.value = …`), and strip the `const` modifier (the class
+  // fields are no longer const-eligible — they hold Signal instances).
+  for (var i = 0; i < userCtors.length; i++) {
+    final ctor = userCtors[i];
+    // Generative constructors get the merge. Factory constructors round-
+    // trip verbatim: their body is a delegating return, not the host's
+    // `initState`-equivalent, so spliced Effect reads would never fire.
+    final isFactory = ctor.factoryKeyword != null;
+    if (isFactory) {
+      pieces[userCtorSlots[i]] = source.substring(ctor.offset, ctor.end);
+      continue;
+    }
+    // Apply `.value` rewrites to the constructor body (and initializer
+    // list expressions). The same `collectValueEdits` pipeline that runs
+    // on user methods handles same-class field writes and cross-class
+    // chain reads. The constructor's argument list and headers are
+    // shielded — the visitor walks the body subtree but offsets remain
+    // file-global, so `applyEditsToRange` correctly splices into the
+    // merged result.
+    final mergedHeaderAndBody = mergeConstructor(
+      ctor,
+      effectNames,
+      source,
+      className,
+    );
+    final result = collectValueEdits(
+      ctor,
+      reactiveNames,
+      source,
+      classRegistry: classRegistry,
+      collectionFields: collectionNames,
+      classCollectionFields: classCollectionFields,
+    );
+    pieces[userCtorSlots[i]] = applyEditsToRange(
+      mergedHeaderAndBody,
+      result.edits,
+      ctor.offset,
+    );
+  }
   // Dispose: merge into user body if present, else synthesize. `@override`
   // is emitted in either case (the marker interface contract). On the merge
   // path the user's `@override` (if any) is carried through verbatim by
@@ -173,27 +248,56 @@ RewriteResult rewritePlainClass(
           emitOverride: true,
           emitSuperCall: false,
         );
-  // No-arg constructor: only when Effects need materialization. When the
-  // user declared `dispose()`, place the constructor immediately before
-  // the (slot-reserved) dispose body so the rendered order is fields →
-  // ctor → dispose.
+  // No-arg synthesized constructor: only when (a) Effects need
+  // materialization AND (b) the user did NOT declare any constructor.
+  // When the user declared at least one constructor, every generative
+  // user ctor already had the Effect-materialization reads spliced in
+  // above (`mergeConstructor`), so an extra synthesized ctor would
+  // conflict with the existing default-name ctor.
   if (disposeMethod != null) {
     pieces[disposeSlot] = disposeText;
-    if (effectNames.isNotEmpty) {
+    if (effectNames.isNotEmpty && userCtors.isEmpty) {
       pieces.insert(disposeSlot, emitConstructor(className, effectNames));
     }
   } else {
-    if (effectNames.isNotEmpty) {
+    if (effectNames.isNotEmpty && userCtors.isEmpty) {
       pieces.add(emitConstructor(className, effectNames));
     }
     pieces.add(disposeText);
   }
 
   final header = _buildHeaderWithDisposable(classDecl, source);
+  final hasScalarSignalField = solidFields.any(
+    (f) => !isCollectionSignalField(f),
+  );
+  final hasListSignalField = solidFields.any(
+    (f) =>
+        isCollectionSignalField(f) &&
+        parseCollectionTypeText(f.typeText)?.ctorName == 'ListSignal',
+  );
+  final hasSetSignalField = solidFields.any(
+    (f) =>
+        isCollectionSignalField(f) &&
+        parseCollectionTypeText(f.typeText)?.ctorName == 'SetSignal',
+  );
+  final hasMapSignalField = solidFields.any(
+    (f) =>
+        isCollectionSignalField(f) &&
+        parseCollectionTypeText(f.typeText)?.ctorName == 'MapSignal',
+  );
   return (
     text: '$header{\n${pieces.join('\n\n')}\n}',
     solidartNames: <String>{
-      'Signal',
+      // Plain classes always declare at least one reactive field/getter to
+      // reach this rewriter, but the field set may be entirely
+      // collection-typed (`ListSignal` / `SetSignal` / `MapSignal`) so the
+      // `Signal` import is only added when at least one scalar field is
+      // present.
+      if (hasScalarSignalField) 'Signal',
+      if (hasListSignalField) 'ListSignal',
+      if (hasSetSignalField) 'SetSignal',
+      if (hasMapSignalField) 'MapSignal',
+      if (solidGetters.isNotEmpty) 'Computed',
       if (effectNames.isNotEmpty) 'Effect',
       if (solidQueries.isNotEmpty) 'Resource',
       // A multi-dep query synthesizes a Record-Computed source field,
@@ -240,18 +344,25 @@ String _buildHeaderWithDisposable(ClassDeclaration classDecl, String source) {
 /// Emits a non-annotated user method with the `.value` rewrite applied to
 /// its body — both the same-class branch (bare `SimpleIdentifier` reads of
 /// [reactiveFields]) and the cross-class single-level branch from
-/// [classRegistry] in one AST walk.
+/// [classRegistry] in one AST walk. [collectionFields] and
+/// [classCollectionFields] suppress `.value` insertion for collection-typed
+/// reactive fields (`ListSignal` / `SetSignal` / `MapSignal`) on the chain-
+/// access and bare-read paths.
 String _rewriteUserMethod(
   MethodDeclaration method,
   Set<String> reactiveFields,
   Map<String, Set<String>> classRegistry,
-  String source,
-) {
+  String source, {
+  Set<String> collectionFields = const {},
+  Map<String, Set<String>> classCollectionFields = const {},
+}) {
   final result = collectValueEdits(
     method,
     reactiveFields,
     source,
     classRegistry: classRegistry,
+    collectionFields: collectionFields,
+    classCollectionFields: classCollectionFields,
   );
   return applyEditsToRange(
     source.substring(method.offset, method.end),

--- a/packages/solid_generator/lib/src/plain_class_rewriter.dart
+++ b/packages/solid_generator/lib/src/plain_class_rewriter.dart
@@ -150,9 +150,10 @@ RewriteResult rewritePlainClass(
     if (member is MethodDeclaration) {
       final name = member.name.lexeme;
       if (member.isGetter && getterByName.containsKey(name)) {
-        // `@SolidState` getter on a plain class → `late final … = Computed<T>(…)`.
-        // Source-order disposal puts the Computed after its dependencies so
-        // the reverse-iteration `dispose()` body tears it down first.
+        // `@SolidState` getter on a plain class lowers to
+        // `late final … = Computed<T>(…)`. Source-order disposal puts the
+        // Computed after its dependencies so the reverse-iteration
+        // `dispose()` body tears it down first.
         final getter = getterByName[name]!;
         pieces.add(emitComputedField(getter));
         disposeNames.add(getter.getterName);

--- a/packages/solid_generator/lib/src/signal_emitter.dart
+++ b/packages/solid_generator/lib/src/signal_emitter.dart
@@ -8,29 +8,97 @@ import 'package:solid_generator/src/transformation_error.dart';
 
 /// Shared signal-emission helpers used by every class-kind rewriter.
 
+/// Parsed shape of a collection-type `@SolidState` field — the constructor
+/// name (`'ListSignal'` / `'SetSignal'` / `'MapSignal'`) and the inner type-
+/// argument text (e.g. `'Todo'` for `List<Todo>`, `'String, int'` for
+/// `Map<String, int>`).
+///
+/// Returned by [parseCollectionTypeText]; consumed by [emitSignalField] and
+/// the rewriters that build the collection-fields name set.
+typedef CollectionSignalKind = ({String ctorName, String innerType});
+
+/// Returns the collection-signal kind for [typeText] when it names a
+/// top-level `List<T>`, `Set<T>`, or `Map<K, V>` — otherwise `null`.
+///
+/// Pure textual: matches `^(List|Set|Map)<...>$` shapes. Nested generics
+/// (`List<List<int>>`) round-trip through the inner-text slice. The match
+/// is conservative — `Iterable<int>`, namespace-prefixed aliases
+/// (`core.List<int>`), and user-defined names that happen to start with
+/// `List<` (none exist in `dart:core`) are intentionally NOT matched and
+/// fall through to plain `Signal<T>`.
+CollectionSignalKind? parseCollectionTypeText(String typeText) {
+  if (typeText.startsWith('List<') && typeText.endsWith('>')) {
+    return (
+      ctorName: 'ListSignal',
+      innerType: typeText.substring(5, typeText.length - 1),
+    );
+  }
+  if (typeText.startsWith('Set<') && typeText.endsWith('>')) {
+    return (
+      ctorName: 'SetSignal',
+      innerType: typeText.substring(4, typeText.length - 1),
+    );
+  }
+  if (typeText.startsWith('Map<') && typeText.endsWith('>')) {
+    return (
+      ctorName: 'MapSignal',
+      innerType: typeText.substring(4, typeText.length - 1),
+    );
+  }
+  return null;
+}
+
+/// True iff [emitSignalField] would emit a collection-signal constructor
+/// (`ListSignal` / `SetSignal` / `MapSignal`) for [f]. The contract: the
+/// declared type matches [parseCollectionTypeText], the field has an
+/// initializer (collection signals have no `.lazy` ctor), and the field is
+/// non-nullable (collection signals reject null). Late + nullable + no-init
+/// fields fall back to plain `Signal<T>` and are reported as non-collection
+/// here so callers don't include them in the same-class collection set used
+/// by the value-rewriter's no-`.value`-on-chain rule.
+bool isCollectionSignalField(FieldModel f) {
+  if (f.isLate) return false;
+  if (f.isNullable) return false;
+  if (f.initializerText.isEmpty) return false;
+  return parseCollectionTypeText(f.typeText) != null;
+}
+
 /// Emits one `[late ]final <name> = Signal<T>(…, name: '<debug>');` line.
 ///
 /// Three cases, in priority order:
 ///
 /// 1. **Has initializer** →
-///    `Signal<T>(<init>, name: '<debug>')`. The `late` modifier (if any)
-///    is preserved verbatim so that `Signal` construction itself is deferred
-///    to first access.
+///    `Signal<T>(<init>, name: '<debug>')` — OR `ListSignal<T>` / `SetSignal<T>`
+///    / `MapSignal<K, V>` when the declared type is a collection
+///    (per [parseCollectionTypeText]) AND the field is non-nullable.
+///    The `late` modifier (if any) is preserved verbatim so that `Signal`
+///    construction itself is deferred to first access.
 /// 2. **No initializer, nullable type** →
 ///    `Signal<T?>(null, name: '<debug>')`. No `late` needed because `null`
-///    is a valid default.
+///    is a valid default. Collection signals are not used here because they
+///    reject null at the signal level.
 /// 3. **No initializer, non-nullable type** →
 ///    `Signal<T>.lazy(name: '<debug>')`. The source field must have been
 ///    declared `late` (the only way Dart accepts a non-nullable field with
 ///    no initializer); the modifier is preserved on the emitted field so
 ///    reads before the first write throw `StateError`, matching Dart's own
-///    `late` semantics.
+///    `late` semantics. Collection signals are not used here because they
+///    have no `.lazy` constructor.
 String emitSignalField(FieldModel f) {
   final debugName = f.annotationName ?? f.fieldName;
   final lateKw = f.isLate ? 'late ' : '';
   final String ctor;
   if (f.initializerText.isNotEmpty) {
-    ctor = "Signal<${f.typeText}>(${f.initializerText}, name: '$debugName')";
+    final collection = isCollectionSignalField(f)
+        ? parseCollectionTypeText(f.typeText)
+        : null;
+    if (collection != null) {
+      ctor =
+          '${collection.ctorName}<${collection.innerType}>'
+          "(${f.initializerText}, name: '$debugName')";
+    } else {
+      ctor = "Signal<${f.typeText}>(${f.initializerText}, name: '$debugName')";
+    }
   } else if (f.isNullable) {
     ctor = "Signal<${f.typeText}>(null, name: '$debugName')";
   } else {
@@ -399,4 +467,65 @@ String emitConstructor(
   }
   buffer.write('  }');
   return buffer.toString();
+}
+
+/// Splices Effect-materialization reads (`<effectName>;`, in declaration
+/// order) into the END of a user-declared plain-class constructor body,
+/// after any user statements. The user's body is preserved verbatim — only
+/// the trailing `}` is shifted to make room for the materialization lines.
+///
+/// Empty bodies (`;` / `{}`) are normalized to `{}` with the
+/// materialization lines as the only contents. Initializer lists, factory
+/// keywords, named/redirecting ctors, and `const` modifiers round-trip
+/// verbatim; the merge only edits the BODY, not the header.
+///
+/// `const` is stripped from the lowered constructor: a plain class lowered
+/// by this rewriter holds mutable `Signal<T>` / `Computed<T>` / `Effect`
+/// fields, so `const ClassName()` is no longer compile-valid. Same rule as
+/// the StatelessWidget → State split.
+///
+/// Throws [CodeGenerationError] for expression-body ctors (`=> …`) — Dart
+/// constructors cannot have expression bodies, so this is a defense-in-
+/// depth guard rather than an expected user path.
+String mergeConstructor(
+  ConstructorDeclaration ctor,
+  List<String> effectNamesInDeclarationOrder,
+  String source,
+  String className,
+) {
+  final body = ctor.body;
+  // Slice the constructor header verbatim, then attach a normalised body.
+  // The header includes constructor name + parameter list + initializer
+  // list (everything from `ctor.offset` up to the body's start).
+  final headerEnd = body.offset;
+  var header = source.substring(ctor.offset, headerEnd);
+  // Strip a leading `const ` from the header — the class fields are no
+  // longer const-eligible (they hold Signal/Computed/Effect instances).
+  // Match `const` followed by whitespace; only the user-declared modifier
+  // is stripped, not appearances elsewhere in the header (initializer
+  // list literals etc.).
+  header = header.replaceFirst(RegExp(r'^\s*const\s+'), '');
+  final reads = effectNamesInDeclarationOrder
+      .map((name) => '    $name;')
+      .join('\n');
+  if (body is EmptyFunctionBody) {
+    // `Foo();` → `Foo() { ... }`.
+    if (reads.isEmpty) return source.substring(ctor.offset, ctor.end);
+    return '$header{\n$reads\n  }';
+  }
+  if (body is BlockFunctionBody) {
+    final rbrace = body.block.rightBracket.offset;
+    final bodyPrefix = source.substring(body.offset, rbrace);
+    if (reads.isEmpty) {
+      return '$header${source.substring(body.offset, body.end)}';
+    }
+    // Splice `\n<reads>\n` immediately before the closing `}`.
+    return '$header$bodyPrefix\n$reads\n  }';
+  }
+  throw CodeGenerationError(
+    'plain-class constructor must have a block body or no body for '
+    'Effect-materialization merge',
+    null,
+    className,
+  );
 }

--- a/packages/solid_generator/lib/src/signal_emitter.dart
+++ b/packages/solid_generator/lib/src/signal_emitter.dart
@@ -65,10 +65,14 @@ bool isCollectionSignalField(FieldModel f) {
 }
 
 /// Returns the empty-literal source for a collection-signal initializer
-/// when the source field has no explicit `= …` clause. `List<T>` → `const
-/// <T>[]`, `Set<T>` → `const <T>{}`, `Map<K, V>` → `const <K, V>{}`. The
-/// inner-type text is spliced verbatim so generic args round-trip
-/// (`List<List<int>>` → `const <List<int>>[]`).
+/// when the source field has no explicit `= …` clause:
+///
+/// - `List<T>` → `const <T>[]`
+/// - `Set<T>`  → `const <T>{}`
+/// - `Map<K, V>` → `const <K, V>{}`
+///
+/// The inner-type text is spliced verbatim so generic args round-trip —
+/// `List<List<int>>` → `const <List<int>>[]`.
 String _emptyCollectionLiteral(CollectionSignalKind kind) {
   switch (kind.ctorName) {
     case 'ListSignal':

--- a/packages/solid_generator/lib/src/signal_emitter.dart
+++ b/packages/solid_generator/lib/src/signal_emitter.dart
@@ -50,55 +50,72 @@ CollectionSignalKind? parseCollectionTypeText(String typeText) {
 
 /// True iff [emitSignalField] would emit a collection-signal constructor
 /// (`ListSignal` / `SetSignal` / `MapSignal`) for [f]. The contract: the
-/// declared type matches [parseCollectionTypeText], the field has an
-/// initializer (collection signals have no `.lazy` ctor), and the field is
-/// non-nullable (collection signals reject null). Late + nullable + no-init
-/// fields fall back to plain `Signal<T>` and are reported as non-collection
-/// here so callers don't include them in the same-class collection set used
-/// by the value-rewriter's no-`.value`-on-chain rule.
+/// declared type matches [parseCollectionTypeText] AND the field is
+/// non-nullable.
+///
+/// `late` is NOT a barrier — collection signals are mutated in place (the
+/// reference stays final; the contents change via mixin methods), so a
+/// `late List<T> xs;` source field can still lower to a `ListSignal<T>`
+/// initialised to an empty literal. Only nullable types still fall back
+/// to plain `Signal<T?>` because collection signals reject null at the
+/// signal level.
 bool isCollectionSignalField(FieldModel f) {
-  if (f.isLate) return false;
   if (f.isNullable) return false;
-  if (f.initializerText.isEmpty) return false;
   return parseCollectionTypeText(f.typeText) != null;
+}
+
+/// Returns the empty-literal source for a collection-signal initializer
+/// when the source field has no explicit `= …` clause. `List<T>` → `const
+/// <T>[]`, `Set<T>` → `const <T>{}`, `Map<K, V>` → `const <K, V>{}`. The
+/// inner-type text is spliced verbatim so generic args round-trip
+/// (`List<List<int>>` → `const <List<int>>[]`).
+String _emptyCollectionLiteral(CollectionSignalKind kind) {
+  switch (kind.ctorName) {
+    case 'ListSignal':
+      return 'const <${kind.innerType}>[]';
+    case 'SetSignal':
+    case 'MapSignal':
+      return 'const <${kind.innerType}>{}';
+  }
+  // Unreachable — `parseCollectionTypeText` only produces these three names.
+  throw StateError('unknown collection ctor: ${kind.ctorName}');
 }
 
 /// Emits one `[late ]final <name> = Signal<T>(…, name: '<debug>');` line.
 ///
-/// Three cases, in priority order:
+/// Collection fields (`List<T>` / `Set<T>` / `Map<K, V>`, non-nullable)
+/// lower to `ListSignal<T>` / `SetSignal<T>` / `MapSignal<K, V>` regardless
+/// of `late`. The user's `= …` clause is spliced verbatim when present;
+/// otherwise an empty literal (`const <T>[]` / `const <T>{}` /
+/// `const <K, V>{}`) is used. The collection-signal mixin tracks reads
+/// through the same channels `.value` would, so `late` adds no value here
+/// (and collection signals don't expose `.lazy` anyway).
 ///
-/// 1. **Has initializer** →
-///    `Signal<T>(<init>, name: '<debug>')` — OR `ListSignal<T>` / `SetSignal<T>`
-///    / `MapSignal<K, V>` when the declared type is a collection
-///    (per [parseCollectionTypeText]) AND the field is non-nullable.
-///    The `late` modifier (if any) is preserved verbatim so that `Signal`
+/// Non-collection (scalar) cases, in priority order:
+///
+/// 1. **Has initializer** → `Signal<T>(<init>, name: '<debug>')`. The
+///    `late` modifier (if any) is preserved verbatim so that `Signal`
 ///    construction itself is deferred to first access.
-/// 2. **No initializer, nullable type** →
-///    `Signal<T?>(null, name: '<debug>')`. No `late` needed because `null`
-///    is a valid default. Collection signals are not used here because they
-///    reject null at the signal level.
+/// 2. **No initializer, nullable type** → `Signal<T?>(null, name: '…')`.
+///    No `late` needed because `null` is a valid default.
 /// 3. **No initializer, non-nullable type** →
-///    `Signal<T>.lazy(name: '<debug>')`. The source field must have been
-///    declared `late` (the only way Dart accepts a non-nullable field with
-///    no initializer); the modifier is preserved on the emitted field so
-///    reads before the first write throw `StateError`, matching Dart's own
-///    `late` semantics. Collection signals are not used here because they
-///    have no `.lazy` constructor.
+///    `Signal<T>.lazy(name: '…')`. The source field must have been
+///    declared `late`; reads before the first write throw `StateError`,
+///    matching Dart's own `late` semantics.
 String emitSignalField(FieldModel f) {
   final debugName = f.annotationName ?? f.fieldName;
   final lateKw = f.isLate ? 'late ' : '';
   final String ctor;
-  if (f.initializerText.isNotEmpty) {
-    final collection = isCollectionSignalField(f)
-        ? parseCollectionTypeText(f.typeText)
-        : null;
-    if (collection != null) {
-      ctor =
-          '${collection.ctorName}<${collection.innerType}>'
-          "(${f.initializerText}, name: '$debugName')";
-    } else {
-      ctor = "Signal<${f.typeText}>(${f.initializerText}, name: '$debugName')";
-    }
+  if (isCollectionSignalField(f)) {
+    final collection = parseCollectionTypeText(f.typeText)!;
+    final init = f.initializerText.isNotEmpty
+        ? f.initializerText
+        : _emptyCollectionLiteral(collection);
+    ctor =
+        '${collection.ctorName}<${collection.innerType}>'
+        "($init, name: '$debugName')";
+  } else if (f.initializerText.isNotEmpty) {
+    ctor = "Signal<${f.typeText}>(${f.initializerText}, name: '$debugName')";
   } else if (f.isNullable) {
     ctor = "Signal<${f.typeText}>(null, name: '$debugName')";
   } else {

--- a/packages/solid_generator/lib/src/state_class_rewriter.dart
+++ b/packages/solid_generator/lib/src/state_class_rewriter.dart
@@ -40,6 +40,7 @@ RewriteResult rewriteStateClass(
   List<QueryModel> solidQueries,
   List<EnvironmentModel> solidEnvironments,
   Map<String, Set<String>> classRegistry,
+  Map<String, Set<String>> classCollectionFields,
   String source,
 ) {
   final className = classDecl.name.lexeme;
@@ -87,12 +88,24 @@ RewriteResult rewriteStateClass(
   final environmentFields = solidEnvironments.isEmpty
       ? const <String, String>{}
       : {for (final e in solidEnvironments) e.fieldName: e.typeText};
+  // Subset of `reactiveNames` whose emitter produces a collection signal
+  // (`ListSignal<T>` / `SetSignal<T>` / `MapSignal<K, V>`). Drives the
+  // value-rewriter's no-`.value`-on-chain rule for these fields.
+  final collectionNames = <String>{
+    for (final f in solidFields)
+      if (isCollectionSignalField(f)) f.fieldName,
+  };
   // Built incrementally during the walk so Signal field names, Effect method
   // names, and Query method names interleave in source-declaration order —
   // the contract `emitDispose` relies on for reverse-disposal correctness.
   final disposeNames = <String>[];
   final effectNames = <String>[];
   final pieces = <String>[];
+  // Set during the `build` branch when the rewriter emitted at least one
+  // `SignalBuilder` wrap — drives the `flutter_solidart` import even when
+  // the class itself has no own `@SolidState` field (the env-only host
+  // reading through to a sibling class's reactive state).
+  var buildHasSignalBuilder = false;
   // `initState`/`dispose` emission is deferred until after the walk so the
   // merge sees the fully-populated `effectNames` / `disposeNames` lists.
   // The slot index reserves the member's source-order position in `pieces`
@@ -127,16 +140,20 @@ RewriteResult rewriteStateClass(
     if (member is MethodDeclaration) {
       final name = member.name.lexeme;
       if (name == 'build') {
-        pieces.add(
-          rewriteBuildMethod(
-            member,
-            reactiveNames,
-            source,
-            queryNames: queryNames,
-            classRegistry: classRegistry,
-            environmentFields: environmentFields,
-          ),
+        final buildText = rewriteBuildMethod(
+          member,
+          reactiveNames,
+          source,
+          queryNames: queryNames,
+          classRegistry: classRegistry,
+          environmentFields: environmentFields,
+          collectionFields: collectionNames,
+          classCollectionFields: classCollectionFields,
         );
+        pieces.add(buildText);
+        if (buildText.contains('SignalBuilder(')) {
+          buildHasSignalBuilder = true;
+        }
       } else if (name == 'initState') {
         initStateMethod = member;
         initStateSlot = pieces.length;
@@ -199,19 +216,40 @@ RewriteResult rewriteStateClass(
     classDecl.offset,
     classDecl.leftBracket.offset,
   );
+  final hasScalarSignalField = solidFields.any(
+    (f) => !isCollectionSignalField(f),
+  );
+  final hasListSignalField = solidFields.any(
+    (f) =>
+        isCollectionSignalField(f) &&
+        parseCollectionTypeText(f.typeText)?.ctorName == 'ListSignal',
+  );
+  final hasSetSignalField = solidFields.any(
+    (f) =>
+        isCollectionSignalField(f) &&
+        parseCollectionTypeText(f.typeText)?.ctorName == 'SetSignal',
+  );
+  final hasMapSignalField = solidFields.any(
+    (f) =>
+        isCollectionSignalField(f) &&
+        parseCollectionTypeText(f.typeText)?.ctorName == 'MapSignal',
+  );
   return (
     text: '$header{\n${pieces.join('\n\n')}\n}',
     solidartNames: <String>{
-      // `Signal` is only emitted when the class has at least one `@SolidState`
-      // field. An env-only host has no Signal reference in lowered output and
-      // so does NOT pull in `flutter_solidart`.
-      if (solidFields.isNotEmpty) 'Signal',
+      // `Signal` is only emitted when the class has at least one scalar
+      // `@SolidState` field. Collection-typed fields use ListSignal /
+      // SetSignal / MapSignal instead — see Section 4.4 of SPEC.md.
+      if (hasScalarSignalField) 'Signal',
+      if (hasListSignalField) 'ListSignal',
+      if (hasSetSignalField) 'SetSignal',
+      if (hasMapSignalField) 'MapSignal',
       if (effectNames.isNotEmpty) 'Effect',
       // Queries emit `Resource<T>(...)` fields; their `<query>().when(...)`
       // call sites in `build` are wrapped in `SignalBuilder` by
       // `rewriteBuildMethod` when at least one query is present.
       if (solidQueries.isNotEmpty) 'Resource',
-      if (solidQueries.isNotEmpty) 'SignalBuilder',
+      if (solidQueries.isNotEmpty || buildHasSignalBuilder) 'SignalBuilder',
       // A multi-dep query synthesizes a Record-Computed source field,
       // requiring `Computed` in the import set even when the class has no
       // `@SolidState` getter.

--- a/packages/solid_generator/lib/src/stateless_rewriter.dart
+++ b/packages/solid_generator/lib/src/stateless_rewriter.dart
@@ -26,6 +26,7 @@ RewriteResult rewriteStatelessWidget(
   List<QueryModel> solidQueries,
   List<EnvironmentModel> solidEnvironments,
   Map<String, Set<String>> classRegistry,
+  Map<String, Set<String>> classCollectionFields,
   String source,
 ) {
   final className = classDecl.name.lexeme;
@@ -33,6 +34,14 @@ RewriteResult rewriteStatelessWidget(
   final reactiveNames = <String>{
     ...solidFields.map((f) => f.fieldName),
     ...solidGetters.map((g) => g.getterName),
+  };
+  // Subset of `reactiveNames` whose emitter produces a collection signal
+  // (`ListSignal<T>` / `SetSignal<T>` / `MapSignal<K, V>`). Used by the
+  // value-rewriter to skip `.value` on chain accesses and bare reads of
+  // these fields — the mixin API resolves through the signal directly.
+  final collectionNames = <String>{
+    for (final f in solidFields)
+      if (isCollectionSignalField(f)) f.fieldName,
   };
   // Query call expressions in `build` are tracked reads. Names are kept
   // separate from `reactiveNames` so the `.value` rewrite does not fire on
@@ -88,6 +97,8 @@ RewriteResult rewriteStatelessWidget(
     classRegistry: classRegistry,
     environmentFields: environmentFields,
     widgetBoundFields: widgetBoundForBuild,
+    collectionFields: collectionNames,
+    classCollectionFields: classCollectionFields,
   );
 
   final reactiveBlock = _emitReactiveBlock(
@@ -116,17 +127,44 @@ RewriteResult rewriteStatelessWidget(
     buildMethodText: buildMethodText,
   );
 
-  // `Signal` and `SignalBuilder` are only emitted when there's a same-class
-  // reactive declaration to wrap. An env-only class (simple-environment shape)
-  // has no Signal/SignalBuilder reference in its lowered output and so does
-  // NOT pull in `flutter_solidart`.
+  // `Signal` and `SignalBuilder` are emitted when EITHER the class has its
+  // own same-class reactive declaration OR the build body wraps a
+  // cross-class tracked read in `SignalBuilder` (the env-injected receiver
+  // shape — the consumer has no own state but reads through to a sibling
+  // class's `@SolidState`). The textual scan on `buildMethodText` catches
+  // the cross-class case without re-walking the AST.
   final hasReactive =
       solidFields.isNotEmpty ||
       solidGetters.isNotEmpty ||
       solidQueries.isNotEmpty;
+  final buildEmitsSignalBuilder = buildMethodText.contains('SignalBuilder(');
+  // A field's emitted ctor is one of: Signal / ListSignal / SetSignal /
+  // MapSignal. Collection emitters bypass `Signal` entirely, so the import
+  // set follows the per-field decision rather than blanket-adding `Signal`.
+  final hasScalarSignalField = solidFields.any(
+    (f) => !isCollectionSignalField(f),
+  );
+  final hasListSignalField = solidFields.any(
+    (f) =>
+        isCollectionSignalField(f) &&
+        parseCollectionTypeText(f.typeText)?.ctorName == 'ListSignal',
+  );
+  final hasSetSignalField = solidFields.any(
+    (f) =>
+        isCollectionSignalField(f) &&
+        parseCollectionTypeText(f.typeText)?.ctorName == 'SetSignal',
+  );
+  final hasMapSignalField = solidFields.any(
+    (f) =>
+        isCollectionSignalField(f) &&
+        parseCollectionTypeText(f.typeText)?.ctorName == 'MapSignal',
+  );
   final solidartNames = <String>{
-    if (solidFields.isNotEmpty) 'Signal',
-    if (hasReactive) 'SignalBuilder',
+    if (hasScalarSignalField) 'Signal',
+    if (hasListSignalField) 'ListSignal',
+    if (hasSetSignalField) 'SetSignal',
+    if (hasMapSignalField) 'MapSignal',
+    if (hasReactive || buildEmitsSignalBuilder) 'SignalBuilder',
   };
   if (solidGetters.isNotEmpty) solidartNames.add('Computed');
   if (solidEffects.isNotEmpty) solidartNames.add('Effect');

--- a/packages/solid_generator/lib/src/value_rewriter.dart
+++ b/packages/solid_generator/lib/src/value_rewriter.dart
@@ -87,9 +87,13 @@ bool _isOnPrefixedCallbackName(String name) {
 /// [reactiveFields] is the name-set of `@SolidState` fields and getters
 /// declared on the enclosing class. The rewrite is name-based; the
 /// `type_aware_no_double_append` golden locks in the no-double-append
-/// guarantee at the name-set boundary. Full type-driven resolution
-/// (`buildStep.resolver.compilationUnitFor` + `staticType` subtype queries)
-/// is deferred — it is the architectural prerequisite for shadowing support.
+/// guarantee at the name-set boundary. Cross-file resolution for
+/// `@SolidEnvironment` types is now wired via `BuildStep.resolver` (see
+/// `builder.dart::_populateCrossFileTypes`) — `[classRegistry]` and
+/// `[classCollectionFields]` already include cross-file entries by the
+/// time this function is called. Full `staticType` subtype queries
+/// (covering arbitrary parameter / local-receiver shapes) remain deferred
+/// — they are the architectural prerequisite for shadowing support.
 ///
 /// [queryNames] is the name-set of `@SolidQuery` methods declared on the
 /// enclosing class. Zero-argument `MethodInvocation`s whose target is
@@ -141,6 +145,8 @@ ValueRewriteResult collectValueEdits(
   Map<String, Set<String>> classRegistry = const {},
   Map<String, String> environmentFields = const {},
   Set<String> widgetBoundFields = const {},
+  Set<String> collectionFields = const {},
+  Map<String, Set<String>> classCollectionFields = const {},
 }) {
   final visitor = _ValueRewriteVisitor(
     reactiveFields,
@@ -149,6 +155,8 @@ ValueRewriteResult collectValueEdits(
     classRegistry,
     environmentFields,
     widgetBoundFields,
+    collectionFields,
+    classCollectionFields,
   );
   node.accept(visitor);
   return ValueRewriteResult(
@@ -207,6 +215,8 @@ class _ValueRewriteVisitor extends RecursiveAstVisitor<void> {
     this._classRegistry,
     this._environmentFields,
     this._widgetBoundFields,
+    this._collectionFields,
+    this._classCollectionFields,
   );
 
   final Set<String> _reactiveFields;
@@ -247,6 +257,23 @@ class _ValueRewriteVisitor extends RecursiveAstVisitor<void> {
   /// set before passing). Empty for callers that do NOT move bodies between
   /// scopes (state-class rewriter, plain-class rewriter).
   final Set<String> _widgetBoundFields;
+
+  /// Same-class `@SolidState` field names whose emitted constructor is a
+  /// collection signal (`ListSignal<T>` / `SetSignal<T>` / `MapSignal<K, V>`).
+  /// Subset of [_reactiveFields]. Collection signals expose the full
+  /// `ListMixin` / `SetMixin` / `MapMixin` API directly on the signal, so
+  /// chain accesses (`xs.length`, `xs.add(x)`, `xs[i]`) and bare-read
+  /// references (`final l = xs;`) do NOT receive a `.value` append. Writes
+  /// (`xs = newList`) still rewrite to `xs.value = newList` via the Signal
+  /// setter — that path is shared with scalar fields.
+  final Set<String> _collectionFields;
+
+  /// Cross-class collection-field map (class name → collection field names).
+  /// Subset of [_classRegistry]. Drives the same no-`.value`-on-chain rule as
+  /// [_collectionFields] but for `<envField>.<collectionField>` shapes —
+  /// `controller.todos.length` resolves to `ListSignal<Todo>.length` and
+  /// must NOT receive a `.value` append between `todos` and `length`.
+  final Map<String, Set<String>> _classCollectionFields;
 
   final List<ValueEdit> edits = [];
   final List<int> trackedReadOffsets = [];
@@ -435,6 +462,19 @@ class _ValueRewriteVisitor extends RecursiveAstVisitor<void> {
   /// [_isShadowed] (which covers only `visitFunctionExpression` and
   /// block-local declarations), so the lookup ORDER carries the
   /// parameter-vs-field shadowing semantics here.
+  ///
+  /// Collection-field branch: if the resolved field is in
+  /// [_classCollectionFields] for its receiver type AND the whole
+  /// `<receiver>.<field>` shape is used as the prefix of a longer chain
+  /// (parent is `PropertyAccess` / `MethodInvocation` / `IndexExpression` /
+  /// `PrefixedIdentifier`), the rewrite skips the `.value` append — the
+  /// trailing `.length` / `.where(…)` / `[i]` resolves through the
+  /// collection-signal mixin directly. For a bare cross-class collection
+  /// read (used as the whole return value, argument, or RHS), `.value` is
+  /// inserted so the reactive context subscribes — without it, the
+  /// returned `ListSignal` reference is identity-stable and a `Computed`
+  /// body would never invalidate. Tracking always fires so the surrounding
+  /// widget subtree is wrapped in `SignalBuilder`.
   void _maybeRewriteCrossClass(PrefixedIdentifier node) {
     if (_isShadowed(node.prefix.name)) return;
     if (_isAccessedValueProperty(node.identifier)) return;
@@ -445,10 +485,35 @@ class _ValueRewriteVisitor extends RecursiveAstVisitor<void> {
     final fieldsOfType = _classRegistry[declaredTypeName];
     if (fieldsOfType == null) return;
     if (!fieldsOfType.contains(node.identifier.name)) return;
-    edits.add(ValueEdit(node.end, node.end, '.value'));
+    final collectionFieldsOfType = _classCollectionFields[declaredTypeName];
+    final isCollection =
+        collectionFieldsOfType != null &&
+        collectionFieldsOfType.contains(node.identifier.name);
+    final isChainPrefix = _isCrossClassChainPrefix(node);
+    if (!isCollection || !isChainPrefix) {
+      edits.add(ValueEdit(node.end, node.end, '.value'));
+    }
     if (_untrackedDepth == 0) {
       trackedReadOffsets.add(node.offset);
     }
+  }
+
+  /// True if [node] (a `<receiver>.<field>` PrefixedIdentifier) is itself
+  /// used as the prefix of a longer chain — i.e. the parent expression
+  /// reaches a member access, method invocation, or index expression on
+  /// top of it. Mirrors [_isChainPrefix] for the same-class branch.
+  ///
+  /// `PrefixedIdentifier.prefix` is always a `SimpleIdentifier`, so an
+  /// `a.b.c` chain parses as `PropertyAccess(target=PrefixedIdentifier(a,
+  /// b), property=c)` — never as nested `PrefixedIdentifier`s. The
+  /// PropertyAccess / MethodInvocation / IndexExpression branches cover
+  /// every legal chain-prefix shape.
+  bool _isCrossClassChainPrefix(PrefixedIdentifier node) {
+    final parent = node.parent;
+    if (parent is PropertyAccess && parent.target == node) return true;
+    if (parent is MethodInvocation && parent.target == node) return true;
+    if (parent is IndexExpression && parent.target == node) return true;
+    return false;
   }
 
   /// If [prefix] resolves to a method/function parameter declared with a
@@ -532,6 +597,36 @@ class _ValueRewriteVisitor extends RecursiveAstVisitor<void> {
     final name = node.name;
     if (_isTrackedField(name)) {
       if (_isAccessedValueProperty(node)) return;
+
+      // Collection-typed `@SolidState` fields: ListSignal / SetSignal /
+      // MapSignal expose their underlying collection API directly via
+      // mixin, so chain accesses (`xs.length`, `xs.add(x)`, `xs[i]`)
+      // resolve through the mixin and notify subscribers from inside the
+      // reactive primitive. A bare reference is different — the local
+      // variable, return value, or argument captures the ListSignal
+      // object identity, which does NOT subscribe the surrounding
+      // reactive context (a `Computed` body that just returns the
+      // collection signal would never invalidate). So bare reads STILL
+      // get the standard `.value` append; only chain prefixes skip it.
+      if (_collectionFields.contains(name)) {
+        if (_isChainPrefix(node)) {
+          if (_untrackedDepth == 0) {
+            trackedReadOffsets.add(node.offset);
+            _recordTrackedReadName(name);
+          }
+          return;
+        }
+        if (!_isBareReferenceToField(node)) return;
+        edits.add(ValueEdit(node.end, node.end, '.value'));
+        final isGet = node.inGetterContext();
+        final isSet = node.inSetterContext();
+        if (isGet && !isSet && _untrackedDepth == 0) {
+          trackedReadOffsets.add(node.offset);
+          _recordTrackedReadName(name);
+        }
+        return;
+      }
+
       if (!_isBareReferenceToField(node)) return;
 
       edits.add(ValueEdit(node.end, node.end, '.value'));
@@ -555,6 +650,22 @@ class _ValueRewriteVisitor extends RecursiveAstVisitor<void> {
       if (!_isBareReferenceToField(node)) return;
       edits.add(ValueEdit(node.offset, node.offset, 'widget.'));
     }
+  }
+
+  /// True if [id] occupies the receiver position of a chain access —
+  /// the prefix of a `PrefixedIdentifier`, the target of a `PropertyAccess`
+  /// / `MethodInvocation` / `IndexExpression`. Used by the collection-field
+  /// branch of [visitSimpleIdentifier] to recognise `xs.<member>`,
+  /// `xs.method(...)`, `xs[i]`, and `xs.cascade...` shapes, all of which
+  /// resolve through the collection-signal mixin and must NOT receive a
+  /// `.value` append.
+  bool _isChainPrefix(SimpleIdentifier id) {
+    final parent = id.parent;
+    if (parent is PrefixedIdentifier && parent.prefix == id) return true;
+    if (parent is PropertyAccess && parent.target == id) return true;
+    if (parent is MethodInvocation && parent.target == id) return true;
+    if (parent is IndexExpression && parent.target == id) return true;
+    return false;
   }
 
   /// Appends [name] to [trackedReadNames] iff not already present, preserving

--- a/packages/solid_generator/lib/src/value_rewriter.dart
+++ b/packages/solid_generator/lib/src/value_rewriter.dart
@@ -498,12 +498,12 @@ class _ValueRewriteVisitor extends RecursiveAstVisitor<void> {
     }
   }
 
-  /// True if [node] is the `target` of its parent expression — `PropertyAccess`,
-  /// `MethodInvocation`, `IndexExpression`, or `CascadeExpression`. Every
-  /// chain shape carries its receiver on a `target` field on the outer
-  /// node, so checking the parent is the only way to detect a cascade
-  /// (whose implicit receiver bypasses a member-chain on the inner
-  /// identifier entirely).
+  /// True if [node] is the `target` of its parent expression — any of
+  /// `PropertyAccess`, `MethodInvocation`, `IndexExpression`, or
+  /// `CascadeExpression`. Every chain shape carries its receiver on a
+  /// `target` field on the outer node, so checking the parent is the only
+  /// way to detect a cascade (whose implicit receiver bypasses a
+  /// member-chain on the inner identifier entirely).
   ///
   /// Used by both same-class ([_isChainPrefix]) and cross-class
   /// ([_isCrossClassChainPrefix]) branches.

--- a/packages/solid_generator/lib/src/value_rewriter.dart
+++ b/packages/solid_generator/lib/src/value_rewriter.dart
@@ -498,23 +498,32 @@ class _ValueRewriteVisitor extends RecursiveAstVisitor<void> {
     }
   }
 
-  /// True if [node] (a `<receiver>.<field>` PrefixedIdentifier) is itself
-  /// used as the prefix of a longer chain — i.e. the parent expression
-  /// reaches a member access, method invocation, or index expression on
-  /// top of it. Mirrors [_isChainPrefix] for the same-class branch.
+  /// True if [node] is the `target` of its parent expression — `PropertyAccess`,
+  /// `MethodInvocation`, `IndexExpression`, or `CascadeExpression`. Every
+  /// chain shape carries its receiver on a `target` field on the outer
+  /// node, so checking the parent is the only way to detect a cascade
+  /// (whose implicit receiver bypasses a member-chain on the inner
+  /// identifier entirely).
   ///
-  /// `PrefixedIdentifier.prefix` is always a `SimpleIdentifier`, so an
-  /// `a.b.c` chain parses as `PropertyAccess(target=PrefixedIdentifier(a,
-  /// b), property=c)` — never as nested `PrefixedIdentifier`s. The
-  /// PropertyAccess / MethodInvocation / IndexExpression branches cover
-  /// every legal chain-prefix shape.
-  bool _isCrossClassChainPrefix(PrefixedIdentifier node) {
+  /// Used by both same-class ([_isChainPrefix]) and cross-class
+  /// ([_isCrossClassChainPrefix]) branches.
+  static bool _isAnyChainTarget(Expression node) {
     final parent = node.parent;
     if (parent is PropertyAccess && parent.target == node) return true;
     if (parent is MethodInvocation && parent.target == node) return true;
     if (parent is IndexExpression && parent.target == node) return true;
+    if (parent is CascadeExpression && parent.target == node) return true;
     return false;
   }
+
+  /// True if [node] (a `<receiver>.<field>` PrefixedIdentifier) is itself
+  /// used as the prefix of a longer chain. `PrefixedIdentifier.prefix` is
+  /// always a `SimpleIdentifier`, so an `a.b.c` chain parses as
+  /// `PropertyAccess(target=PrefixedIdentifier(a, b), property=c)` —
+  /// never as nested `PrefixedIdentifier`s. Hence the cross-class case
+  /// delegates entirely to [_isAnyChainTarget].
+  bool _isCrossClassChainPrefix(PrefixedIdentifier node) =>
+      _isAnyChainTarget(node);
 
   /// If [prefix] resolves to a method/function parameter declared with a
   /// [NamedType] annotation, returns that type's simple name (e.g. `'Counter'`
@@ -653,19 +662,16 @@ class _ValueRewriteVisitor extends RecursiveAstVisitor<void> {
   }
 
   /// True if [id] occupies the receiver position of a chain access —
-  /// the prefix of a `PrefixedIdentifier`, the target of a `PropertyAccess`
-  /// / `MethodInvocation` / `IndexExpression`. Used by the collection-field
-  /// branch of [visitSimpleIdentifier] to recognise `xs.<member>`,
-  /// `xs.method(...)`, `xs[i]`, and `xs.cascade...` shapes, all of which
-  /// resolve through the collection-signal mixin and must NOT receive a
-  /// `.value` append.
+  /// the prefix of a `PrefixedIdentifier`, OR any of the four
+  /// chain-target shapes covered by [_isAnyChainTarget]. Used by the
+  /// collection-field branch of [visitSimpleIdentifier] to recognise
+  /// `xs.<member>`, `xs.method(...)`, `xs[i]`, and `xs..add(1)..add(2)`
+  /// cascades — all of which resolve through the collection-signal mixin
+  /// and must NOT receive a `.value` append.
   bool _isChainPrefix(SimpleIdentifier id) {
     final parent = id.parent;
     if (parent is PrefixedIdentifier && parent.prefix == id) return true;
-    if (parent is PropertyAccess && parent.target == id) return true;
-    if (parent is MethodInvocation && parent.target == id) return true;
-    if (parent is IndexExpression && parent.target == id) return true;
-    return false;
+    return _isAnyChainTarget(id);
   }
 
   /// Appends [name] to [trackedReadNames] iff not already present, preserving

--- a/packages/solid_generator/test/golden/inputs/collection_cascade.dart
+++ b/packages/solid_generator/test/golden/inputs/collection_cascade.dart
@@ -1,0 +1,27 @@
+// Cascade chain reads on collection signals must NOT receive a `.value`
+// insertion between the receiver identifier and the cascade sections —
+// `CascadeExpression.target` is the collection identifier, so
+// `_isChainPrefix` matches and the rewriter skips the append. The cascade
+// sections themselves (`..add(7)`, `..['x'] = 1`) target the cascade's
+// implicit receiver, which is the underlying signal — and `ListSignal` /
+// `MapSignal` mutators notify subscribers from inside the mixin.
+
+import 'package:solid_annotations/solid_annotations.dart';
+
+class CascadeProbe {
+  @SolidState()
+  List<int> xs = const [];
+
+  @SolidState()
+  Map<String, int> counts = const {};
+
+  void seed() {
+    xs
+      ..add(7)
+      ..add(8)
+      ..sort();
+    counts
+      ..['x'] = 1
+      ..['y'] = 2;
+  }
+}

--- a/packages/solid_generator/test/golden/inputs/collection_mixin_breadth.dart
+++ b/packages/solid_generator/test/golden/inputs/collection_mixin_breadth.dart
@@ -63,8 +63,8 @@ class Breadth extends StatelessWidget {
 
   void mutate() {
     // Mutation methods — direct calls on the signal (no `.value`),
-    // because the cascade-free single call shape is `MethodInvocation`
-    // with target=identifier, which `_isChainPrefix` catches.
+    // because the single-call shape is `MethodInvocation` with
+    // target=identifier, which `_isChainPrefix` catches.
     xs.add(1);
     xs.insert(0, 5);
     xs.removeAt(0);

--- a/packages/solid_generator/test/golden/inputs/collection_mixin_breadth.dart
+++ b/packages/solid_generator/test/golden/inputs/collection_mixin_breadth.dart
@@ -14,7 +14,10 @@
 // `[i] = v`, `[k] = v`, `putIfAbsent`). Every one of them must round-trip
 // without a `.value` between the signal and the member.
 
-// ignore_for_file: avoid_print
+// `print` is the canonical Effect side-effect demonstration; cascades are
+// pinned by a sibling fixture (`collection_cascade.dart`), so the bare
+// repeat-receiver calls in `mutate()` below are intentional.
+// ignore_for_file: avoid_print, cascade_invocations
 
 import 'package:flutter/widgets.dart';
 import 'package:solid_annotations/solid_annotations.dart';

--- a/packages/solid_generator/test/golden/inputs/collection_mixin_breadth.dart
+++ b/packages/solid_generator/test/golden/inputs/collection_mixin_breadth.dart
@@ -1,0 +1,93 @@
+// Pins the rule that NO collection-signal chain member receives a `.value`
+// insertion — the rewrite is keyed on the AST chain shape (`_isChainPrefix`
+// matching `PrefixedIdentifier.prefix` / `PropertyAccess.target` /
+// `MethodInvocation.target` / `IndexExpression.target`), so every
+// `ListMixin<E>` / `SetMixin<E>` / `MapMixin<K, V>` member resolves through
+// the signal directly — no method name is special-cased.
+//
+// `xs`, `tags`, `counts` are each collection signals. The build body and
+// the Computed bodies below exercise: property getters (`length`, `first`,
+// `isEmpty`, `keys`), instance methods returning iterables / primitives
+// (`where`, `map`, `fold`, `contains`, `containsKey`, `indexOf`,
+// `indexWhere`, `lookup`), index access (`[i]`, `[k]`), and mutation
+// methods (`add`, `insert`, `removeAt`, `removeWhere`, `sort`,
+// `[i] = v`, `[k] = v`, `putIfAbsent`). Every one of them must round-trip
+// without a `.value` between the signal and the member.
+
+// ignore_for_file: avoid_print
+
+import 'package:flutter/widgets.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Breadth extends StatelessWidget {
+  Breadth({super.key});
+
+  @SolidState()
+  List<int> xs = const [];
+
+  @SolidState()
+  Set<int> tags = const {};
+
+  @SolidState()
+  Map<String, int> counts = const {};
+
+  // Same-class Computed bodies exercising a wide mix of mixin members.
+  @SolidState()
+  int get sum => xs.fold<int>(0, (a, b) => a + b);
+
+  @SolidState()
+  int get evenCount => xs.where((i) => i.isEven).length;
+
+  @SolidState()
+  bool get hasOne => tags.contains(1);
+
+  @SolidState()
+  Iterable<String> get keys => counts.keys;
+
+  // Effect body uses a mixed bag of read shapes — every one resolves via
+  // the mixin on the signal, no `.value` insertion.
+  @SolidEffect()
+  void log() {
+    print(
+      'len=${xs.length} '
+      'first=${xs.first} '
+      'idx0=${xs[0]} '
+      'has-one=${tags.contains(1)} '
+      'keys=${counts.keys} '
+      'a=${counts['a']} '
+      'has-a=${counts.containsKey('a')} '
+      'indexOf=${xs.indexOf(0)} '
+      'indexWhere=${xs.indexWhere((i) => i > 5)}',
+    );
+  }
+
+  void mutate() {
+    // Mutation methods — direct calls on the signal (no `.value`),
+    // because the cascade-free single call shape is `MethodInvocation`
+    // with target=identifier, which `_isChainPrefix` catches.
+    xs.add(1);
+    xs.insert(0, 5);
+    xs.removeAt(0);
+    xs.removeWhere((i) => i.isOdd);
+    xs.sort();
+    xs[0] = 99;
+    tags.add(2);
+    tags.remove(2);
+    counts['a'] = 1;
+    counts.remove('a');
+    counts.putIfAbsent('b', () => 0);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      'sum=$sum '
+      'evens=$evenCount '
+      'has-one=$hasOne '
+      'last=${xs.last} '
+      'empty=${xs.isEmpty} '
+      'set-len=${tags.length} '
+      'map-len=${counts.length}',
+    );
+  }
+}

--- a/packages/solid_generator/test/golden/inputs/computed_on_plain_class.dart
+++ b/packages/solid_generator/test/golden/inputs/computed_on_plain_class.dart
@@ -1,0 +1,14 @@
+// `@SolidState` getter on a plain (non-Widget) class — Computed lowering
+// via the same `emitComputedField` path the stateless rewriter uses. The
+// getter declared after the Signal field reads it via the same-class
+// `.value` rewrite. Reverse disposal: doubled first, then value.
+
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Counter {
+  @SolidState()
+  int value = 0;
+
+  @SolidState()
+  int get doubled => value * 2;
+}

--- a/packages/solid_generator/test/golden/inputs/computed_reading_same_class_collection.dart
+++ b/packages/solid_generator/test/golden/inputs/computed_reading_same_class_collection.dart
@@ -1,0 +1,31 @@
+// Same-class collection chain reads inside a `@SolidState` getter body
+// must NOT receive `.value` insertion — `ListSignal<T>` / `SetSignal<T>` /
+// `MapSignal<K, V>` mix in their respective collection mixins and track
+// reads natively. The Computed body's `xs.where(...)` resolves through
+// `ListMixin.where` on the signal directly, and the resulting Iterable
+// subscribes the Computed via the same mechanism `.value` would.
+//
+// The Effect body below pins the same rule for `@SolidEffect`: a
+// same-class collection chain read inside the body subscribes through
+// the mixin without `.value`.
+
+// `print` is the canonical Effect side-effect demonstration.
+// ignore_for_file: avoid_print
+
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Inventory {
+  @SolidState()
+  List<int> items = const [];
+
+  @SolidState()
+  List<int> get evens => items.where((i) => i.isEven).toList();
+
+  @SolidState()
+  int get count => items.length;
+
+  @SolidEffect()
+  void log() {
+    print('count=${items.length}, first=${items[0]}');
+  }
+}

--- a/packages/solid_generator/test/golden/inputs/cross_class_list_signal_read.dart
+++ b/packages/solid_generator/test/golden/inputs/cross_class_list_signal_read.dart
@@ -1,0 +1,26 @@
+// Cross-class collection-signal read: `Controller.todos` is a `List<int>`
+// `@SolidState` field — lowers to `ListSignal<int>` — and is consumed by
+// `Display` via `@SolidEnvironment`. `controller.todos.length` must NOT
+// receive a `.value` between the receiver and `.length` (the `ListMixin`
+// member is reached through the signal directly). The enclosing `Text`
+// must still be wrapped in `SignalBuilder` so the read subscribes.
+
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+
+class Controller {
+  @SolidState()
+  List<int> todos = const [];
+}
+
+class Display extends StatelessWidget {
+  Display({super.key});
+
+  @SolidEnvironment()
+  late Controller controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text('count: ${controller.todos.length}');
+  }
+}

--- a/packages/solid_generator/test/golden/inputs/cross_file_environment_read/controllers.dart
+++ b/packages/solid_generator/test/golden/inputs/cross_file_environment_read/controllers.dart
@@ -1,0 +1,15 @@
+// Cross-file @SolidState host. Imported by `widget.dart` via
+// `package:a/cross_file_environment_read/controllers.dart` — the builder's
+// resolver pass redirects same-package `lib/` URIs to `source/` so the
+// pre-transformation annotations are visible to the cross-class chain
+// rewrite running on `widget.dart`.
+
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Counter {
+  @SolidState()
+  int value = 0;
+
+  @SolidState()
+  List<int> history = const [];
+}

--- a/packages/solid_generator/test/golden/inputs/cross_file_environment_read/widget.dart
+++ b/packages/solid_generator/test/golden/inputs/cross_file_environment_read/widget.dart
@@ -1,0 +1,34 @@
+// Cross-file @SolidEnvironment consumer. The injected `Counter` is defined
+// in `controllers.dart` (same package, different file). The build body must
+// rewrite `counter.value` → `counter.value.value` (scalar `@SolidState`
+// chain rewrite) AND `counter.history.length` MUST NOT receive a `.value`
+// insertion (the cross-file collection field is a `ListSignal<int>` whose
+// `ListMixin.length` is reached through the receiver chain directly).
+// Both reads are wrapped in `SignalBuilder`.
+
+// The `package:a/...` import is a `build_test`-synthesised package URI —
+// the analyzer cannot resolve it outside the multi-file golden harness,
+// so the `uri_does_not_exist` / `undefined_class` errors are expected
+// here and suppressed.
+// ignore_for_file: uri_does_not_exist, undefined_class
+
+import 'package:a/cross_file_environment_read/controllers.dart';
+import 'package:flutter/widgets.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Display extends StatelessWidget {
+  Display({super.key});
+
+  @SolidEnvironment()
+  late Counter counter;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Text('value: ${counter.value}'),
+        Text('history-len: ${counter.history.length}'),
+      ],
+    );
+  }
+}

--- a/packages/solid_generator/test/golden/inputs/list_signal_field.dart
+++ b/packages/solid_generator/test/golden/inputs/list_signal_field.dart
@@ -1,0 +1,35 @@
+// Collection-typed `@SolidState` field on a `StatelessWidget`. The emitter
+// produces `ListSignal<int>` (not `Signal<List<int>>`), and the value
+// rewriter SKIPS `.value` insertion on chain reads (`xs.length`,
+// `xs[i]`) because `ListSignal<T>` exposes the full `ListMixin<T>` API
+// directly. Direct mutations (`xs.add`, `xs[i] = v`) are emitted verbatim
+// (`ListSignal` notifies subscribers on each call). The pure-write
+// rewrite (`xs = ...`) still goes through `.value =`.
+
+import 'package:flutter/material.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+class ListProbe extends StatelessWidget {
+  ListProbe({super.key});
+
+  @SolidState()
+  List<int> xs = const [];
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Text('length: ${xs.length}'),
+        Text('first: ${xs[0]}'),
+        ElevatedButton(
+          onPressed: () => xs.add(1),
+          child: const Text('add'),
+        ),
+        ElevatedButton(
+          onPressed: () => xs[0] = 5,
+          child: const Text('set'),
+        ),
+      ],
+    );
+  }
+}

--- a/packages/solid_generator/test/golden/inputs/list_signal_lazy_fallback.dart
+++ b/packages/solid_generator/test/golden/inputs/list_signal_lazy_fallback.dart
@@ -1,18 +1,27 @@
-// `late List<T> xs;` with no initializer must NOT produce a `ListSignal` —
-// `ListSignal` has no `.lazy` constructor. The emitter falls back to
-// `Signal<List<T>>.lazy(...)`, matching the scalar-late path. Chain
-// reads still get `.value` rewriting under the plain-Signal path because
-// `xs` is NOT in the collection-fields name set (a `Signal<List<T>>` does
-// not expose `ListMixin` members directly).
+// `late List<T> xs;` / `late Set<T> tags;` / `late Map<K, V> hits;`
+// (non-nullable, no initializer) all lower to their respective collection
+// signals — the `late` modifier is irrelevant for collection signals
+// because the reference is final and mutation happens through the
+// `ListMixin` / `SetMixin` / `MapMixin` methods on the underlying
+// collection. The emitted ctors use empty literal defaults
+// (`const <T>[]`, `const <T>{}`, `const <K, V>{}`); the source `late`
+// modifier is preserved on each emitted field so signal construction
+// still defers to first access.
 
 import 'package:flutter/widgets.dart';
 import 'package:solid_annotations/solid_annotations.dart';
 
-class LateListProbe extends StatelessWidget {
-  LateListProbe({super.key});
+class LateCollectionProbe extends StatelessWidget {
+  LateCollectionProbe({super.key});
 
   @SolidState()
   late List<int> xs;
+
+  @SolidState()
+  late Set<String> tags;
+
+  @SolidState()
+  late Map<String, int> hits;
 
   @override
   Widget build(BuildContext context) => const Placeholder();

--- a/packages/solid_generator/test/golden/inputs/list_signal_lazy_fallback.dart
+++ b/packages/solid_generator/test/golden/inputs/list_signal_lazy_fallback.dart
@@ -1,0 +1,19 @@
+// `late List<T> xs;` with no initializer must NOT produce a `ListSignal` —
+// `ListSignal` has no `.lazy` constructor. The emitter falls back to
+// `Signal<List<T>>.lazy(...)`, matching the scalar-late path. Chain
+// reads still get `.value` rewriting under the plain-Signal path because
+// `xs` is NOT in the collection-fields name set (a `Signal<List<T>>` does
+// not expose `ListMixin` members directly).
+
+import 'package:flutter/widgets.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+class LateListProbe extends StatelessWidget {
+  LateListProbe({super.key});
+
+  @SolidState()
+  late List<int> xs;
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/golden/inputs/list_signal_nullable_fallback.dart
+++ b/packages/solid_generator/test/golden/inputs/list_signal_nullable_fallback.dart
@@ -1,0 +1,16 @@
+// `List<T>?` (nullable) must NOT produce a `ListSignal` — `ListSignal`
+// rejects null. The emitter falls back to `Signal<List<T>?>(null, ...)`,
+// matching the nullable-scalar path.
+
+import 'package:flutter/widgets.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+class NullableListProbe extends StatelessWidget {
+  NullableListProbe({super.key});
+
+  @SolidState()
+  List<int>? xs;
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/golden/inputs/map_signal_field.dart
+++ b/packages/solid_generator/test/golden/inputs/map_signal_field.dart
@@ -1,0 +1,32 @@
+// Collection-typed `@SolidState` field of type `Map<K, V>` → `MapSignal<K, V>`.
+// Same chain-access / mutation rules: `.length`, `.containsKey`, `[k]`, `[k]
+// = v`, `.remove` resolve through `MapMixin<K, V>` on the signal directly.
+
+import 'package:flutter/material.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+class MapProbe extends StatelessWidget {
+  MapProbe({super.key});
+
+  @SolidState()
+  Map<String, int> scores = const {};
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Text('count: ${scores.length}'),
+        Text('has-a: ${scores.containsKey('a')}'),
+        Text('value-a: ${scores['a']}'),
+        ElevatedButton(
+          onPressed: () => scores['a'] = 1,
+          child: const Text('set'),
+        ),
+        ElevatedButton(
+          onPressed: () => scores.remove('a'),
+          child: const Text('remove'),
+        ),
+      ],
+    );
+  }
+}

--- a/packages/solid_generator/test/golden/inputs/plain_class_named_ctor.dart
+++ b/packages/solid_generator/test/golden/inputs/plain_class_named_ctor.dart
@@ -1,0 +1,17 @@
+// Plain class with multiple named constructors — each generative one gets
+// the merge (initializer-list assignment to a `@SolidState` field is
+// rewritten in the body; here the only body is a default `;` body so the
+// merge is a no-op aside from `const` stripping).
+
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Counter {
+  Counter();
+
+  Counter.seeded(int init) {
+    value = init;
+  }
+
+  @SolidState()
+  late int value;
+}

--- a/packages/solid_generator/test/golden/inputs/plain_class_user_ctor_basic.dart
+++ b/packages/solid_generator/test/golden/inputs/plain_class_user_ctor_basic.dart
@@ -1,0 +1,17 @@
+// Plain class with a user-declared constructor that seeds a `@SolidState`
+// `late` field. The body's `value = init` assignment must rewrite to
+// `value.value = init` (same-class write rule). The `const` modifier (if
+// present on the source ctor) is stripped because the lowered class holds
+// a mutable `Signal<int>` field. No Effects, so no synthesized
+// materialization read is spliced.
+
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Counter {
+  Counter({int init = 0}) {
+    value = init;
+  }
+
+  @SolidState()
+  late int value;
+}

--- a/packages/solid_generator/test/golden/inputs/plain_class_user_ctor_with_effect.dart
+++ b/packages/solid_generator/test/golden/inputs/plain_class_user_ctor_with_effect.dart
@@ -1,0 +1,25 @@
+// Plain class with a user-declared constructor AND an `@SolidEffect` —
+// the merge must (a) preserve the user's body verbatim with `.value`
+// rewrites applied, AND (b) splice an `<effectName>;` materialization
+// read at the end of the body so the Effect's `late final` initialiser
+// runs during construction (the plain-class analogue of the State class's
+// `initState()` splice).
+
+// `print` is used as the Effect's canonical side-effect demonstration.
+// ignore_for_file: avoid_print
+
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Counter {
+  Counter({int init = 0}) {
+    value = init;
+  }
+
+  @SolidState()
+  late int value;
+
+  @SolidEffect()
+  void log() {
+    print('value: $value');
+  }
+}

--- a/packages/solid_generator/test/golden/inputs/set_signal_field.dart
+++ b/packages/solid_generator/test/golden/inputs/set_signal_field.dart
@@ -1,0 +1,31 @@
+// Collection-typed `@SolidState` field of type `Set<T>` → `SetSignal<T>`.
+// Same chain-access / mutation rules as `ListSignal`: `.length`, `.contains`,
+// `.add`, `.remove` resolve through `SetMixin<T>` on the signal directly.
+
+import 'package:flutter/material.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+class SetProbe extends StatelessWidget {
+  SetProbe({super.key});
+
+  @SolidState()
+  Set<int> tags = const {};
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Text('count: ${tags.length}'),
+        Text('has-1: ${tags.contains(1)}'),
+        ElevatedButton(
+          onPressed: () => tags.add(1),
+          child: const Text('add'),
+        ),
+        ElevatedButton(
+          onPressed: () => tags.remove(1),
+          child: const Text('remove'),
+        ),
+      ],
+    );
+  }
+}

--- a/packages/solid_generator/test/golden/outputs/collection_cascade.g.dart
+++ b/packages/solid_generator/test/golden/outputs/collection_cascade.g.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+class CascadeProbe implements Disposable {
+  final xs = ListSignal<int>(const [], name: 'xs');
+
+  final counts = MapSignal<String, int>(const {}, name: 'counts');
+
+  void seed() {
+    xs
+      ..add(7)
+      ..add(8)
+      ..sort();
+    counts
+      ..['x'] = 1
+      ..['y'] = 2;
+  }
+
+  @override
+  void dispose() {
+    counts.dispose();
+    xs.dispose();
+  }
+}

--- a/packages/solid_generator/test/golden/outputs/collection_mixin_breadth.g.dart
+++ b/packages/solid_generator/test/golden/outputs/collection_mixin_breadth.g.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class Breadth extends StatefulWidget {
+  const Breadth({super.key});
+
+  @override
+  State<Breadth> createState() => _BreadthState();
+}
+
+class _BreadthState extends State<Breadth> {
+  final xs = ListSignal<int>(const [], name: 'xs');
+  final tags = SetSignal<int>(const {}, name: 'tags');
+  final counts = MapSignal<String, int>(const {}, name: 'counts');
+  late final sum = Computed<int>(
+    () => xs.fold<int>(0, (a, b) => a + b),
+    name: 'sum',
+  );
+  late final evenCount = Computed<int>(
+    () => xs.where((i) => i.isEven).length,
+    name: 'evenCount',
+  );
+  late final hasOne = Computed<bool>(() => tags.contains(1), name: 'hasOne');
+  late final keys = Computed<Iterable<String>>(() => counts.keys, name: 'keys');
+  late final log = Effect(() {
+    print(
+      'len=${xs.length} '
+      'first=${xs.first} '
+      'idx0=${xs[0]} '
+      'has-one=${tags.contains(1)} '
+      'keys=${counts.keys} '
+      'a=${counts['a']} '
+      'has-a=${counts.containsKey('a')} '
+      'indexOf=${xs.indexOf(0)} '
+      'indexWhere=${xs.indexWhere((i) => i > 5)}',
+    );
+  }, name: 'log');
+
+  @override
+  void initState() {
+    super.initState();
+    log;
+  }
+
+  @override
+  void dispose() {
+    log.dispose();
+    keys.dispose();
+    hasOne.dispose();
+    evenCount.dispose();
+    sum.dispose();
+    counts.dispose();
+    tags.dispose();
+    xs.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SignalBuilder(
+      builder: (context, child) {
+        return Text(
+          'sum=${sum.value} '
+          'evens=${evenCount.value} '
+          'has-one=${hasOne.value} '
+          'last=${xs.last} '
+          'empty=${xs.isEmpty} '
+          'set-len=${tags.length} '
+          'map-len=${counts.length}',
+        );
+      },
+    );
+  }
+}

--- a/packages/solid_generator/test/golden/outputs/computed_on_plain_class.g.dart
+++ b/packages/solid_generator/test/golden/outputs/computed_on_plain_class.g.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Counter implements Disposable {
+  final value = Signal<int>(0, name: 'value');
+
+  late final doubled = Computed<int>(() => value.value * 2, name: 'doubled');
+
+  @override
+  void dispose() {
+    doubled.dispose();
+    value.dispose();
+  }
+}

--- a/packages/solid_generator/test/golden/outputs/computed_reading_same_class_collection.g.dart
+++ b/packages/solid_generator/test/golden/outputs/computed_reading_same_class_collection.g.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Inventory implements Disposable {
+  final items = ListSignal<int>(const [], name: 'items');
+
+  late final evens = Computed<List<int>>(
+    () => items.where((i) => i.isEven).toList(),
+    name: 'evens',
+  );
+
+  late final count = Computed<int>(() => items.length, name: 'count');
+
+  late final log = Effect(() {
+    print('count=${items.length}, first=${items[0]}');
+  }, name: 'log');
+
+  Inventory() {
+    log;
+  }
+
+  @override
+  void dispose() {
+    log.dispose();
+    count.dispose();
+    evens.dispose();
+    items.dispose();
+  }
+}

--- a/packages/solid_generator/test/golden/outputs/cross_class_list_signal_read.g.dart
+++ b/packages/solid_generator/test/golden/outputs/cross_class_list_signal_read.g.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:provider/provider.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Controller implements Disposable {
+  final todos = ListSignal<int>(const [], name: 'todos');
+
+  @override
+  void dispose() {
+    todos.dispose();
+  }
+}
+
+class Display extends StatefulWidget {
+  const Display({super.key});
+
+  @override
+  State<Display> createState() => _DisplayState();
+}
+
+class _DisplayState extends State<Display> {
+  late final controller = context.read<Controller>();
+
+  @override
+  Widget build(BuildContext context) {
+    return SignalBuilder(
+      builder: (context, child) {
+        return Text('count: ${controller.todos.length}');
+      },
+    );
+  }
+}

--- a/packages/solid_generator/test/golden/outputs/cross_file_environment_read/controllers.g.dart
+++ b/packages/solid_generator/test/golden/outputs/cross_file_environment_read/controllers.g.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Counter implements Disposable {
+  final value = Signal<int>(0, name: 'value');
+
+  final history = ListSignal<int>(const [], name: 'history');
+
+  @override
+  void dispose() {
+    history.dispose();
+    value.dispose();
+  }
+}

--- a/packages/solid_generator/test/golden/outputs/cross_file_environment_read/widget.g.dart
+++ b/packages/solid_generator/test/golden/outputs/cross_file_environment_read/widget.g.dart
@@ -1,0 +1,33 @@
+import 'package:a/cross_file_environment_read/controllers.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:provider/provider.dart';
+
+class Display extends StatefulWidget {
+  const Display({super.key});
+
+  @override
+  State<Display> createState() => _DisplayState();
+}
+
+class _DisplayState extends State<Display> {
+  late final counter = context.read<Counter>();
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        SignalBuilder(
+          builder: (context, child) {
+            return Text('value: ${counter.value.value}');
+          },
+        ),
+        SignalBuilder(
+          builder: (context, child) {
+            return Text('history-len: ${counter.history.length}');
+          },
+        ),
+      ],
+    );
+  }
+}

--- a/packages/solid_generator/test/golden/outputs/list_signal_field.g.dart
+++ b/packages/solid_generator/test/golden/outputs/list_signal_field.g.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class ListProbe extends StatefulWidget {
+  const ListProbe({super.key});
+
+  @override
+  State<ListProbe> createState() => _ListProbeState();
+}
+
+class _ListProbeState extends State<ListProbe> {
+  final xs = ListSignal<int>(const [], name: 'xs');
+
+  @override
+  void dispose() {
+    xs.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        SignalBuilder(
+          builder: (context, child) {
+            return Text('length: ${xs.length}');
+          },
+        ),
+        SignalBuilder(
+          builder: (context, child) {
+            return Text('first: ${xs[0]}');
+          },
+        ),
+        ElevatedButton(onPressed: () => xs.add(1), child: const Text('add')),
+        ElevatedButton(onPressed: () => xs[0] = 5, child: const Text('set')),
+      ],
+    );
+  }
+}

--- a/packages/solid_generator/test/golden/outputs/list_signal_lazy_fallback.g.dart
+++ b/packages/solid_generator/test/golden/outputs/list_signal_lazy_fallback.g.dart
@@ -1,18 +1,22 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_solidart/flutter_solidart.dart';
 
-class LateListProbe extends StatefulWidget {
-  const LateListProbe({super.key});
+class LateCollectionProbe extends StatefulWidget {
+  const LateCollectionProbe({super.key});
 
   @override
-  State<LateListProbe> createState() => _LateListProbeState();
+  State<LateCollectionProbe> createState() => _LateCollectionProbeState();
 }
 
-class _LateListProbeState extends State<LateListProbe> {
-  late final xs = Signal<List<int>>.lazy(name: 'xs');
+class _LateCollectionProbeState extends State<LateCollectionProbe> {
+  late final xs = ListSignal<int>(const <int>[], name: 'xs');
+  late final tags = SetSignal<String>(const <String>{}, name: 'tags');
+  late final hits = MapSignal<String, int>(const <String, int>{}, name: 'hits');
 
   @override
   void dispose() {
+    hits.dispose();
+    tags.dispose();
     xs.dispose();
     super.dispose();
   }

--- a/packages/solid_generator/test/golden/outputs/list_signal_lazy_fallback.g.dart
+++ b/packages/solid_generator/test/golden/outputs/list_signal_lazy_fallback.g.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class LateListProbe extends StatefulWidget {
+  const LateListProbe({super.key});
+
+  @override
+  State<LateListProbe> createState() => _LateListProbeState();
+}
+
+class _LateListProbeState extends State<LateListProbe> {
+  late final xs = Signal<List<int>>.lazy(name: 'xs');
+
+  @override
+  void dispose() {
+    xs.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/golden/outputs/list_signal_nullable_fallback.g.dart
+++ b/packages/solid_generator/test/golden/outputs/list_signal_nullable_fallback.g.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class NullableListProbe extends StatefulWidget {
+  const NullableListProbe({super.key});
+
+  @override
+  State<NullableListProbe> createState() => _NullableListProbeState();
+}
+
+class _NullableListProbeState extends State<NullableListProbe> {
+  final xs = Signal<List<int>?>(null, name: 'xs');
+
+  @override
+  void dispose() {
+    xs.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/golden/outputs/map_signal_field.g.dart
+++ b/packages/solid_generator/test/golden/outputs/map_signal_field.g.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class MapProbe extends StatefulWidget {
+  const MapProbe({super.key});
+
+  @override
+  State<MapProbe> createState() => _MapProbeState();
+}
+
+class _MapProbeState extends State<MapProbe> {
+  final scores = MapSignal<String, int>(const {}, name: 'scores');
+
+  @override
+  void dispose() {
+    scores.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        SignalBuilder(
+          builder: (context, child) {
+            return Text('count: ${scores.length}');
+          },
+        ),
+        SignalBuilder(
+          builder: (context, child) {
+            return Text('has-a: ${scores.containsKey('a')}');
+          },
+        ),
+        SignalBuilder(
+          builder: (context, child) {
+            return Text('value-a: ${scores['a']}');
+          },
+        ),
+        ElevatedButton(
+          onPressed: () => scores['a'] = 1,
+          child: const Text('set'),
+        ),
+        ElevatedButton(
+          onPressed: () => scores.remove('a'),
+          child: const Text('remove'),
+        ),
+      ],
+    );
+  }
+}

--- a/packages/solid_generator/test/golden/outputs/plain_class_named_ctor.g.dart
+++ b/packages/solid_generator/test/golden/outputs/plain_class_named_ctor.g.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Counter implements Disposable {
+  Counter();
+
+  Counter.seeded(int init) {
+    value.value = init;
+  }
+
+  late final value = Signal<int>.lazy(name: 'value');
+
+  @override
+  void dispose() {
+    value.dispose();
+  }
+}

--- a/packages/solid_generator/test/golden/outputs/plain_class_user_ctor_basic.g.dart
+++ b/packages/solid_generator/test/golden/outputs/plain_class_user_ctor_basic.g.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Counter implements Disposable {
+  Counter({int init = 0}) {
+    value.value = init;
+  }
+
+  late final value = Signal<int>.lazy(name: 'value');
+
+  @override
+  void dispose() {
+    value.dispose();
+  }
+}

--- a/packages/solid_generator/test/golden/outputs/plain_class_user_ctor_with_effect.g.dart
+++ b/packages/solid_generator/test/golden/outputs/plain_class_user_ctor_with_effect.g.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Counter implements Disposable {
+  Counter({int init = 0}) {
+    value.value = init;
+
+    log;
+  }
+
+  late final value = Signal<int>.lazy(name: 'value');
+
+  late final log = Effect(() {
+    print('value: ${value.value}');
+  }, name: 'log');
+
+  @override
+  void dispose() {
+    log.dispose();
+    value.dispose();
+  }
+}

--- a/packages/solid_generator/test/golden/outputs/set_signal_field.g.dart
+++ b/packages/solid_generator/test/golden/outputs/set_signal_field.g.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class SetProbe extends StatefulWidget {
+  const SetProbe({super.key});
+
+  @override
+  State<SetProbe> createState() => _SetProbeState();
+}
+
+class _SetProbeState extends State<SetProbe> {
+  final tags = SetSignal<int>(const {}, name: 'tags');
+
+  @override
+  void dispose() {
+    tags.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        SignalBuilder(
+          builder: (context, child) {
+            return Text('count: ${tags.length}');
+          },
+        ),
+        SignalBuilder(
+          builder: (context, child) {
+            return Text('has-1: ${tags.contains(1)}');
+          },
+        ),
+        ElevatedButton(onPressed: () => tags.add(1), child: const Text('add')),
+        ElevatedButton(
+          onPressed: () => tags.remove(1),
+          child: const Text('remove'),
+        ),
+      ],
+    );
+  }
+}

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -99,6 +99,7 @@ const List<String> goldenNames = <String>[
   'plain_class_named_ctor',
   'computed_reading_same_class_collection',
   'collection_mixin_breadth',
+  'collection_cascade',
 ];
 
 /// Memoized golden directory resolution. Resolved relative to the package

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -98,6 +98,7 @@ const List<String> goldenNames = <String>[
   'plain_class_user_ctor_with_effect',
   'plain_class_named_ctor',
   'computed_reading_same_class_collection',
+  'collection_mixin_breadth',
 ];
 
 /// Memoized golden directory resolution. Resolved relative to the package

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -97,6 +97,7 @@ const List<String> goldenNames = <String>[
   'plain_class_user_ctor_basic',
   'plain_class_user_ctor_with_effect',
   'plain_class_named_ctor',
+  'computed_reading_same_class_collection',
 ];
 
 /// Memoized golden directory resolution. Resolved relative to the package

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -86,6 +86,17 @@ const List<String> goldenNames = <String>[
   'dispose_already_present_skipped',
   'provider_no_at_solid_annotations',
   'provider_value_skipped',
+  'list_signal_field',
+  'set_signal_field',
+  'map_signal_field',
+  'list_signal_lazy_fallback',
+  'list_signal_nullable_fallback',
+  'cross_class_list_signal_read',
+  'cross_file_environment_read',
+  'computed_on_plain_class',
+  'plain_class_user_ctor_basic',
+  'plain_class_user_ctor_with_effect',
+  'plain_class_named_ctor',
 ];
 
 /// Memoized golden directory resolution. Resolved relative to the package
@@ -127,6 +138,74 @@ Future<String> runBuilderCapture(String name, String input) async {
   );
   if (captured == null) fail('builder produced no output for $name');
   return captured!;
+}
+
+/// True when [name] resolves to a multi-file fixture directory at
+/// `test/golden/inputs/<name>/`, vs the conventional single-file fixture at
+/// `test/golden/inputs/<name>.dart`. Used by the golden harness to dispatch
+/// between single-file and multi-file paths.
+Future<bool> isMultiFileFixture(String name) async {
+  final dirPath = '${await goldenDir()}/inputs/$name';
+  return Directory(dirPath).existsSync();
+}
+
+/// Loads every `*.dart` file under `test/golden/inputs/<name>/` and returns
+/// a map of `{relativePath → contents}`. Relative paths are anchored to the
+/// fixture directory (e.g. `widget.dart`, `controllers/foo.dart`).
+///
+/// Used by the multi-file branch of the golden harness for fixtures that
+/// span more than one source file — e.g. cross-file `@SolidEnvironment`
+/// scenarios where the consumer's `late T x;` resolves to a class defined
+/// in a sibling source file.
+Future<Map<String, String>> loadGoldenMultiInput(String name) async {
+  final dirPath = '${await goldenDir()}/inputs/$name';
+  final dir = Directory(dirPath);
+  if (!dir.existsSync()) fail('missing multi-file input dir: $dirPath');
+  final result = <String, String>{};
+  for (final entity in dir.listSync(recursive: true)) {
+    if (entity is! File) continue;
+    if (!entity.path.endsWith('.dart')) continue;
+    final relativePath = entity.path.substring(dirPath.length + 1);
+    result[relativePath] = entity.readAsStringSync();
+  }
+  return result;
+}
+
+/// Runs the builder once on the multi-file [inputs] map (relative paths
+/// keyed to source text) under the fixture `<name>/` and returns a
+/// `{relativePath → outputText}` map containing the lowered output for
+/// each input.
+///
+/// Each input file is registered under `a|source/<name>/<relativePath>` and
+/// each output is captured from `a|lib/<name>/<relativePath>`.
+Future<Map<String, String>> runMultiFileBuilderCapture(
+  String name,
+  Map<String, String> inputs,
+) async {
+  final captured = <String, String>{};
+  final inputAssets = <String, String>{
+    for (final entry in inputs.entries)
+      'a|source/$name/${entry.key}': entry.value,
+  };
+  final outputMatchers = <String, Object>{
+    for (final entry in inputs.entries)
+      'a|lib/$name/${entry.key}': predicate<List<int>>((bytes) {
+        captured[entry.key] = utf8.decode(bytes);
+        return true;
+      }),
+  };
+  await testBuilder(
+    solidBuilder(BuilderOptions.empty),
+    inputAssets,
+    outputs: outputMatchers,
+  );
+  if (captured.length != inputs.length) {
+    fail(
+      'builder produced ${captured.length} outputs for $name, '
+      'expected ${inputs.length}',
+    );
+  }
+  return captured;
 }
 
 /// Registers one rejection test per entry in [cases] inside a `group` named

--- a/packages/solid_generator/test/integration/golden_test.dart
+++ b/packages/solid_generator/test/integration/golden_test.dart
@@ -16,33 +16,88 @@ void main() {
   group('golden', () {
     for (final name in goldenNames) {
       test(name, () async {
-        final input = await loadGoldenInput(name);
-        final expectedPath = '${await goldenDir()}/outputs/$name.g.dart';
-        final expectedFile = File(expectedPath);
-
-        if (_updateGoldens) {
-          final captured = await runBuilderCapture(name, input);
-          expectedFile
-            ..createSync(recursive: true)
-            ..writeAsStringSync(captured);
+        if (await isMultiFileFixture(name)) {
+          await _runMultiFileGolden(name);
           return;
         }
-
-        if (!expectedFile.existsSync()) {
-          fail(
-            'missing expected fixture: $expectedPath\n'
-            'Run UPDATE_GOLDENS=1 dart test to create it.',
-          );
-        }
-
-        final expected = expectedFile.readAsStringSync();
-
-        await testBuilder(
-          solidBuilder(BuilderOptions.empty),
-          {'a|source/$name.dart': input},
-          outputs: {'a|lib/$name.dart': expected},
-        );
+        await _runSingleFileGolden(name);
       });
     }
   });
+}
+
+Future<void> _runSingleFileGolden(String name) async {
+  final input = await loadGoldenInput(name);
+  final expectedPath = '${await goldenDir()}/outputs/$name.g.dart';
+  final expectedFile = File(expectedPath);
+
+  if (_updateGoldens) {
+    final captured = await runBuilderCapture(name, input);
+    expectedFile
+      ..createSync(recursive: true)
+      ..writeAsStringSync(captured);
+    return;
+  }
+
+  if (!expectedFile.existsSync()) {
+    fail(
+      'missing expected fixture: $expectedPath\n'
+      'Run UPDATE_GOLDENS=1 dart test to create it.',
+    );
+  }
+
+  final expected = expectedFile.readAsStringSync();
+
+  await testBuilder(
+    solidBuilder(BuilderOptions.empty),
+    {'a|source/$name.dart': input},
+    outputs: {'a|lib/$name.dart': expected},
+  );
+}
+
+Future<void> _runMultiFileGolden(String name) async {
+  final inputs = await loadGoldenMultiInput(name);
+
+  if (_updateGoldens) {
+    final captured = await runMultiFileBuilderCapture(name, inputs);
+    for (final entry in captured.entries) {
+      final outPath =
+          '${await goldenDir()}/outputs/$name/'
+          '${entry.key.replaceFirst(RegExp(r'\.dart$'), '.g.dart')}';
+      File(outPath)
+        ..createSync(recursive: true)
+        ..writeAsStringSync(entry.value);
+    }
+    return;
+  }
+
+  final expectedTexts = <String, String>{};
+  for (final relativePath in inputs.keys) {
+    final expectedPath =
+        '${await goldenDir()}/outputs/$name/'
+        '${relativePath.replaceFirst(RegExp(r'\.dart$'), '.g.dart')}';
+    final expectedFile = File(expectedPath);
+    if (!expectedFile.existsSync()) {
+      fail(
+        'missing expected fixture: $expectedPath\n'
+        'Run UPDATE_GOLDENS=1 dart test to create it.',
+      );
+    }
+    expectedTexts[relativePath] = expectedFile.readAsStringSync();
+  }
+
+  final inputAssets = <String, String>{
+    for (final entry in inputs.entries)
+      'a|source/$name/${entry.key}': entry.value,
+  };
+  final outputAssertions = <String, Object>{
+    for (final entry in expectedTexts.entries)
+      'a|lib/$name/${entry.key}': entry.value,
+  };
+
+  await testBuilder(
+    solidBuilder(BuilderOptions.empty),
+    inputAssets,
+    outputs: outputAssertions,
+  );
 }

--- a/packages/solid_generator/test/integration/idempotency_test.dart
+++ b/packages/solid_generator/test/integration/idempotency_test.dart
@@ -11,6 +11,13 @@ void main() {
   group('idempotency', () {
     for (final name in goldenNames) {
       test('$name produces byte-identical output across two runs', () async {
+        if (await isMultiFileFixture(name)) {
+          final inputs = await loadGoldenMultiInput(name);
+          final first = await runMultiFileBuilderCapture(name, inputs);
+          final second = await runMultiFileBuilderCapture(name, inputs);
+          expect(second, equals(first));
+          return;
+        }
         final input = await loadGoldenInput(name);
 
         final first = await runBuilderCapture(name, input);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,7 @@ workspace:
   - packages/solid_annotations
   - packages/integration_tests
   - example
+  - examples/todos
 
 dev_dependencies:
   very_good_analysis: ^10.0.0


### PR DESCRIPTION
## Summary

- Add `ListSignal<T>`, `SetSignal<T>`, and `MapSignal<K, V>` for `@SolidState` collection fields, exposing full mixin API directly on signals
- Support user-defined constructors on plain classes with `@SolidState` fields — constructor body receives `.value` rewrite and Effect materialization splicing
- Add cross-file environment resolution — env fields can reference `@SolidState` fields on sibling classes across file boundaries without `.value` insertion on collection accesses
- Update SPEC.md with sections 4.4b (Collection → ListSignal/SetSignal/MapSignal) and constructor body merge details
- Add comprehensive todos example demonstrating collection signals, plain class patterns, and `@SolidEnvironment` usage
- Expand integration test suite with cross-file environment and collection signal golden tests

## Testing

- Golden tests for collection signals (list/set/map field, lazy fallback, nullable fallback)
- Golden tests for plain class named and user-defined constructors
- Golden tests for cross-file environment resolution with collection field access
- Todos example includes unit tests for controller mutations and widget tests for UI interactions
- Run `dart run build_runner build -d` to verify generator output against goldens