### PR TITLE
Add weather example and fix reactive method body rewrites

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -854,6 +854,54 @@ late final scaledTick = Resource<double>(
 );
 ```
 
+Input (Future form, body reads cross-class signals through an `@SolidEnvironment` receiver — direct source for one, synthesized Record-Computed source for two or more):
+
+```dart
+class Settings {
+  @SolidState() int factor = 1;
+  @SolidState() String? prefix;
+}
+
+class ValueCard extends StatelessWidget {
+  ValueCard({super.key});
+
+  @SolidEnvironment()
+  late Settings settings;
+
+  @SolidQuery()
+  Future<String> fetchValue() async =>
+      '${settings.prefix ?? ''}${10 * settings.factor}';
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}
+```
+
+Output:
+
+```dart
+late final settings = context.read<Settings>();
+late final _fetchValueSource = Computed<(String?, int)>(
+  () => (settings.prefix.value, settings.factor.value),
+  name: '_fetchValueSource',
+);
+late final fetchValue = Resource<String>(
+  () async => '${settings.prefix.value ?? ''}${10 * settings.factor.value}',
+  source: _fetchValueSource,
+  name: 'fetchValue',
+);
+```
+
+For a single cross-class signal dep the `source:` is emitted directly as `<envField>.<signalName>` — no Computed wrapper:
+
+```dart
+@SolidQuery()
+Future<int> fetchValue() async => 10 * settings.factor;
+// → source: settings.factor
+```
+
+The cross-class field's declared type (e.g. `int`, `String?`) appears textually in the synthesized Computed Record. The generator auto-injects the matching import into the consumer's lib output (in relative form), so the user's source file does not need to import the type or add any `// ignore: unused_import` directive — see rule 5 above for the synthesis details.
+
 Stream form:
 
 ```dart
@@ -915,20 +963,24 @@ Rules:
 
 4. **Body rewrite.** The original method's body is wrapped in a parameterless function expression preserving the `async` / `async*` keyword (or returning a `Stream<T>` directly for the synchronous Stream form). Section 5.1 type-driven `.value` rewrite applies inside the body so any `@SolidState` field / getter reads are correctly unboxed.
 
-5. **Auto-tracking — direct source for one dep, synthesized Record-Computed for multiple.** The body's tracked reads determine the Resource's `source:` argument. Two read kinds participate, accumulated in source-first-appearance order:
+5. **Auto-tracking — direct source for one dep, synthesized Record-Computed for multiple.** The body's tracked reads determine the Resource's `source:` argument. Three read kinds participate, each accumulated in source-first-appearance order in its own list; the three lists are concatenated as `[state, query, cross-class]` to form the merged tuple:
 
-   - **Reactive identifier reads** — bare identifiers (or chains) whose resolved static type is `SignalBase<T>`: same-class `@SolidState` fields and getters (M1 / Section 4.5).
-   - **Query-call reads** — zero-argument `MethodInvocation`s whose target is a bare `SimpleIdentifier` matching another `@SolidQuery` method on the same class, not shadowed by a local. Tear-offs (`<queryName>.refresh()`) and untracked reads (`<queryName>().untracked` — Section 6.4) are excluded.
+   - **Same-class reactive identifier reads** — bare identifiers (or chains) whose resolved static type is `SignalBase<T>`: same-class `@SolidState` fields and getters (M1 / Section 4.5).
+   - **Same-class query-call reads** — zero-argument `MethodInvocation`s whose target is a bare `SimpleIdentifier` matching another `@SolidQuery` method on the same class, not shadowed by a local. Tear-offs (`<queryName>.refresh()`) and untracked reads (`<queryName>().untracked` — Section 6.4) are excluded.
+   - **Cross-class signal reads through an `@SolidEnvironment` receiver** — `<envField>.<signalName>` chains where `<envField>` is an `@SolidEnvironment` field on the enclosing class and `<signalName>` is a `@SolidState` field/getter on the env-field's declared type. The Signal lives on the injected instance; the Resource needs a stable reference to it as `source:` to re-fetch on changes. Collection-typed cross-class signals (`ListSignal` / `SetSignal` / `MapSignal`) are excluded — their mutation-notification model is mixin-driven, not `source:`-driven; queries that depend on collection contents must read a scalar signal that re-emits on collection change, or call `.refresh()` explicitly.
 
-   Wiring depends on the count of accumulated tracked reads:
+   Wiring depends on the total count of accumulated tracked reads across all three kinds:
 
    - **Zero tracked reads**: no `source:` argument emitted; the Resource only refreshes via explicit `.refresh()` calls.
-   - **One tracked read**: the read identifier is passed directly as `source: <name>`. No synthesized field is emitted — wrapping a single observable in a Computed that just returns its `.value` would be a no-op, so the generator skips it. The upstream `Resource<T>` constructor accepts any `SignalBase<dynamic>` as `source:`; `Signal<T>` / `Computed<T>` qualify, and `Resource<T>` qualifies because `Resource<T>` extends `Signal<ResourceState<T>>`.
+   - **One tracked read**: the read is passed directly as `source: <expr>` with no synthesized wrapper Computed (a single-observable Computed wrapper would be a no-op). For a same-class state or query dep, `<expr>` is the bare identifier; for a cross-class signal dep, `<expr>` is the dotted form `<envField>.<signalName>` — that expression evaluates to the Signal object reachable through the env-injected receiver. The upstream `Resource<T>` constructor accepts any `SignalBase<dynamic>` as `source:`; `Signal<T>` / `Computed<T>` qualify, and `Resource<T>` qualifies because `Resource<T>` extends `Signal<ResourceState<T>>`.
    - **Two or more tracked reads**: the generator synthesizes a `late final _<name>Source = Computed<(E1, E2, …)>(() => (e1, e2, …), name: '<name>_source')` field whose value is a `Record` combining all tracked values. The Computed is passed as `source: _<name>Source`. For each tracked read:
-     - A reactive identifier read of type `Signal<X>` / `Computed<X>` contributes element type `X` and read expression `<name>.value`.
-     - A query-call read of inner type `X` contributes element type `ResourceState<X>` and read expression `<queryName>.state`. (`Resource<X>.state` is the canonical accessor; reading it inside a `Computed` closure subscribes to the upstream Resource's emissions because `Resource<X>` extends `Signal<ResourceState<X>>`.)
+     - A same-class reactive identifier read of type `Signal<X>` / `Computed<X>` contributes element type `X` and read expression `<name>.value`.
+     - A same-class query-call read of inner type `X` contributes element type `ResourceState<X>` and read expression `<queryName>.state`. (`Resource<X>.state` is the canonical accessor; reading it inside a `Computed` closure subscribes to the upstream Resource's emissions because `Resource<X>` extends `Signal<ResourceState<X>>`.)
+     - A cross-class signal read `<envField>.<signalName>` of type `Signal<X>` / `Computed<X>` contributes element type `X` (resolved through the env-field's declared type and the cross-class registry) and read expression `<envField>.<signalName>.value`.
 
      Records compare by value-equality, so changing ANY tracked observable flips the Record's identity, the Resource sees its source change, and the fetcher re-runs (subject to any `debounce:` delay). The synthesized field is the only reason an underscore-prefixed Resource-related declaration ever appears in lowered output.
+
+   Cross-class signal types named in the synthesized Record (`X` in `Computed<(…, X, …)>`) become visible in `lib/` automatically. During the cross-file resolution pass the generator scans the env-field class's own imports; for each `@SolidState` field on the cross-class whose declared type is not declared in that same file, it captures the file's same-package import URIs as candidate origins. When emitting the consumer's lib output, the generator injects each captured URI (rewritten to the relative form from the consumer's lib location, so `prefer_relative_imports` stays satisfied) directly into the import block. The user's `source/` file does NOT import the type and does NOT need any `// ignore: unused_import` directives. Imports already declared on the source side are deduped by resolved `AssetId`, so adding an explicit import in source remains valid and never produces a duplicate. Cross-package types (declared in a third-party package) are out of scope for the auto-injection pass — those still require the developer to import the type explicitly.
 
    A self-cycle — a query whose body invokes itself — is rejected at codegen time with a clear error. Inter-query cycles (A reads B, B reads A) are not validated at codegen time; they surface as a runtime error from `flutter_solidart`.
 

--- a/docs/src/content/docs/faq.mdx
+++ b/docs/src/content/docs/faq.mdx
@@ -83,6 +83,6 @@ targets:
 
 This way, other generators will also consider the `source` directory as input.
 
-Then run `dart run build_runner watch --delete-conflicting-outputs` once — `build_runner` invokes every registered builder, so Solid runs alongside `freezed`, `json_serializable`, etc. in the same process.
+Then run `dart run build_runner watch` once — `build_runner` invokes every registered builder, so Solid runs alongside `freezed`, `json_serializable`, etc. in the same process.
 
 Write your code in the `source` directory, using `part` statements or whatever the other generators need.

--- a/docs/src/content/docs/guides/getting-started.mdx
+++ b/docs/src/content/docs/guides/getting-started.mdx
@@ -151,10 +151,10 @@ Run the generator with `build_runner`:
 
 ```bash
 # one-shot build
-dart run build_runner build --delete-conflicting-outputs
+dart run build_runner build
 
 # watch mode (recommended during development)
-dart run build_runner watch --delete-conflicting-outputs
+dart run build_runner watch
 ```
 
 ### Hot reload
@@ -175,7 +175,7 @@ dart fix --apply
 In CI, chain the two commands so the generated output is always lint-clean:
 
 ```bash
-dart run build_runner build --delete-conflicting-outputs
+dart run build_runner build
 dart fix --apply
 ```
 
@@ -184,5 +184,5 @@ The Solid skill (installed via the AI assistant setup above) ships a `verify.sh`
 </Aside>
 
 <Aside>
-The next chapters assume you have set up Solid in your Flutter project, created the `source` folder, and are running `dart run build_runner watch --delete-conflicting-outputs` to regenerate `lib/` on every change.
+The next chapters assume you have set up Solid in your Flutter project, created the `source` folder, and are running `dart run build_runner watch` to regenerate `lib/` on every change.
 </Aside>

--- a/examples/weather/EVALUATION.md
+++ b/examples/weather/EVALUATION.md
@@ -281,17 +281,33 @@ shorthand — both are removed and print a warning if passed. Six docs/script fi
 were updated to drop the flag; the user's auto-memory was updated to match. Output
 deletion happens implicitly.
 
+### Cross-class type imports (Fix 4 landed)
+
+When a `@SolidQuery` body reads a cross-class signal via an `@SolidEnvironment`
+receiver (e.g. `units.tempUnit`), the synthesized Record-Computed names the
+field's declared type (`TempUnit`) textually in `lib/`:
+
+```dart
+late final _weatherSource = Computed<(TempUnit, WindUnit)>(...);
+```
+
+In v1 of the cross-class fix the user had to import `domain/units.dart` in
+the source file with `// ignore: unused_import`, because the source body
+never spelled the type. The generator now auto-injects the missing import
+into the consumer's lib output during the cross-file resolution pass —
+relative form, deduped against existing source-side imports by resolved
+`AssetId`. The source files have no extra imports and no ignores. Verified
+via two regression goldens:
+`packages/solid_generator/test/golden/inputs/query_with_cross_class_signal_unimported_type/`
+and `…_already_imported_type/`.
+
 ### `flutter analyze` flagged numerous post-build infos that needed file-level ignores
 
 To get a clean `dart analyze --fatal-infos` (CI's strictness), the following had to
-be added to `analysis_options.yaml` beyond what `examples/todos` already specifies
-(the `document_ignores: ignore` originally needed for the Fix 1 workaround was
-removed after the fix landed):
+be added to `analysis_options.yaml` beyond what `examples/todos` already specifies:
 
 - `discarded_futures: ignore` — for `current.refresh(); hourly.refresh();` inside
   sync `onPressed` callbacks.
-- `document_ignores: ignore` — for the `// ignore: undefined_identifier` lines
-  applied as the `widget.city` workaround.
 - `use_setters_to_change_properties: ignore` — for `void setTempUnit(TempUnit unit) => tempUnit = unit;` in `UnitsController`.
 - `deprecated_member_use: ignore` — `RadioListTile.groupValue` is deprecated post
   Flutter 3.32 in favour of `RadioGroup`. Suppressed rather than migrated to keep

--- a/examples/weather/EVALUATION.md
+++ b/examples/weather/EVALUATION.md
@@ -1,0 +1,323 @@
+# Weather example — Solid generator evaluation
+
+Findings from authoring `examples/weather` as a stress-test of Flutter Solid's
+under-exercised paths: `@SolidQuery` with `debounce:`, `.refresh()` + `.isRefreshing`,
+parallel resources, per-instance resources keyed off widget constructor params, and a
+three-deep `@SolidEnvironment` chain.
+
+The example was first authored against `packages/solid_annotations` and `packages/solid_generator`
+at commit `fa59efa`. Two real issues surfaced (per-instance widget-ctor field rewrite gap, and
+over-strict `@SolidQuery` arrow-body validation); both were fixed in the follow-up commit
+and the workarounds removed from this example. `dart format --set-exit-if-changed .`,
+`dart analyze --fatal-infos`, and `dart run build_runner build` all pass cleanly with the
+final code.
+
+---
+
+## Primitives exercised — first-try results
+
+| Primitive | Where | First try? | Notes |
+| --- | --- | --- | --- |
+| `@SolidState` scalar field | `units_controller.dart` (`TempUnit tempUnit`, `WindUnit windUnit`) | yes | Trivial. |
+| `@SolidState` collection field | `cities_controller.dart` (`List<City> cities`) | **no** | Initial `= const []` rejected. Generator emits a clear message — see Generator-enforced restrictions below. |
+| `@SolidState` getter → `Computed` (plain class) | `cities_controller.dart` (`int get count`) | yes | Works on plain class. |
+| `@SolidQuery` (Future) | `widgets/city_card.dart`, `pages/search_page.dart`, `pages/city_detail_page.dart` | **no, now fixed** | Originally arrow bodies on `Future`-returning queries were rejected; the over-strict validation was removed (see Fix 2 below). Final example uses natural `=> …` arrow form on every Future-returning query. |
+| `@SolidQuery(debounce:)` | `pages/search_page.dart` (`results()`) | yes | Generator emits `debounceDelay: const Duration(milliseconds: 350)` and synthesizes a `source:` Computed from the `@SolidState String query` read inside the body. |
+| `.refresh()` + `.isRefreshing` | `pages/city_detail_page.dart` (refresh button + `LinearProgressIndicator`) | yes | Both resources keep their stale value while `isRefreshing == true`. |
+| Two parallel resources in one widget | `pages/city_detail_page.dart` (`current()`, `hourly()`) | yes | Both materialize as independent `late final Resource<T>` fields, both disposed in reverse declaration order. |
+| Per-instance resource keyed off widget ctor param | `widgets/city_card.dart` (`weather()` reading `city.lat/lon`) | **no, now fixed** | The generator missed the widget→state scope shift inside `@SolidQuery` bodies (and `@SolidState` getter / `@SolidEffect` bodies). Fix 1 below threads the rewrite through. Final example reads `city.lat`/`city.lon` natively. |
+| `@SolidEnvironment` × 3 in one widget | `widgets/city_card.dart`, `pages/city_detail_page.dart` | yes | Two/three injections per widget all wire up. |
+| Three-deep `.environment()` chain at root | `source/main.dart` | yes | `WeatherApi → CitiesController → UnitsController`. Generator auto-injected `dispose: (context, provider) => provider.dispose()` on all three call sites. |
+| Plain class with constructor parameter | `cities_controller.dart` (`CitiesController({initial})`) | yes | Constructor runs and the synthesized Effect/Signal materialization is interleaved correctly. |
+| Plain class as DI'd service (no annotations) | `api/weather_api.dart` | yes | Coexists cleanly. Required: a `void dispose()` method on the class (since auto-injected `dispose:` calls `provider.dispose()` and `WeatherApi` is not Solid-lowered). |
+| Cross-class signal read driving query refetch | `widgets/city_card.dart` reads `units.tempUnit`/`units.windUnit` inside `weather()` | yes | Generator inserts `.value` and registers a multi-dep source Computed, so toggling units in Settings re-fetches every visible card. |
+
+---
+
+## Fix 1 (landed) — widget ctor params not rewritten inside `@SolidQuery` / `@SolidEffect` / `@SolidState` getter bodies
+
+**Severity (original):** broke the headline "per-instance resource keyed off widget constructor
+param" pattern. Builds appeared to succeed (no `CodeGenerationError`) but the emitted
+`lib/` code referenced an undefined identifier and only `dart analyze` caught it.
+
+**Status:** fixed. `examples/weather` now uses the natural pattern without workaround.
+
+**Source (the natural pattern a developer would write):**
+
+```dart
+class CityCard extends StatelessWidget {
+  CityCard({super.key, required this.city});
+  final City city;
+
+  @SolidEnvironment() late WeatherApi api;
+  @SolidEnvironment() late UnitsController units;
+
+  @SolidQuery()
+  Future<CurrentWeather> weather() async {
+    return api.currentWeather(
+      lat: city.lat,         // <-- works in build() but NOT here
+      lon: city.lon,
+      tempUnit: units.tempUnit,
+      windUnit: units.windUnit,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(city.name);  // <-- this WILL be rewritten to widget.city.name
+  }
+}
+```
+
+**Generated `lib/widgets/city_card.dart` (broken):**
+
+```dart
+class _CityCardState extends State<CityCard> {
+  late final api = context.read<WeatherApi>();
+  late final units = context.read<UnitsController>();
+  late final weather = Resource<CurrentWeather>(() async {
+    return api.currentWeather(
+      lat: city.lat,        // ← UNDEFINED — `city` lives on the Widget, not on State
+      lon: city.lon,
+      tempUnit: units.tempUnit.value,
+      windUnit: units.windUnit.value,
+    );
+  }, name: 'weather');
+  …
+  @override
+  Widget build(BuildContext context) {
+    …Text(widget.city.name)…   // ← correctly rewritten
+  }
+}
+```
+
+`dart analyze` reports:
+
+```
+error • Undefined name 'city' • lib/widgets/city_card.dart:27:12 • undefined_identifier
+error • Undefined name 'city' • lib/widgets/city_card.dart:28:12 • undefined_identifier
+```
+
+`build_runner` itself does **not** flag this — it reports
+`Built with build_runner/aot in Xs; wrote N outputs.` The breakage only surfaces at
+analyze time.
+
+**Root cause (verified by reading the generator):**
+
+`packages/solid_generator/lib/src/stateless_rewriter.dart:84–102` applies the
+"widget→state scope shift" (renaming bare references to widget-bound non-`@SolidState`
+fields to `widget.X`) **only inside the build method**, via `rewriteBuildMethod`.
+`emitQueryFields` (called from `stateless_rewriter.dart:273`, implemented in
+`packages/solid_generator/lib/src/signal_emitter.dart:339`) emits the query body
+**without applying the same rewrite**. Cross-class `@SolidState` reads (e.g.
+`units.tempUnit` → `units.tempUnit.value`) are rewritten because that path is a
+different transform; only the **own-class widget-bound field** path is missed.
+
+**`this.city` workaround does NOT work** — the rewriter passes `this.city` through
+verbatim, so the lib version reads `this.city.lat`, and `this` in the State class
+refers to `_CityCardState`, which has no `city` field.
+
+**Fix shipped:** the readers `readSolidStateGetter`, `readSolidEffectMethod`, and
+`readSolidQueryMethod` (`packages/solid_generator/lib/src/annotation_reader.dart`)
+now accept a `widgetBoundFields` parameter and forward it to `_readReactiveBody` →
+`collectValueEdits`. The builder (`packages/solid_generator/lib/builder.dart`)
+pre-computes the per-class ctor-bound set via `collectWidgetBoundNames` (promoted to
+public in `stateless_rewriter.dart`) and passes it to each reader. Same code path
+the `build()` body has used since v2.0; the three other reactive-member bodies now
+share it.
+
+Three regression goldens lock the fix in place:
+
+- `packages/solid_generator/test/golden/inputs/computed_reads_widget_ctor_field.dart`
+  — `@SolidState` getter on a `StatelessWidget` reading a ctor field.
+- `packages/solid_generator/test/golden/inputs/effect_reads_widget_ctor_field.dart`
+  — `@SolidEffect` on a `StatelessWidget` reading a ctor field.
+- `packages/solid_generator/test/golden/inputs/query_reads_widget_ctor_field.dart`
+  — `@SolidQuery` on a `StatelessWidget` reading a ctor field (the form we hit).
+
+The original example pattern now generates correctly:
+
+```dart
+@SolidQuery()
+Future<CurrentWeather> weather() => api.currentWeather(
+  lat: city.lat,         // ← rewritten to widget.city.lat in lib/
+  lon: city.lon,
+  tempUnit: units.tempUnit,
+  windUnit: units.windUnit,
+);
+```
+
+---
+
+## Generator-enforced restrictions encountered
+
+These are intentional rejections by the generator — surfacing them so future LLMs
+know what patterns to avoid.
+
+### 1. `const` initializer on a `@SolidState` collection field is rejected
+
+Source:
+
+```dart
+@SolidState()
+List<City> cities = const [];
+```
+
+Generator error (during `dart run build_runner build`):
+
+```
+CodeGenerationError: Failed to generate cities - @SolidState() collection field `cities` has a `const` initializer:
+    List<City> cities = const [];
+A `const` literal is unmodifiable — the lowered ListSignal would throw `UnsupportedError` on the first write. Drop the `const` so the collection signal wraps a mutable copy:
+    List<City> cities = [];
+```
+
+Excellent error: it names the field, quotes the offending line, and prints the fix.
+
+### 2. `@SolidQuery` arrow-body bound to a Future return type — was rejected, now accepted (Fix 2 landed)
+
+**Original behaviour:** `Future<T>` queries with an arrow body (no `async`) were
+rejected even when the body simply returned a `Future<T>` expression. Source:
+
+```dart
+@SolidQuery()
+Future<CurrentWeather> weather() => api.currentWeather(...);
+```
+
+```
+ValidationError at CityCard.weather: [INVALID_QUERY_TARGET_METHOD_WHOSE_BODY_KEYWORD_DOES_NOT_MATCH_THE_RETURN_TYPE]
+  @SolidQuery cannot be applied to a method whose body keyword does not match the return type
+```
+
+**Fix shipped:** the body-keyword check at `target_validator.dart:284–290` was
+deleted. All four shapes (`=> expr`, `async => expr`, `{ return expr; }`,
+`async { return expr; }`) are valid Dart and accepted unchanged by the emitter.
+Dart's own analyzer reports `await_in_non_async_function` if a body uses `await`
+without `async`, so the generator no longer duplicates that check.
+
+The corresponding rejection test (`future_without_async` case in
+`solid_query_invalid_targets_test.dart`) and its input fixture are removed; a
+positive golden `query_future_arrow_body` was added in their place.
+
+### 3. `@SolidState` getter on existing `State<X>` subclass is hard-rejected
+
+Probe:
+
+```dart
+class _ProbeStatefulPageState extends State<ProbeStatefulPage> {
+  @SolidState() int count = 0;
+  @SolidState() int get doubled => count * 2;
+  @override Widget build(BuildContext context) => Text('$doubled');
+}
+```
+
+Generator error:
+
+```
+CodeGenerationError: Failed to generate _ProbeStatefulPageState - @SolidState getter on existing State<X> subclass is not yet supported; offending getter: doubled
+```
+
+Matches the documented restriction at
+`packages/solid_generator/lib/src/state_class_rewriter.dart:51`. Plain classes and
+`StatelessWidget` subclasses support the getter→`Computed` lowering; `State<X>`
+subclasses do not. The phrase "not yet supported" suggests this is intentional but
+incomplete.
+
+### 4. Factory-only plain class with `@SolidEffect` — works as expected
+
+A hypothesis raised during planning: factory constructors might silently fail to
+materialize Effects. Probed four variants:
+
+| Variant | Generative ctor | Result |
+| --- | --- | --- |
+| `factory X.create() => X._(0); X._(this.seed);` | named private | Effect materialized in `X._` |
+| `factory X.create() => X(); X();` | default | Effect materialized in `X()` |
+| `factory X.create() { … return X._(); } X._();` (factory has a body) | named private | Effect materialized in `X._` |
+| `factory X() = _Impl;` + separate `_Impl()` | redirecting factory on abstract class | Effect materialized in `_Impl()` |
+| Singleton via `factory X() => _instance ??= X._internal();` | `X._internal();` | Effect materialized in `X._internal` |
+
+**Conclusion:** the hypothesis does not reproduce. The generator always inserts
+the materializing `effectName;` statement into the **generative** constructor of
+whichever class hosts the `@SolidEffect`. Since Dart requires a generative ctor for
+any factory to return an instance, there is always a place for the materialization
+to land.
+
+The Explore agent's flag was based on reading a guard (`rejectIfEffectsNotYetSupported`
+in `packages/solid_generator/lib/src/effect_model.dart:62–74`) that has no call
+site — but that guard is for `@SolidEffect` on a `State<X>` subclass, not on a
+plain class with a factory. The two paths are independent. I did not probe the
+former because all my widgets are `StatelessWidget`.
+
+---
+
+## Other observations
+
+### `MaterialApp` `home:` is not enough for Provider scope across routes
+
+Initially put `.environment()` on `const HomePage().environment(…)`. Pushing a new
+route from `HomePage` then could not see the providers (Navigator-pushed routes
+are siblings to the initial route's subtree, not children). Fix: chain
+`.environment()` on `const WeatherApp()` (which returns `MaterialApp`) so the
+Provider sits above the Navigator. This is a Flutter/Provider pattern, not a
+Solid-specific issue, but worth noting because the existing single-page examples
+(`examples/todos`, `example/`) put providers on `home:` and don't surface this.
+
+### `dispose` is implicitly required on every DI'd type
+
+`WeatherApi` is a plain `http` wrapper with no Solid annotations. When passed to
+`.environment((_) => WeatherApi())`, the generator auto-injects
+`dispose: (context, provider) => provider.dispose()` — which requires `WeatherApi`
+to have a `dispose()` method. Added `void dispose() => _client.close();`. This is
+intentional: per project policy, types passed to `.environment()` are expected to
+declare `dispose()` when they have something to clean up; Solid-lowered classes get
+one synthesized automatically, and non-Solid types that genuinely have nothing to
+release can simply not be passed through `.environment()`. Closing the http client
+on Provider teardown is legitimate cleanup, so the explicit method stays.
+
+### Obsolete `--delete-conflicting-outputs` flag (Fix 3 landed)
+
+`build_runner` no longer accepts `--delete-conflicting-outputs` or its `-d`
+shorthand — both are removed and print a warning if passed. Six docs/script files
+were updated to drop the flag; the user's auto-memory was updated to match. Output
+deletion happens implicitly.
+
+### `flutter analyze` flagged numerous post-build infos that needed file-level ignores
+
+To get a clean `dart analyze --fatal-infos` (CI's strictness), the following had to
+be added to `analysis_options.yaml` beyond what `examples/todos` already specifies
+(the `document_ignores: ignore` originally needed for the Fix 1 workaround was
+removed after the fix landed):
+
+- `discarded_futures: ignore` — for `current.refresh(); hourly.refresh();` inside
+  sync `onPressed` callbacks.
+- `document_ignores: ignore` — for the `// ignore: undefined_identifier` lines
+  applied as the `widget.city` workaround.
+- `use_setters_to_change_properties: ignore` — for `void setTempUnit(TempUnit unit) => tempUnit = unit;` in `UnitsController`.
+- `deprecated_member_use: ignore` — `RadioListTile.groupValue` is deprecated post
+  Flutter 3.32 in favour of `RadioGroup`. Suppressed rather than migrated to keep
+  the example focused on Solid primitives, not the Material 3 API churn.
+- `avoid_equals_and_hash_code_on_mutable_classes: ignore` — `City` defines `==`/
+  `hashCode` and is logically immutable (all `final` fields) but isn't annotated
+  with `@immutable`. Suppressed locally.
+
+These are downstream Flutter/lint concerns rather than Solid issues, but a future
+fresh example author will hit them and should know to copy this expanded list.
+
+---
+
+## Reproduction notes
+
+```bash
+# from the repo root
+flutter pub get
+cd examples/weather
+dart run build_runner build
+dart analyze --fatal-infos
+dart format --set-exit-if-changed .
+```
+
+The pre-fix bug behaviour (Fix 1) can be reproduced by checking out the commit
+prior to the generator fix, building the example, and observing the
+`Undefined name 'city' • undefined_identifier` errors in `lib/widgets/city_card.dart`
+and `lib/pages/city_detail_page.dart`. With the fix landed, the natural `city.lat`
+form is rewritten to `widget.city.lat` in the generated `lib/` automatically.

--- a/examples/weather/analysis_options.yaml
+++ b/examples/weather/analysis_options.yaml
@@ -1,0 +1,22 @@
+include: package:very_good_analysis/analysis_options.yaml
+analyzer:
+  errors:
+    must_be_immutable: ignore
+    const_constructor_with_non_final_field: ignore
+    const_with_non_const: ignore
+    unnecessary_ignore: ignore
+    always_put_required_named_parameters_first: ignore
+    invalid_annotation_target: ignore
+    avoid_print: ignore
+    unnecessary_statements: ignore
+    lines_longer_than_80_chars: ignore
+    specify_nonobvious_property_types: ignore
+    discarded_futures: ignore
+    use_setters_to_change_properties: ignore
+    deprecated_member_use: ignore
+    avoid_equals_and_hash_code_on_mutable_classes: ignore
+linter:
+  rules:
+    public_member_api_docs: false
+    always_use_package_imports: false
+    prefer_relative_imports: true

--- a/examples/weather/build.yaml
+++ b/examples/weather/build.yaml
@@ -1,0 +1,6 @@
+targets:
+  $default:
+    sources:
+      - source/**
+      - lib/**
+      - $package$

--- a/examples/weather/lib/api/weather_api.dart
+++ b/examples/weather/lib/api/weather_api.dart
@@ -1,0 +1,96 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+
+import '../domain/city.dart';
+import '../domain/current_weather.dart';
+import '../domain/forecast.dart';
+import '../domain/units.dart';
+
+class WeatherApi {
+  WeatherApi({http.Client? client}) : _client = client ?? http.Client();
+
+  final http.Client _client;
+
+  void dispose() {
+    _client.close();
+  }
+
+  static final Uri _geocodeBase = Uri.parse(
+    'https://geocoding-api.open-meteo.com/v1/search',
+  );
+  static final Uri _forecastBase = Uri.parse(
+    'https://api.open-meteo.com/v1/forecast',
+  );
+
+  Future<List<City>> geocode(String query) async {
+    if (query.trim().isEmpty) return const [];
+    final uri = _geocodeBase.replace(
+      queryParameters: {
+        'name': query.trim(),
+        'count': '10',
+        'language': 'en',
+        'format': 'json',
+      },
+    );
+    debugPrint('[WeatherApi] geocode → $uri');
+    final res = await _client.get(uri);
+    if (res.statusCode != 200) {
+      throw Exception('Geocoding failed: HTTP ${res.statusCode}');
+    }
+    final body = jsonDecode(res.body) as Map<String, dynamic>;
+    final results = (body['results'] as List?) ?? const [];
+    return results
+        .cast<Map<String, dynamic>>()
+        .map(City.fromGeocodingJson)
+        .toList();
+  }
+
+  Future<CurrentWeather> currentWeather({
+    required double lat,
+    required double lon,
+    required TempUnit tempUnit,
+    required WindUnit windUnit,
+  }) async {
+    final uri = _forecastBase.replace(
+      queryParameters: {
+        'latitude': lat.toString(),
+        'longitude': lon.toString(),
+        'current': 'temperature_2m,wind_speed_10m,weather_code',
+        'temperature_unit': tempUnit.apiValue,
+        'wind_speed_unit': windUnit.apiValue,
+      },
+    );
+    debugPrint('[WeatherApi] currentWeather → $uri');
+    final res = await _client.get(uri);
+    if (res.statusCode != 200) {
+      throw Exception('Forecast failed: HTTP ${res.statusCode}');
+    }
+    return CurrentWeather.fromJson(
+      jsonDecode(res.body) as Map<String, dynamic>,
+    );
+  }
+
+  Future<Forecast> hourlyForecast({
+    required double lat,
+    required double lon,
+    required TempUnit tempUnit,
+  }) async {
+    final uri = _forecastBase.replace(
+      queryParameters: {
+        'latitude': lat.toString(),
+        'longitude': lon.toString(),
+        'hourly': 'temperature_2m,weather_code',
+        'temperature_unit': tempUnit.apiValue,
+        'forecast_days': '1',
+      },
+    );
+    debugPrint('[WeatherApi] hourlyForecast → $uri');
+    final res = await _client.get(uri);
+    if (res.statusCode != 200) {
+      throw Exception('Hourly forecast failed: HTTP ${res.statusCode}');
+    }
+    return Forecast.fromJson(jsonDecode(res.body) as Map<String, dynamic>);
+  }
+}

--- a/examples/weather/lib/controllers/cities_controller.dart
+++ b/examples/weather/lib/controllers/cities_controller.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+import '../domain/city.dart';
+
+class CitiesController implements Disposable {
+  CitiesController({List<City> initial = const []}) {
+    cities.addAll(initial);
+  }
+
+  final cities = ListSignal<City>([], name: 'cities');
+
+  late final count = Computed<int>(() => cities.length, name: 'count');
+
+  void add(City city) {
+    if (cities.contains(city)) return;
+    cities.add(city);
+  }
+
+  void remove(City city) {
+    cities.removeWhere((c) => c == city);
+  }
+
+  bool contains(City city) => cities.contains(city);
+
+  @override
+  void dispose() {
+    count.dispose();
+    cities.dispose();
+  }
+}

--- a/examples/weather/lib/controllers/units_controller.dart
+++ b/examples/weather/lib/controllers/units_controller.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+import '../domain/units.dart';
+
+class UnitsController implements Disposable {
+  final tempUnit = Signal<TempUnit>(TempUnit.celsius, name: 'tempUnit');
+
+  final windUnit = Signal<WindUnit>(WindUnit.kmh, name: 'windUnit');
+
+  void setTempUnit(TempUnit unit) => tempUnit.value = unit;
+
+  void setWindUnit(WindUnit unit) => windUnit.value = unit;
+
+  void toggleTempUnit() => tempUnit.value = tempUnit.value == TempUnit.celsius
+      ? TempUnit.fahrenheit
+      : TempUnit.celsius;
+
+  void toggleWindUnit() => windUnit.value = windUnit.value == WindUnit.kmh
+      ? WindUnit.mph
+      : WindUnit.kmh;
+
+  String formatTemp(double value) =>
+      '${value.toStringAsFixed(1)}${tempUnit.value.symbol}';
+
+  String formatWind(double value) =>
+      '${value.toStringAsFixed(1)} ${windUnit.value.symbol}';
+
+  @override
+  void dispose() {
+    windUnit.dispose();
+    tempUnit.dispose();
+  }
+}

--- a/examples/weather/lib/domain/city.dart
+++ b/examples/weather/lib/domain/city.dart
@@ -1,0 +1,65 @@
+class City {
+  const City({
+    required this.name,
+    required this.country,
+    required this.admin1,
+    required this.lat,
+    required this.lon,
+  });
+
+  factory City.fromGeocodingJson(Map<String, dynamic> json) {
+    return City(
+      name: json['name'] as String,
+      country: json['country'] as String?,
+      admin1: json['admin1'] as String?,
+      lat: (json['latitude'] as num).toDouble(),
+      lon: (json['longitude'] as num).toDouble(),
+    );
+  }
+
+  final String name;
+  final String? country;
+  final String? admin1;
+  final double lat;
+  final double lon;
+
+  String get subtitle {
+    final parts = [admin1, country].where((s) => s != null && s.isNotEmpty);
+    return parts.join(', ');
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is City &&
+          runtimeType == other.runtimeType &&
+          lat == other.lat &&
+          lon == other.lon;
+
+  @override
+  int get hashCode => Object.hash(lat, lon);
+
+  static const List<City> samples = [
+    City(
+      name: 'Berlin',
+      country: 'Germany',
+      admin1: 'Berlin',
+      lat: 52.52,
+      lon: 13.41,
+    ),
+    City(
+      name: 'Tokyo',
+      country: 'Japan',
+      admin1: 'Tokyo',
+      lat: 35.6762,
+      lon: 139.6503,
+    ),
+    City(
+      name: 'San Francisco',
+      country: 'United States',
+      admin1: 'California',
+      lat: 37.7749,
+      lon: -122.4194,
+    ),
+  ];
+}

--- a/examples/weather/lib/domain/current_weather.dart
+++ b/examples/weather/lib/domain/current_weather.dart
@@ -1,0 +1,23 @@
+class CurrentWeather {
+  const CurrentWeather({
+    required this.temperature,
+    required this.windSpeed,
+    required this.weatherCode,
+    required this.time,
+  });
+
+  factory CurrentWeather.fromJson(Map<String, dynamic> json) {
+    final current = json['current'] as Map<String, dynamic>;
+    return CurrentWeather(
+      temperature: (current['temperature_2m'] as num).toDouble(),
+      windSpeed: (current['wind_speed_10m'] as num).toDouble(),
+      weatherCode: current['weather_code'] as int,
+      time: DateTime.parse(current['time'] as String),
+    );
+  }
+
+  final double temperature;
+  final double windSpeed;
+  final int weatherCode;
+  final DateTime time;
+}

--- a/examples/weather/lib/domain/forecast.dart
+++ b/examples/weather/lib/domain/forecast.dart
@@ -1,0 +1,35 @@
+class HourlyPoint {
+  const HourlyPoint({
+    required this.time,
+    required this.temperature,
+    required this.weatherCode,
+  });
+
+  final DateTime time;
+  final double temperature;
+  final int weatherCode;
+}
+
+class Forecast {
+  const Forecast({required this.hourly});
+
+  factory Forecast.fromJson(Map<String, dynamic> json) {
+    final hourly = json['hourly'] as Map<String, dynamic>;
+    final times = (hourly['time'] as List).cast<String>();
+    final temps = (hourly['temperature_2m'] as List).cast<num>();
+    final codes = (hourly['weather_code'] as List).cast<int>();
+    final points = <HourlyPoint>[];
+    for (var i = 0; i < times.length && i < 24; i++) {
+      points.add(
+        HourlyPoint(
+          time: DateTime.parse(times[i]),
+          temperature: temps[i].toDouble(),
+          weatherCode: codes[i],
+        ),
+      );
+    }
+    return Forecast(hourly: points);
+  }
+
+  final List<HourlyPoint> hourly;
+}

--- a/examples/weather/lib/domain/units.dart
+++ b/examples/weather/lib/domain/units.dart
@@ -1,0 +1,17 @@
+enum TempUnit {
+  celsius('celsius', '°C'),
+  fahrenheit('fahrenheit', '°F');
+
+  const TempUnit(this.apiValue, this.symbol);
+  final String apiValue;
+  final String symbol;
+}
+
+enum WindUnit {
+  kmh('kmh', 'km/h'),
+  mph('mph', 'mph');
+
+  const WindUnit(this.apiValue, this.symbol);
+  final String apiValue;
+  final String symbol;
+}

--- a/examples/weather/lib/main.dart
+++ b/examples/weather/lib/main.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+import 'api/weather_api.dart';
+import 'controllers/cities_controller.dart';
+import 'controllers/units_controller.dart';
+import 'domain/city.dart';
+import 'pages/home_page.dart';
+
+void main() {
+  SolidartConfig.autoDispose = false;
+  runApp(
+    const WeatherApp()
+        .environment(
+          (_) => WeatherApi(),
+          dispose: (context, provider) => provider.dispose(),
+        )
+        .environment(
+          (_) => CitiesController(initial: City.samples),
+          dispose: (context, provider) => provider.dispose(),
+        )
+        .environment(
+          (_) => UnitsController(),
+          dispose: (context, provider) => provider.dispose(),
+        ),
+  );
+}
+
+class WeatherApp extends StatelessWidget {
+  const WeatherApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Weather',
+      theme: ThemeData(useMaterial3: true, colorSchemeSeed: Colors.blue),
+      home: const HomePage(),
+    );
+  }
+}

--- a/examples/weather/lib/main.dart
+++ b/examples/weather/lib/main.dart
@@ -34,6 +34,7 @@ class WeatherApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Weather',
+      debugShowCheckedModeBanner: false,
       theme: ThemeData(useMaterial3: true, colorSchemeSeed: Colors.blue),
       home: const HomePage(),
     );

--- a/examples/weather/lib/pages/city_detail_page.dart
+++ b/examples/weather/lib/pages/city_detail_page.dart
@@ -1,0 +1,199 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:provider/provider.dart';
+import '../api/weather_api.dart';
+import '../controllers/units_controller.dart';
+import '../domain/city.dart';
+import '../domain/current_weather.dart';
+import '../domain/forecast.dart';
+import '../widgets/weather_icon.dart';
+
+class CityDetailPage extends StatefulWidget {
+  const CityDetailPage({super.key, required this.city});
+
+  final City city;
+
+  @override
+  State<CityDetailPage> createState() => _CityDetailPageState();
+}
+
+class _CityDetailPageState extends State<CityDetailPage> {
+  late final api = context.read<WeatherApi>();
+  late final units = context.read<UnitsController>();
+  late final current = Resource<CurrentWeather>(
+    () => api.currentWeather(
+      lat: widget.city.lat,
+      lon: widget.city.lon,
+      tempUnit: units.tempUnit.value,
+      windUnit: units.windUnit.value,
+    ),
+    name: 'current',
+  );
+  late final hourly = Resource<Forecast>(
+    () => api.hourlyForecast(
+      lat: widget.city.lat,
+      lon: widget.city.lon,
+      tempUnit: units.tempUnit.value,
+    ),
+    name: 'hourly',
+  );
+
+  @override
+  void dispose() {
+    hourly.dispose();
+    current.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.city.name),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: () {
+              current.refresh();
+              hourly.refresh();
+            },
+          ),
+        ],
+      ),
+      body: SignalBuilder(
+        builder: (context, child) {
+          return ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              _CurrentSection(city: widget.city),
+              const SizedBox(height: 24),
+              const Text(
+                'Next 24 hours',
+                style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 8),
+              SizedBox(
+                height: 120,
+                child: hourly().when(
+                  ready: (forecast) => ListView.builder(
+                    scrollDirection: Axis.horizontal,
+                    itemCount: forecast.hourly.length,
+                    itemBuilder: (context, index) {
+                      final p = forecast.hourly[index];
+                      return Container(
+                        width: 70,
+                        margin: const EdgeInsets.symmetric(horizontal: 4),
+                        padding: const EdgeInsets.all(8),
+                        decoration: BoxDecoration(
+                          border: Border.all(color: Colors.grey.shade300),
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Text(
+                              '${p.time.hour.toString().padLeft(2, '0')}:00',
+                              style: const TextStyle(fontSize: 12),
+                            ),
+                            WeatherIcon(code: p.weatherCode, size: 28),
+                            Text(units.formatTemp(p.temperature)),
+                          ],
+                        ),
+                      );
+                    },
+                  ),
+                  loading: () =>
+                      const Center(child: CircularProgressIndicator()),
+                  error: (e, _) => Center(child: Text('Failed: $e')),
+                ),
+              ),
+              const SizedBox(height: 16),
+              if (current().isRefreshing || hourly().isRefreshing)
+                const LinearProgressIndicator(),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _CurrentSection extends StatefulWidget {
+  const _CurrentSection({required this.city});
+
+  final City city;
+
+  @override
+  State<_CurrentSection> createState() => __CurrentSectionState();
+}
+
+class __CurrentSectionState extends State<_CurrentSection> {
+  late final units = context.read<UnitsController>();
+  late final api = context.read<WeatherApi>();
+  late final current = Resource<CurrentWeather>(
+    () => api.currentWeather(
+      lat: widget.city.lat,
+      lon: widget.city.lon,
+      tempUnit: units.tempUnit.value,
+      windUnit: units.windUnit.value,
+    ),
+    name: 'current',
+  );
+
+  @override
+  void dispose() {
+    current.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SignalBuilder(
+      builder: (context, child) {
+        return current().when(
+          ready: (w) => Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Row(
+                children: [
+                  WeatherIcon(code: w.weatherCode, size: 64),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          units.formatTemp(w.temperature),
+                          style: Theme.of(context).textTheme.displaySmall,
+                        ),
+                        Text('Wind ${units.formatWind(w.windSpeed)}'),
+                        if (current().isRefreshing)
+                          const Padding(
+                            padding: EdgeInsets.only(top: 4),
+                            child: Text(
+                              'Refreshing…',
+                              style: TextStyle(color: Colors.blue),
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          loading: () => const Padding(
+            padding: EdgeInsets.all(32),
+            child: Center(child: CircularProgressIndicator()),
+          ),
+          error: (e, _) => Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Text('Current weather failed: $e'),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/examples/weather/lib/pages/city_detail_page.dart
+++ b/examples/weather/lib/pages/city_detail_page.dart
@@ -6,6 +6,7 @@ import '../controllers/units_controller.dart';
 import '../domain/city.dart';
 import '../domain/current_weather.dart';
 import '../domain/forecast.dart';
+import '../domain/units.dart';
 import '../widgets/weather_icon.dart';
 
 class CityDetailPage extends StatefulWidget {
@@ -20,6 +21,10 @@ class CityDetailPage extends StatefulWidget {
 class _CityDetailPageState extends State<CityDetailPage> {
   late final api = context.read<WeatherApi>();
   late final units = context.read<UnitsController>();
+  late final _currentSource = Computed<(TempUnit, WindUnit)>(
+    () => (units.tempUnit.value, units.windUnit.value),
+    name: '_currentSource',
+  );
   late final current = Resource<CurrentWeather>(
     () => api.currentWeather(
       lat: widget.city.lat,
@@ -27,6 +32,7 @@ class _CityDetailPageState extends State<CityDetailPage> {
       tempUnit: units.tempUnit.value,
       windUnit: units.windUnit.value,
     ),
+    source: _currentSource,
     name: 'current',
   );
   late final hourly = Resource<Forecast>(
@@ -35,6 +41,7 @@ class _CityDetailPageState extends State<CityDetailPage> {
       lon: widget.city.lon,
       tempUnit: units.tempUnit.value,
     ),
+    source: units.tempUnit,
     name: 'hourly',
   );
 
@@ -42,6 +49,7 @@ class _CityDetailPageState extends State<CityDetailPage> {
   void dispose() {
     hourly.dispose();
     current.dispose();
+    _currentSource.dispose();
     super.dispose();
   }
 
@@ -130,6 +138,10 @@ class _CurrentSection extends StatefulWidget {
 class __CurrentSectionState extends State<_CurrentSection> {
   late final units = context.read<UnitsController>();
   late final api = context.read<WeatherApi>();
+  late final _currentSource = Computed<(TempUnit, WindUnit)>(
+    () => (units.tempUnit.value, units.windUnit.value),
+    name: '_currentSource',
+  );
   late final current = Resource<CurrentWeather>(
     () => api.currentWeather(
       lat: widget.city.lat,
@@ -137,12 +149,14 @@ class __CurrentSectionState extends State<_CurrentSection> {
       tempUnit: units.tempUnit.value,
       windUnit: units.windUnit.value,
     ),
+    source: _currentSource,
     name: 'current',
   );
 
   @override
   void dispose() {
     current.dispose();
+    _currentSource.dispose();
     super.dispose();
   }
 

--- a/examples/weather/lib/pages/home_page.dart
+++ b/examples/weather/lib/pages/home_page.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:provider/provider.dart';
+import '../controllers/cities_controller.dart';
+import '../widgets/city_card.dart';
+import 'search_page.dart';
+import 'settings_page.dart';
+
+class HomePage extends StatefulWidget {
+  const HomePage({super.key});
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  late final citiesController = context.read<CitiesController>();
+
+  @override
+  Widget build(BuildContext context) {
+    return SignalBuilder(
+      builder: (context, child) {
+        return Scaffold(
+          appBar: AppBar(
+            title: SignalBuilder(
+              builder: (context, child) {
+                return Text('Weather (${citiesController.count.value})');
+              },
+            ),
+            actions: [
+              IconButton(
+                icon: const Icon(Icons.settings),
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (_) => const SettingsPage(),
+                    ),
+                  );
+                },
+              ),
+            ],
+          ),
+          body: citiesController.cities.isEmpty
+              ? const Center(
+                  child: Text('No cities — add one with the + button'),
+                )
+              : ListView.builder(
+                  itemCount: citiesController.cities.length,
+                  itemBuilder: (context, index) {
+                    final city = citiesController.cities[index];
+                    return CityCard(key: ValueKey(city), city: city);
+                  },
+                ),
+          floatingActionButton: FloatingActionButton(
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute<void>(builder: (_) => const SearchPage()),
+              );
+            },
+            child: const Icon(Icons.add),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/examples/weather/lib/pages/search_page.dart
+++ b/examples/weather/lib/pages/search_page.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:provider/provider.dart';
+import '../api/weather_api.dart';
+import '../controllers/cities_controller.dart';
+import '../domain/city.dart';
+import '../widgets/search_result_tile.dart';
+
+class SearchPage extends StatefulWidget {
+  const SearchPage({super.key});
+
+  @override
+  State<SearchPage> createState() => _SearchPageState();
+}
+
+class _SearchPageState extends State<SearchPage> {
+  late final api = context.read<WeatherApi>();
+  late final citiesController = context.read<CitiesController>();
+  final query = Signal<String>('', name: 'query');
+  late final results = Resource<List<City>>(
+    () => api.geocode(query.value),
+    source: query,
+    debounceDelay: const Duration(milliseconds: 350),
+    name: 'results',
+  );
+
+  @override
+  void dispose() {
+    results.dispose();
+    query.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Add city')),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(12),
+            child: TextField(
+              autofocus: true,
+              decoration: const InputDecoration(
+                hintText: 'Search city name',
+                prefixIcon: Icon(Icons.search),
+                border: OutlineInputBorder(),
+              ),
+              onChanged: (s) => query.value = s,
+            ),
+          ),
+          SignalBuilder(
+            builder: (context, child) {
+              return Expanded(
+                child: query.value.trim().isEmpty
+                    ? const Center(child: Text('Type to search'))
+                    : SignalBuilder(
+                        builder: (context, child) {
+                          return results().when(
+                            ready: (cities) {
+                              if (cities.isEmpty) {
+                                return const Center(child: Text('No matches'));
+                              }
+                              return ListView.builder(
+                                itemCount: cities.length,
+                                itemBuilder: (context, index) {
+                                  final city = cities[index];
+                                  return SearchResultTile(
+                                    city: city,
+                                    alreadyAdded: citiesController.contains(
+                                      city,
+                                    ),
+                                    onAdd: () {
+                                      citiesController.add(city);
+                                      Navigator.of(context).pop();
+                                    },
+                                  );
+                                },
+                              );
+                            },
+                            loading: () => const Center(
+                              child: CircularProgressIndicator(),
+                            ),
+                            error: (e, _) => Center(
+                              child: Padding(
+                                padding: const EdgeInsets.all(16),
+                                child: Text(
+                                  'Search failed: $e',
+                                  style: const TextStyle(color: Colors.red),
+                                ),
+                              ),
+                            ),
+                          );
+                        },
+                      ),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/examples/weather/lib/pages/settings_page.dart
+++ b/examples/weather/lib/pages/settings_page.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:provider/provider.dart';
+import '../controllers/units_controller.dart';
+import '../domain/units.dart';
+
+class SettingsPage extends StatefulWidget {
+  const SettingsPage({super.key});
+
+  @override
+  State<SettingsPage> createState() => _SettingsPageState();
+}
+
+class _SettingsPageState extends State<SettingsPage> {
+  late final units = context.read<UnitsController>();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Settings')),
+      body: ListView(
+        children: [
+          const Padding(
+            padding: EdgeInsets.fromLTRB(16, 16, 16, 8),
+            child: Text('Temperature', style: TextStyle(fontSize: 12)),
+          ),
+          SignalBuilder(
+            builder: (context, child) {
+              return RadioListTile<TempUnit>(
+                title: const Text('Celsius'),
+                value: TempUnit.celsius,
+                groupValue: units.tempUnit.value,
+                onChanged: (v) {
+                  if (v != null) units.setTempUnit(v);
+                },
+              );
+            },
+          ),
+          SignalBuilder(
+            builder: (context, child) {
+              return RadioListTile<TempUnit>(
+                title: const Text('Fahrenheit'),
+                value: TempUnit.fahrenheit,
+                groupValue: units.tempUnit.value,
+                onChanged: (v) {
+                  if (v != null) units.setTempUnit(v);
+                },
+              );
+            },
+          ),
+          const Divider(),
+          const Padding(
+            padding: EdgeInsets.fromLTRB(16, 16, 16, 8),
+            child: Text('Wind speed', style: TextStyle(fontSize: 12)),
+          ),
+          SignalBuilder(
+            builder: (context, child) {
+              return RadioListTile<WindUnit>(
+                title: const Text('km/h'),
+                value: WindUnit.kmh,
+                groupValue: units.windUnit.value,
+                onChanged: (v) {
+                  if (v != null) units.setWindUnit(v);
+                },
+              );
+            },
+          ),
+          SignalBuilder(
+            builder: (context, child) {
+              return RadioListTile<WindUnit>(
+                title: const Text('mph'),
+                value: WindUnit.mph,
+                groupValue: units.windUnit.value,
+                onChanged: (v) {
+                  if (v != null) units.setWindUnit(v);
+                },
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/examples/weather/lib/widgets/city_card.dart
+++ b/examples/weather/lib/widgets/city_card.dart
@@ -6,6 +6,7 @@ import '../controllers/cities_controller.dart';
 import '../controllers/units_controller.dart';
 import '../domain/city.dart';
 import '../domain/current_weather.dart';
+import '../domain/units.dart';
 import '../pages/city_detail_page.dart';
 import 'weather_icon.dart';
 
@@ -22,6 +23,10 @@ class _CityCardState extends State<CityCard> {
   late final api = context.read<WeatherApi>();
   late final units = context.read<UnitsController>();
   late final citiesController = context.read<CitiesController>();
+  late final _weatherSource = Computed<(TempUnit, WindUnit)>(
+    () => (units.tempUnit.value, units.windUnit.value),
+    name: '_weatherSource',
+  );
   late final weather = Resource<CurrentWeather>(
     () => api.currentWeather(
       lat: widget.city.lat,
@@ -29,12 +34,14 @@ class _CityCardState extends State<CityCard> {
       tempUnit: units.tempUnit.value,
       windUnit: units.windUnit.value,
     ),
+    source: _weatherSource,
     name: 'weather',
   );
 
   @override
   void dispose() {
     weather.dispose();
+    _weatherSource.dispose();
     super.dispose();
   }
 

--- a/examples/weather/lib/widgets/city_card.dart
+++ b/examples/weather/lib/widgets/city_card.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:provider/provider.dart';
+import '../api/weather_api.dart';
+import '../controllers/cities_controller.dart';
+import '../controllers/units_controller.dart';
+import '../domain/city.dart';
+import '../domain/current_weather.dart';
+import '../pages/city_detail_page.dart';
+import 'weather_icon.dart';
+
+class CityCard extends StatefulWidget {
+  const CityCard({super.key, required this.city});
+
+  final City city;
+
+  @override
+  State<CityCard> createState() => _CityCardState();
+}
+
+class _CityCardState extends State<CityCard> {
+  late final api = context.read<WeatherApi>();
+  late final units = context.read<UnitsController>();
+  late final citiesController = context.read<CitiesController>();
+  late final weather = Resource<CurrentWeather>(
+    () => api.currentWeather(
+      lat: widget.city.lat,
+      lon: widget.city.lon,
+      tempUnit: units.tempUnit.value,
+      windUnit: units.windUnit.value,
+    ),
+    name: 'weather',
+  );
+
+  @override
+  void dispose() {
+    weather.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Dismissible(
+      key: ValueKey('${widget.city.lat},${widget.city.lon}'),
+      direction: DismissDirection.endToStart,
+      onDismissed: (_) => citiesController.remove(widget.city),
+      background: Container(
+        color: Colors.red,
+        alignment: Alignment.centerRight,
+        padding: const EdgeInsets.only(right: 16),
+        child: const Icon(Icons.delete, color: Colors.white),
+      ),
+      child: Card(
+        margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+        child: InkWell(
+          onTap: () {
+            Navigator.of(context).push(
+              MaterialPageRoute<void>(
+                builder: (_) => CityDetailPage(city: widget.city),
+              ),
+            );
+          },
+          child: Padding(
+            padding: const EdgeInsets.all(12),
+            child: SignalBuilder(
+              builder: (context, child) {
+                return weather().when(
+                  ready: (w) => Row(
+                    children: [
+                      WeatherIcon(code: w.weatherCode, size: 40),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              widget.city.name,
+                              style: Theme.of(context).textTheme.titleMedium,
+                            ),
+                            Text(
+                              widget.city.subtitle,
+                              style: Theme.of(context).textTheme.bodySmall,
+                            ),
+                          ],
+                        ),
+                      ),
+                      Column(
+                        crossAxisAlignment: CrossAxisAlignment.end,
+                        children: [
+                          Text(
+                            units.formatTemp(w.temperature),
+                            style: Theme.of(context).textTheme.titleLarge,
+                          ),
+                          Text(
+                            units.formatWind(w.windSpeed),
+                            style: Theme.of(context).textTheme.bodySmall,
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                  loading: () => Row(
+                    children: [
+                      const SizedBox(
+                        width: 40,
+                        height: 40,
+                        child: Center(
+                          child: SizedBox(
+                            width: 24,
+                            height: 24,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      Text(widget.city.name),
+                    ],
+                  ),
+                  error: (e, _) => Row(
+                    children: [
+                      const Icon(
+                        Icons.error_outline,
+                        color: Colors.red,
+                        size: 40,
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              widget.city.name,
+                              style: Theme.of(context).textTheme.titleMedium,
+                            ),
+                            Text(
+                              'Failed: $e',
+                              style: const TextStyle(color: Colors.red),
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/examples/weather/lib/widgets/search_result_tile.dart
+++ b/examples/weather/lib/widgets/search_result_tile.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+import '../domain/city.dart';
+
+class SearchResultTile extends StatelessWidget {
+  const SearchResultTile({
+    super.key,
+    required this.city,
+    required this.alreadyAdded,
+    required this.onAdd,
+  });
+
+  final City city;
+  final bool alreadyAdded;
+  final VoidCallback onAdd;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Text(city.name),
+      subtitle: Text(city.subtitle),
+      trailing: alreadyAdded
+          ? const Icon(Icons.check, color: Colors.green)
+          : const Icon(Icons.add_circle_outline),
+      onTap: alreadyAdded ? null : onAdd,
+    );
+  }
+}

--- a/examples/weather/lib/widgets/weather_icon.dart
+++ b/examples/weather/lib/widgets/weather_icon.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+class WeatherIcon extends StatelessWidget {
+  const WeatherIcon({super.key, required this.code, this.size = 32});
+
+  final int code;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    return Icon(_iconFor(code), size: size, color: _colorFor(code));
+  }
+
+  static IconData _iconFor(int code) {
+    if (code == 0) return Icons.wb_sunny;
+    if (code == 1 || code == 2) return Icons.wb_cloudy;
+    if (code == 3) return Icons.cloud;
+    if (code == 45 || code == 48) return Icons.blur_on;
+    if (code >= 51 && code <= 57) return Icons.grain;
+    if (code >= 61 && code <= 67) return Icons.umbrella;
+    if (code >= 71 && code <= 77) return Icons.ac_unit;
+    if (code >= 80 && code <= 82) return Icons.beach_access;
+    if (code >= 85 && code <= 86) return Icons.ac_unit;
+    if (code >= 95) return Icons.flash_on;
+    return Icons.help_outline;
+  }
+
+  static Color _colorFor(int code) {
+    if (code == 0) return Colors.orange;
+    if (code >= 95) return Colors.deepPurple;
+    if (code >= 71 && code <= 77 || code >= 85 && code <= 86) {
+      return Colors.lightBlue;
+    }
+    if (code >= 61 && code <= 67 || code >= 80 && code <= 82) {
+      return Colors.blue;
+    }
+    return Colors.blueGrey;
+  }
+}

--- a/examples/weather/pubspec.yaml
+++ b/examples/weather/pubspec.yaml
@@ -1,0 +1,29 @@
+name: weather_example
+description: A multi-city weather example app demonstrating Solid v2.
+publish_to: 'none'
+version: 0.0.1
+
+environment:
+  sdk: ^3.9.2
+
+resolution: workspace
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_solidart: ^2.7.3
+  http: ^1.2.2
+  provider: ^6.1.0
+  solid_annotations:
+    path: ../../packages/solid_annotations
+
+dev_dependencies:
+  build_runner: ^2.14.0
+  flutter_test:
+    sdk: flutter
+  solid_generator:
+    path: ../../packages/solid_generator
+  very_good_analysis: ^10.0.0
+
+flutter:
+  uses-material-design: true

--- a/examples/weather/source/api/weather_api.dart
+++ b/examples/weather/source/api/weather_api.dart
@@ -1,0 +1,96 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+
+import '../domain/city.dart';
+import '../domain/current_weather.dart';
+import '../domain/forecast.dart';
+import '../domain/units.dart';
+
+class WeatherApi {
+  WeatherApi({http.Client? client}) : _client = client ?? http.Client();
+
+  final http.Client _client;
+
+  void dispose() {
+    _client.close();
+  }
+
+  static final Uri _geocodeBase = Uri.parse(
+    'https://geocoding-api.open-meteo.com/v1/search',
+  );
+  static final Uri _forecastBase = Uri.parse(
+    'https://api.open-meteo.com/v1/forecast',
+  );
+
+  Future<List<City>> geocode(String query) async {
+    if (query.trim().isEmpty) return const [];
+    final uri = _geocodeBase.replace(
+      queryParameters: {
+        'name': query.trim(),
+        'count': '10',
+        'language': 'en',
+        'format': 'json',
+      },
+    );
+    debugPrint('[WeatherApi] geocode → $uri');
+    final res = await _client.get(uri);
+    if (res.statusCode != 200) {
+      throw Exception('Geocoding failed: HTTP ${res.statusCode}');
+    }
+    final body = jsonDecode(res.body) as Map<String, dynamic>;
+    final results = (body['results'] as List?) ?? const [];
+    return results
+        .cast<Map<String, dynamic>>()
+        .map(City.fromGeocodingJson)
+        .toList();
+  }
+
+  Future<CurrentWeather> currentWeather({
+    required double lat,
+    required double lon,
+    required TempUnit tempUnit,
+    required WindUnit windUnit,
+  }) async {
+    final uri = _forecastBase.replace(
+      queryParameters: {
+        'latitude': lat.toString(),
+        'longitude': lon.toString(),
+        'current': 'temperature_2m,wind_speed_10m,weather_code',
+        'temperature_unit': tempUnit.apiValue,
+        'wind_speed_unit': windUnit.apiValue,
+      },
+    );
+    debugPrint('[WeatherApi] currentWeather → $uri');
+    final res = await _client.get(uri);
+    if (res.statusCode != 200) {
+      throw Exception('Forecast failed: HTTP ${res.statusCode}');
+    }
+    return CurrentWeather.fromJson(
+      jsonDecode(res.body) as Map<String, dynamic>,
+    );
+  }
+
+  Future<Forecast> hourlyForecast({
+    required double lat,
+    required double lon,
+    required TempUnit tempUnit,
+  }) async {
+    final uri = _forecastBase.replace(
+      queryParameters: {
+        'latitude': lat.toString(),
+        'longitude': lon.toString(),
+        'hourly': 'temperature_2m,weather_code',
+        'temperature_unit': tempUnit.apiValue,
+        'forecast_days': '1',
+      },
+    );
+    debugPrint('[WeatherApi] hourlyForecast → $uri');
+    final res = await _client.get(uri);
+    if (res.statusCode != 200) {
+      throw Exception('Hourly forecast failed: HTTP ${res.statusCode}');
+    }
+    return Forecast.fromJson(jsonDecode(res.body) as Map<String, dynamic>);
+  }
+}

--- a/examples/weather/source/controllers/cities_controller.dart
+++ b/examples/weather/source/controllers/cities_controller.dart
@@ -1,0 +1,26 @@
+import 'package:solid_annotations/solid_annotations.dart';
+
+import '../domain/city.dart';
+
+class CitiesController {
+  CitiesController({List<City> initial = const []}) {
+    cities.addAll(initial);
+  }
+
+  @SolidState()
+  List<City> cities = [];
+
+  @SolidState()
+  int get count => cities.length;
+
+  void add(City city) {
+    if (cities.contains(city)) return;
+    cities.add(city);
+  }
+
+  void remove(City city) {
+    cities.removeWhere((c) => c == city);
+  }
+
+  bool contains(City city) => cities.contains(city);
+}

--- a/examples/weather/source/controllers/units_controller.dart
+++ b/examples/weather/source/controllers/units_controller.dart
@@ -1,0 +1,28 @@
+import 'package:solid_annotations/solid_annotations.dart';
+
+import '../domain/units.dart';
+
+class UnitsController {
+  @SolidState()
+  TempUnit tempUnit = TempUnit.celsius;
+
+  @SolidState()
+  WindUnit windUnit = WindUnit.kmh;
+
+  void setTempUnit(TempUnit unit) => tempUnit = unit;
+
+  void setWindUnit(WindUnit unit) => windUnit = unit;
+
+  void toggleTempUnit() => tempUnit = tempUnit == TempUnit.celsius
+      ? TempUnit.fahrenheit
+      : TempUnit.celsius;
+
+  void toggleWindUnit() =>
+      windUnit = windUnit == WindUnit.kmh ? WindUnit.mph : WindUnit.kmh;
+
+  String formatTemp(double value) =>
+      '${value.toStringAsFixed(1)}${tempUnit.symbol}';
+
+  String formatWind(double value) =>
+      '${value.toStringAsFixed(1)} ${windUnit.symbol}';
+}

--- a/examples/weather/source/domain/city.dart
+++ b/examples/weather/source/domain/city.dart
@@ -1,0 +1,65 @@
+class City {
+  const City({
+    required this.name,
+    required this.country,
+    required this.admin1,
+    required this.lat,
+    required this.lon,
+  });
+
+  factory City.fromGeocodingJson(Map<String, dynamic> json) {
+    return City(
+      name: json['name'] as String,
+      country: json['country'] as String?,
+      admin1: json['admin1'] as String?,
+      lat: (json['latitude'] as num).toDouble(),
+      lon: (json['longitude'] as num).toDouble(),
+    );
+  }
+
+  final String name;
+  final String? country;
+  final String? admin1;
+  final double lat;
+  final double lon;
+
+  String get subtitle {
+    final parts = [admin1, country].where((s) => s != null && s.isNotEmpty);
+    return parts.join(', ');
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is City &&
+          runtimeType == other.runtimeType &&
+          lat == other.lat &&
+          lon == other.lon;
+
+  @override
+  int get hashCode => Object.hash(lat, lon);
+
+  static const List<City> samples = [
+    City(
+      name: 'Berlin',
+      country: 'Germany',
+      admin1: 'Berlin',
+      lat: 52.52,
+      lon: 13.41,
+    ),
+    City(
+      name: 'Tokyo',
+      country: 'Japan',
+      admin1: 'Tokyo',
+      lat: 35.6762,
+      lon: 139.6503,
+    ),
+    City(
+      name: 'San Francisco',
+      country: 'United States',
+      admin1: 'California',
+      lat: 37.7749,
+      lon: -122.4194,
+    ),
+  ];
+}

--- a/examples/weather/source/domain/current_weather.dart
+++ b/examples/weather/source/domain/current_weather.dart
@@ -1,0 +1,23 @@
+class CurrentWeather {
+  const CurrentWeather({
+    required this.temperature,
+    required this.windSpeed,
+    required this.weatherCode,
+    required this.time,
+  });
+
+  factory CurrentWeather.fromJson(Map<String, dynamic> json) {
+    final current = json['current'] as Map<String, dynamic>;
+    return CurrentWeather(
+      temperature: (current['temperature_2m'] as num).toDouble(),
+      windSpeed: (current['wind_speed_10m'] as num).toDouble(),
+      weatherCode: current['weather_code'] as int,
+      time: DateTime.parse(current['time'] as String),
+    );
+  }
+
+  final double temperature;
+  final double windSpeed;
+  final int weatherCode;
+  final DateTime time;
+}

--- a/examples/weather/source/domain/forecast.dart
+++ b/examples/weather/source/domain/forecast.dart
@@ -1,0 +1,35 @@
+class HourlyPoint {
+  const HourlyPoint({
+    required this.time,
+    required this.temperature,
+    required this.weatherCode,
+  });
+
+  final DateTime time;
+  final double temperature;
+  final int weatherCode;
+}
+
+class Forecast {
+  const Forecast({required this.hourly});
+
+  factory Forecast.fromJson(Map<String, dynamic> json) {
+    final hourly = json['hourly'] as Map<String, dynamic>;
+    final times = (hourly['time'] as List).cast<String>();
+    final temps = (hourly['temperature_2m'] as List).cast<num>();
+    final codes = (hourly['weather_code'] as List).cast<int>();
+    final points = <HourlyPoint>[];
+    for (var i = 0; i < times.length && i < 24; i++) {
+      points.add(
+        HourlyPoint(
+          time: DateTime.parse(times[i]),
+          temperature: temps[i].toDouble(),
+          weatherCode: codes[i],
+        ),
+      );
+    }
+    return Forecast(hourly: points);
+  }
+
+  final List<HourlyPoint> hourly;
+}

--- a/examples/weather/source/domain/units.dart
+++ b/examples/weather/source/domain/units.dart
@@ -1,0 +1,17 @@
+enum TempUnit {
+  celsius('celsius', '°C'),
+  fahrenheit('fahrenheit', '°F');
+
+  const TempUnit(this.apiValue, this.symbol);
+  final String apiValue;
+  final String symbol;
+}
+
+enum WindUnit {
+  kmh('kmh', 'km/h'),
+  mph('mph', 'mph');
+
+  const WindUnit(this.apiValue, this.symbol);
+  final String apiValue;
+  final String symbol;
+}

--- a/examples/weather/source/main.dart
+++ b/examples/weather/source/main.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+import 'api/weather_api.dart';
+import 'controllers/cities_controller.dart';
+import 'controllers/units_controller.dart';
+import 'domain/city.dart';
+import 'pages/home_page.dart';
+
+void main() {
+  SolidartConfig.autoDispose = false;
+  runApp(
+    const WeatherApp()
+        .environment((_) => WeatherApi())
+        .environment((_) => CitiesController(initial: City.samples))
+        .environment((_) => UnitsController()),
+  );
+}
+
+class WeatherApp extends StatelessWidget {
+  const WeatherApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Weather',
+      theme: ThemeData(useMaterial3: true, colorSchemeSeed: Colors.blue),
+      home: const HomePage(),
+    );
+  }
+}

--- a/examples/weather/source/main.dart
+++ b/examples/weather/source/main.dart
@@ -25,6 +25,7 @@ class WeatherApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Weather',
+      debugShowCheckedModeBanner: false,
       theme: ThemeData(useMaterial3: true, colorSchemeSeed: Colors.blue),
       home: const HomePage(),
     );

--- a/examples/weather/source/pages/city_detail_page.dart
+++ b/examples/weather/source/pages/city_detail_page.dart
@@ -1,0 +1,170 @@
+import 'package:flutter/material.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+import '../api/weather_api.dart';
+import '../controllers/units_controller.dart';
+import '../domain/city.dart';
+import '../domain/current_weather.dart';
+import '../domain/forecast.dart';
+import '../widgets/weather_icon.dart';
+
+class CityDetailPage extends StatelessWidget {
+  CityDetailPage({super.key, required this.city});
+
+  final City city;
+
+  @SolidEnvironment()
+  late WeatherApi api;
+
+  @SolidEnvironment()
+  late UnitsController units;
+
+  @SolidQuery()
+  Future<CurrentWeather> current() => api.currentWeather(
+    lat: city.lat,
+    lon: city.lon,
+    tempUnit: units.tempUnit,
+    windUnit: units.windUnit,
+  );
+
+  @SolidQuery()
+  Future<Forecast> hourly() => api.hourlyForecast(
+    lat: city.lat,
+    lon: city.lon,
+    tempUnit: units.tempUnit,
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(city.name),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: () {
+              current.refresh();
+              hourly.refresh();
+            },
+          ),
+        ],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          _CurrentSection(city: city),
+          const SizedBox(height: 24),
+          const Text(
+            'Next 24 hours',
+            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          SizedBox(
+            height: 120,
+            child: hourly().when(
+              ready: (forecast) => ListView.builder(
+                scrollDirection: Axis.horizontal,
+                itemCount: forecast.hourly.length,
+                itemBuilder: (context, index) {
+                  final p = forecast.hourly[index];
+                  return Container(
+                    width: 70,
+                    margin: const EdgeInsets.symmetric(horizontal: 4),
+                    padding: const EdgeInsets.all(8),
+                    decoration: BoxDecoration(
+                      border: Border.all(color: Colors.grey.shade300),
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Text(
+                          '${p.time.hour.toString().padLeft(2, '0')}:00',
+                          style: const TextStyle(fontSize: 12),
+                        ),
+                        WeatherIcon(code: p.weatherCode, size: 28),
+                        Text(units.formatTemp(p.temperature)),
+                      ],
+                    ),
+                  );
+                },
+              ),
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (e, _) => Center(child: Text('Failed: $e')),
+            ),
+          ),
+          const SizedBox(height: 16),
+          if (current().isRefreshing || hourly().isRefreshing)
+            const LinearProgressIndicator(),
+        ],
+      ),
+    );
+  }
+}
+
+class _CurrentSection extends StatelessWidget {
+  const _CurrentSection({required this.city});
+
+  final City city;
+
+  @SolidEnvironment()
+  late UnitsController units;
+
+  @SolidEnvironment()
+  late WeatherApi api;
+
+  @SolidQuery()
+  Future<CurrentWeather> current() => api.currentWeather(
+    lat: city.lat,
+    lon: city.lon,
+    tempUnit: units.tempUnit,
+    windUnit: units.windUnit,
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    return current().when(
+      ready: (w) => Card(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            children: [
+              WeatherIcon(code: w.weatherCode, size: 64),
+              const SizedBox(width: 16),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      units.formatTemp(w.temperature),
+                      style: Theme.of(context).textTheme.displaySmall,
+                    ),
+                    Text('Wind ${units.formatWind(w.windSpeed)}'),
+                    if (current().isRefreshing)
+                      const Padding(
+                        padding: EdgeInsets.only(top: 4),
+                        child: Text(
+                          'Refreshing…',
+                          style: TextStyle(color: Colors.blue),
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+      loading: () => const Padding(
+        padding: EdgeInsets.all(32),
+        child: Center(child: CircularProgressIndicator()),
+      ),
+      error: (e, _) => Card(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Text('Current weather failed: $e'),
+        ),
+      ),
+    );
+  }
+}

--- a/examples/weather/source/pages/home_page.dart
+++ b/examples/weather/source/pages/home_page.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+import '../controllers/cities_controller.dart';
+import '../widgets/city_card.dart';
+import 'search_page.dart';
+import 'settings_page.dart';
+
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
+
+  @SolidEnvironment()
+  late CitiesController citiesController;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Weather (${citiesController.count})'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.settings),
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute<void>(builder: (_) => const SettingsPage()),
+              );
+            },
+          ),
+        ],
+      ),
+      body: citiesController.cities.isEmpty
+          ? const Center(child: Text('No cities — add one with the + button'))
+          : ListView.builder(
+              itemCount: citiesController.cities.length,
+              itemBuilder: (context, index) {
+                final city = citiesController.cities[index];
+                return CityCard(key: ValueKey(city), city: city);
+              },
+            ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          Navigator.of(context).push(
+            MaterialPageRoute<void>(builder: (_) => const SearchPage()),
+          );
+        },
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/examples/weather/source/pages/search_page.dart
+++ b/examples/weather/source/pages/search_page.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+import '../api/weather_api.dart';
+import '../controllers/cities_controller.dart';
+import '../domain/city.dart';
+import '../widgets/search_result_tile.dart';
+
+class SearchPage extends StatelessWidget {
+  const SearchPage({super.key});
+
+  @SolidEnvironment()
+  late WeatherApi api;
+
+  @SolidEnvironment()
+  late CitiesController citiesController;
+
+  @SolidState()
+  String query = '';
+
+  @SolidQuery(debounce: Duration(milliseconds: 350))
+  Future<List<City>> results() => api.geocode(query);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Add city')),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(12),
+            child: TextField(
+              autofocus: true,
+              decoration: const InputDecoration(
+                hintText: 'Search city name',
+                prefixIcon: Icon(Icons.search),
+                border: OutlineInputBorder(),
+              ),
+              onChanged: (s) => query = s,
+            ),
+          ),
+          Expanded(
+            child: query.trim().isEmpty
+                ? const Center(child: Text('Type to search'))
+                : results().when(
+                    ready: (cities) {
+                      if (cities.isEmpty) {
+                        return const Center(child: Text('No matches'));
+                      }
+                      return ListView.builder(
+                        itemCount: cities.length,
+                        itemBuilder: (context, index) {
+                          final city = cities[index];
+                          return SearchResultTile(
+                            city: city,
+                            alreadyAdded: citiesController.contains(city),
+                            onAdd: () {
+                              citiesController.add(city);
+                              Navigator.of(context).pop();
+                            },
+                          );
+                        },
+                      );
+                    },
+                    loading: () => const Center(
+                      child: CircularProgressIndicator(),
+                    ),
+                    error: (e, _) => Center(
+                      child: Padding(
+                        padding: const EdgeInsets.all(16),
+                        child: Text(
+                          'Search failed: $e',
+                          style: const TextStyle(color: Colors.red),
+                        ),
+                      ),
+                    ),
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/examples/weather/source/pages/settings_page.dart
+++ b/examples/weather/source/pages/settings_page.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+import '../controllers/units_controller.dart';
+import '../domain/units.dart';
+
+class SettingsPage extends StatelessWidget {
+  const SettingsPage({super.key});
+
+  @SolidEnvironment()
+  late UnitsController units;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Settings')),
+      body: ListView(
+        children: [
+          const Padding(
+            padding: EdgeInsets.fromLTRB(16, 16, 16, 8),
+            child: Text('Temperature', style: TextStyle(fontSize: 12)),
+          ),
+          RadioListTile<TempUnit>(
+            title: const Text('Celsius'),
+            value: TempUnit.celsius,
+            groupValue: units.tempUnit,
+            onChanged: (v) {
+              if (v != null) units.setTempUnit(v);
+            },
+          ),
+          RadioListTile<TempUnit>(
+            title: const Text('Fahrenheit'),
+            value: TempUnit.fahrenheit,
+            groupValue: units.tempUnit,
+            onChanged: (v) {
+              if (v != null) units.setTempUnit(v);
+            },
+          ),
+          const Divider(),
+          const Padding(
+            padding: EdgeInsets.fromLTRB(16, 16, 16, 8),
+            child: Text('Wind speed', style: TextStyle(fontSize: 12)),
+          ),
+          RadioListTile<WindUnit>(
+            title: const Text('km/h'),
+            value: WindUnit.kmh,
+            groupValue: units.windUnit,
+            onChanged: (v) {
+              if (v != null) units.setWindUnit(v);
+            },
+          ),
+          RadioListTile<WindUnit>(
+            title: const Text('mph'),
+            value: WindUnit.mph,
+            groupValue: units.windUnit,
+            onChanged: (v) {
+              if (v != null) units.setWindUnit(v);
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/examples/weather/source/widgets/city_card.dart
+++ b/examples/weather/source/widgets/city_card.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/material.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+import '../api/weather_api.dart';
+import '../controllers/cities_controller.dart';
+import '../controllers/units_controller.dart';
+import '../domain/city.dart';
+import '../domain/current_weather.dart';
+import '../pages/city_detail_page.dart';
+import 'weather_icon.dart';
+
+class CityCard extends StatelessWidget {
+  CityCard({super.key, required this.city});
+
+  final City city;
+
+  @SolidEnvironment()
+  late WeatherApi api;
+
+  @SolidEnvironment()
+  late UnitsController units;
+
+  @SolidEnvironment()
+  late CitiesController citiesController;
+
+  @SolidQuery()
+  Future<CurrentWeather> weather() => api.currentWeather(
+    lat: city.lat,
+    lon: city.lon,
+    tempUnit: units.tempUnit,
+    windUnit: units.windUnit,
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    return Dismissible(
+      key: ValueKey('${city.lat},${city.lon}'),
+      direction: DismissDirection.endToStart,
+      onDismissed: (_) => citiesController.remove(city),
+      background: Container(
+        color: Colors.red,
+        alignment: Alignment.centerRight,
+        padding: const EdgeInsets.only(right: 16),
+        child: const Icon(Icons.delete, color: Colors.white),
+      ),
+      child: Card(
+        margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+        child: InkWell(
+          onTap: () {
+            Navigator.of(context).push(
+              MaterialPageRoute<void>(
+                builder: (_) => CityDetailPage(city: city),
+              ),
+            );
+          },
+          child: Padding(
+            padding: const EdgeInsets.all(12),
+            child: weather().when(
+              ready: (w) => Row(
+                children: [
+                  WeatherIcon(code: w.weatherCode, size: 40),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          city.name,
+                          style: Theme.of(context).textTheme.titleMedium,
+                        ),
+                        Text(
+                          city.subtitle,
+                          style: Theme.of(context).textTheme.bodySmall,
+                        ),
+                      ],
+                    ),
+                  ),
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      Text(
+                        units.formatTemp(w.temperature),
+                        style: Theme.of(context).textTheme.titleLarge,
+                      ),
+                      Text(
+                        units.formatWind(w.windSpeed),
+                        style: Theme.of(context).textTheme.bodySmall,
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+              loading: () => Row(
+                children: [
+                  const SizedBox(
+                    width: 40,
+                    height: 40,
+                    child: Center(
+                      child: SizedBox(
+                        width: 24,
+                        height: 24,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Text(city.name),
+                ],
+              ),
+              error: (e, _) => Row(
+                children: [
+                  const Icon(Icons.error_outline, color: Colors.red, size: 40),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          city.name,
+                          style: Theme.of(context).textTheme.titleMedium,
+                        ),
+                        Text(
+                          'Failed: $e',
+                          style: const TextStyle(color: Colors.red),
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/examples/weather/source/widgets/search_result_tile.dart
+++ b/examples/weather/source/widgets/search_result_tile.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+import '../domain/city.dart';
+
+class SearchResultTile extends StatelessWidget {
+  const SearchResultTile({
+    super.key,
+    required this.city,
+    required this.alreadyAdded,
+    required this.onAdd,
+  });
+
+  final City city;
+  final bool alreadyAdded;
+  final VoidCallback onAdd;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Text(city.name),
+      subtitle: Text(city.subtitle),
+      trailing: alreadyAdded
+          ? const Icon(Icons.check, color: Colors.green)
+          : const Icon(Icons.add_circle_outline),
+      onTap: alreadyAdded ? null : onAdd,
+    );
+  }
+}

--- a/examples/weather/source/widgets/weather_icon.dart
+++ b/examples/weather/source/widgets/weather_icon.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+class WeatherIcon extends StatelessWidget {
+  const WeatherIcon({super.key, required this.code, this.size = 32});
+
+  final int code;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    return Icon(_iconFor(code), size: size, color: _colorFor(code));
+  }
+
+  static IconData _iconFor(int code) {
+    if (code == 0) return Icons.wb_sunny;
+    if (code == 1 || code == 2) return Icons.wb_cloudy;
+    if (code == 3) return Icons.cloud;
+    if (code == 45 || code == 48) return Icons.blur_on;
+    if (code >= 51 && code <= 57) return Icons.grain;
+    if (code >= 61 && code <= 67) return Icons.umbrella;
+    if (code >= 71 && code <= 77) return Icons.ac_unit;
+    if (code >= 80 && code <= 82) return Icons.beach_access;
+    if (code >= 85 && code <= 86) return Icons.ac_unit;
+    if (code >= 95) return Icons.flash_on;
+    return Icons.help_outline;
+  }
+
+  static Color _colorFor(int code) {
+    if (code == 0) return Colors.orange;
+    if (code >= 95) return Colors.deepPurple;
+    if (code >= 71 && code <= 77 || code >= 85 && code <= 86) {
+      return Colors.lightBlue;
+    }
+    if (code >= 61 && code <= 67 || code >= 80 && code <= 82) {
+      return Colors.blue;
+    }
+    return Colors.blueGrey;
+  }
+}

--- a/packages/solid_generator/lib/builder.dart
+++ b/packages/solid_generator/lib/builder.dart
@@ -376,6 +376,7 @@ List<_AnnotatedClass> _collectAnnotatedClasses(
     // set independent of source order (a query A can call a query B declared
     // later).
     final queryNames = _collectClassQueryNames(decl);
+    final widgetBoundCtorNames = _collectWidgetBoundCtorNames(decl);
     for (final member in decl.members) {
       if (member is FieldDeclaration) {
         final model = readSolidStateField(member, source);
@@ -406,6 +407,7 @@ List<_AnnotatedClass> _collectAnnotatedClasses(
           classCollectionFields: crossClassCollections,
           environmentFields: environmentFieldsForBody,
           collectionFields: collectionFieldsSeen,
+          widgetBoundFields: widgetBoundCtorNames,
         );
         if (getter != null) {
           getters.add(getter);
@@ -427,6 +429,7 @@ List<_AnnotatedClass> _collectAnnotatedClasses(
           classCollectionFields: crossClassCollections,
           environmentFields: environmentFieldsForBody,
           collectionFields: collectionFieldsSeen,
+          widgetBoundFields: widgetBoundCtorNames,
         );
         if (effect != null) {
           effects.add(effect);
@@ -441,6 +444,7 @@ List<_AnnotatedClass> _collectAnnotatedClasses(
           classCollectionFields: crossClassCollections,
           environmentFields: environmentFieldsForBody,
           collectionFields: collectionFieldsSeen,
+          widgetBoundFields: widgetBoundCtorNames,
         );
         if (query != null) {
           queries.add(query);
@@ -499,6 +503,18 @@ Set<String> _collectClassQueryNames(ClassDeclaration decl) {
     (names ??= <String>{}).add(member.name.lexeme);
   }
   return names ?? const <String>{};
+}
+
+/// Per-class widget-bound ctor field names — the names that must be rewritten
+/// from `field` to `widget.field` inside reactive-member bodies that move from
+/// the source `StatelessWidget` into the lowered `State<X>`. Only meaningful
+/// for `StatelessWidget` classes; plain classes and existing `State<X>`
+/// subclasses have no Widget/State split and pass the empty default through.
+Set<String> _collectWidgetBoundCtorNames(ClassDeclaration decl) {
+  if (classKindOf(decl) != ClassKind.statelessWidget) return const <String>{};
+  return collectWidgetBoundNames(
+    decl.members.whereType<ConstructorDeclaration>(),
+  );
 }
 
 /// Renders the full `lib/` output for a file that has at least one annotated

--- a/packages/solid_generator/lib/builder.dart
+++ b/packages/solid_generator/lib/builder.dart
@@ -169,6 +169,13 @@ class _SolidBuilder implements Builder {
     // `@SolidQuery` on a sibling class in the same file.
     final sameFileRegistry = _prescanClassRegistry(parsed.unit);
     final sameFileCollections = _prescanClassCollectionFields(parsed.unit);
+    final sameFileFieldTypes = _prescanClassFieldTypes(parsed.unit);
+    // Captures, per cross-class `@SolidState` field type text, the
+    // `package:<self>/<lib-relative>` URIs that bring that type into scope
+    // on the env-field's class file. Used by [_renderOutput] to inject the
+    // import into the consumer's lib output so the synthesized
+    // `Computed<(…, T, …)>` Record-Computed resolves at lib-time.
+    final crossClassFieldTypeOriginUris = <String, Set<String>>{};
     // Cross-file resolver: walks every `package:`/relative import of the
     // current source file, redirecting same-package imports from `lib/` to
     // `source/`, and pulls in `@SolidState` member names for every class
@@ -179,6 +186,8 @@ class _SolidBuilder implements Builder {
       buildStep,
       sameFileRegistry,
       sameFileCollections,
+      sameFileFieldTypes,
+      crossClassFieldTypeOriginUris,
     );
 
     final annotatedClasses = _collectAnnotatedClasses(
@@ -216,6 +225,9 @@ class _SolidBuilder implements Builder {
       annotatedClasses,
       sameFileRegistry,
       sameFileCollections,
+      sameFileFieldTypes,
+      crossClassFieldTypeOriginUris,
+      buildStep.inputId,
       source,
     );
     await buildStep.writeAsString(outputId, transformed);
@@ -251,6 +263,44 @@ Map<String, Set<String>> _prescanClassRegistry(CompilationUnit unit) {
       }
     }
     if (names.isNotEmpty) registry[decl.name.lexeme] = names;
+  }
+  return registry;
+}
+
+/// Pre-scans every `ClassDeclaration` in [unit] and returns the cross-class
+/// **type-text** map (class name → field/getter name → declared type text).
+/// Parallel to [_prescanClassRegistry] — the same scan but with the
+/// declared type peeled out. Consumed by `emitQuerySourceField` to emit the
+/// Record element type for a `@SolidQuery` cross-class dep that reaches a
+/// sibling class's `@SolidState` field/getter through an `@SolidEnvironment`
+/// receiver.
+///
+/// Type-less declarations (no annotation on a field, no return type on a
+/// getter) are stored as the empty string — the emitter throws a clear
+/// `CodeGenerationError` at use time so the offending member can be named in
+/// the diagnostic.
+Map<String, Map<String, String>> _prescanClassFieldTypes(
+  CompilationUnit unit,
+) {
+  final registry = <String, Map<String, String>>{};
+  for (final decl in unit.declarations) {
+    if (decl is! ClassDeclaration) continue;
+    final types = <String, String>{};
+    for (final member in decl.members) {
+      if (member is FieldDeclaration) {
+        if (!member.metadata.any((a) => a.name.name == solidStateName)) {
+          continue;
+        }
+        final name = member.fields.variables.first.name.lexeme;
+        types[name] = member.fields.type?.toSource() ?? '';
+      } else if (member is MethodDeclaration && member.isGetter) {
+        if (!member.metadata.any((a) => a.name.name == solidStateName)) {
+          continue;
+        }
+        types[member.name.lexeme] = member.returnType?.toSource() ?? '';
+      }
+    }
+    if (types.isNotEmpty) registry[decl.name.lexeme] = types;
   }
   return registry;
 }
@@ -531,6 +581,9 @@ String _renderOutput(
   List<_AnnotatedClass> annotatedClasses,
   Map<String, Set<String>> classRegistry,
   Map<String, Set<String>> classCollectionFields,
+  Map<String, Map<String, String>> classFieldTypes,
+  Map<String, Set<String>> crossClassFieldTypeOriginUris,
+  AssetId inputId,
   String source,
 ) {
   // Walk `unit.declarations` in source order. Class declarations are paired
@@ -547,6 +600,7 @@ String _renderOutput(
           annotatedClasses[classIdx++],
           classRegistry,
           classCollectionFields,
+          classFieldTypes,
           source,
         )
       else
@@ -579,6 +633,29 @@ String _renderOutput(
     sourceUris.add(uri);
     sourceDirectives[uri] = directive.toSource();
   }
+  // Synthesize imports for cross-class signal types named in
+  // `@SolidQuery`-synthesized Record-Computed sources. Dedup against
+  // source-side imports by resolved `AssetId` — a relative `'types.dart'`
+  // and the synthesized `package:<self>/.../types.dart` refer to the
+  // same asset and must collapse to one import.
+  final sourceImportAssets = <AssetId>{
+    for (final uri in sourceDirectives.keys)
+      ?_resolveImportToSourceAsset(uri, inputId),
+  };
+  final extraImports = <String>{
+    for (final annotated in annotatedClasses)
+      if (annotated.queries.any(
+        (q) => q.trackedCrossClassSignalNames.isNotEmpty,
+      ))
+        ..._synthesizeExtraImports(
+          annotated,
+          classFieldTypes,
+          crossClassFieldTypeOriginUris,
+          sourceDirectives,
+          sourceImportAssets,
+          inputId,
+        ),
+  };
   final imports = computeOutputImports(
     sourceUris,
     addSolidart: results.any(
@@ -586,6 +663,7 @@ String _renderOutput(
     ),
     addProvider: annotatedClasses.any((c) => c.environments.isNotEmpty),
     referencesSolidAnnotations: referencesSolidAnnotations,
+    extraImports: extraImports,
   );
   final importBlock = imports
       .map((u) => sourceDirectives[u] ?? "import '$u';")
@@ -615,6 +693,7 @@ RewriteResult _resultForClass(
   _AnnotatedClass c,
   Map<String, Set<String>> classRegistry,
   Map<String, Set<String>> classCollectionFields,
+  Map<String, Map<String, String>> classFieldTypes,
   String source,
 ) {
   if (c.hasNoAnnotations) return _passthroughResult(c.decl, source);
@@ -627,6 +706,7 @@ RewriteResult _resultForClass(
     c.environments,
     classRegistry,
     classCollectionFields,
+    classFieldTypes,
     source,
   );
 }
@@ -657,6 +737,7 @@ RewriteResult _rewriteClass(
   List<EnvironmentModel> environments,
   Map<String, Set<String>> classRegistry,
   Map<String, Set<String>> classCollectionFields,
+  Map<String, Map<String, String>> classFieldTypes,
   String source,
 ) {
   final kind = classKindOf(decl);
@@ -672,6 +753,7 @@ RewriteResult _rewriteClass(
         environments,
         classRegistry,
         classCollectionFields,
+        classFieldTypes,
         source,
       );
     case ClassKind.plainClass:
@@ -684,6 +766,7 @@ RewriteResult _rewriteClass(
         environments,
         classRegistry,
         classCollectionFields,
+        classFieldTypes,
         source,
       );
     case ClassKind.stateClass:
@@ -696,6 +779,7 @@ RewriteResult _rewriteClass(
         environments,
         classRegistry,
         classCollectionFields,
+        classFieldTypes,
         source,
       );
     case ClassKind.statefulWidget:
@@ -732,6 +816,8 @@ Future<void> _populateCrossFileTypes(
   BuildStep step,
   Map<String, Set<String>> classRegistry,
   Map<String, Set<String>> classCollectionFields,
+  Map<String, Map<String, String>> classFieldTypes,
+  Map<String, Set<String>> crossClassFieldTypeOriginUris,
 ) async {
   // Walk every `@SolidEnvironment` field declaration in the unit. The
   // builder pre-scan does NOT pre-build env-field models — the readers do
@@ -787,6 +873,7 @@ Future<void> _populateCrossFileTypes(
       if (!wantedTypes.contains(className)) continue;
       final scalarNames = <String>{};
       final collectionNames = <String>{};
+      final fieldTypeTexts = <String, String>{};
       for (final member in decl.members) {
         if (member is FieldDeclaration) {
           final isSolidState = member.metadata.any(
@@ -796,6 +883,7 @@ Future<void> _populateCrossFileTypes(
           final variable = member.fields.variables.first;
           final fieldName = variable.name.lexeme;
           scalarNames.add(fieldName);
+          fieldTypeTexts[fieldName] = member.fields.type?.toSource() ?? '';
           // Mirror the collection-detection rule in signal_emitter.dart so
           // the cross-file collection set agrees with the same-file one:
           // collection signals are emitted for any non-nullable `List<T>`
@@ -810,7 +898,11 @@ Future<void> _populateCrossFileTypes(
           final isSolidState = member.metadata.any(
             (a) => a.name.name == solidStateName,
           );
-          if (isSolidState) scalarNames.add(member.name.lexeme);
+          if (isSolidState) {
+            scalarNames.add(member.name.lexeme);
+            fieldTypeTexts[member.name.lexeme] =
+                member.returnType?.toSource() ?? '';
+          }
         }
       }
       if (scalarNames.isNotEmpty) {
@@ -818,10 +910,132 @@ Future<void> _populateCrossFileTypes(
         if (collectionNames.isNotEmpty) {
           classCollectionFields[className] = collectionNames;
         }
+        if (fieldTypeTexts.isNotEmpty) {
+          classFieldTypes[className] = fieldTypeTexts;
+        }
+        // For each `@SolidState` field whose declared type is NOT declared
+        // inside the same class file, capture the file's same-package import
+        // URIs as candidate origins. The consumer's lib output will inject
+        // these so the synthesized Record-Computed `Computed<(…, T, …)>`
+        // resolves at lib-time even when the consumer's source never
+        // textually references `T`.
+        final declaredHere = _collectDeclaredTypeNames(imported);
+        final localCandidateUris = <String>{};
+        for (final directive
+            in imported.directives.whereType<ImportDirective>()) {
+          final uri = directive.uri.stringValue;
+          if (uri == null) continue;
+          final importedAsset = _resolveImportToSourceAsset(uri, assetId);
+          if (importedAsset == null) continue;
+          if (importedAsset.package != step.inputId.package) continue;
+          if (!importedAsset.path.startsWith('source/')) continue;
+          localCandidateUris.add(
+            _sourceToLibAsset(importedAsset).uri.toString(),
+          );
+        }
+        if (localCandidateUris.isNotEmpty) {
+          for (final entry in fieldTypeTexts.entries) {
+            final typeText = entry.value;
+            if (typeText.isEmpty) continue;
+            if (declaredHere.contains(typeText)) continue;
+            (crossClassFieldTypeOriginUris[typeText] ??= <String>{}).addAll(
+              localCandidateUris,
+            );
+          }
+        }
       }
       wantedTypes.remove(className);
     }
   }
+}
+
+/// Computes the `extraImports` contribution from a single annotated class —
+/// the cross-class signal types its `@SolidQuery` bodies name in their
+/// synthesized Record-Computed sources. Imports are returned in
+/// relative-lib form (so `prefer_relative_imports` stays satisfied) and
+/// dedup'd against the consumer's source-side imports by resolved AssetId.
+Iterable<String> _synthesizeExtraImports(
+  _AnnotatedClass annotated,
+  Map<String, Map<String, String>> classFieldTypes,
+  Map<String, Set<String>> crossClassFieldTypeOriginUris,
+  Map<String, String> sourceDirectives,
+  Set<AssetId> sourceImportAssets,
+  AssetId inputId,
+) sync* {
+  final envTypeByField = {
+    for (final env in annotated.environments) env.fieldName: env.typeText,
+  };
+  for (final query in annotated.queries) {
+    for (final dep in query.trackedCrossClassSignalNames) {
+      final envType = envTypeByField[dep.envField];
+      if (envType == null) continue;
+      final typeText = classFieldTypes[envType]?[dep.name];
+      if (typeText == null || typeText.isEmpty) continue;
+      final uris = crossClassFieldTypeOriginUris[typeText];
+      if (uris == null) continue;
+      for (final u in uris) {
+        if (sourceDirectives.containsKey(u)) continue;
+        final asset = _resolveImportToSourceAsset(u, inputId);
+        if (asset != null && sourceImportAssets.contains(asset)) continue;
+        yield asset != null && asset.package == inputId.package
+            ? _relativeLibImportFrom(inputId, asset)
+            : u;
+      }
+    }
+  }
+}
+
+/// Returns the set of top-level type names declared in [unit] — classes,
+/// enums, mixins, typedefs, extensions. Used by [_populateCrossFileTypes] to
+/// distinguish "this type lives in the same file I'm scanning (no import
+/// needed downstream)" from "this type comes from one of the file's imports
+/// and the downstream consumer must import it to resolve `Computed<(…, T,
+/// …)>` in lib".
+Set<String> _collectDeclaredTypeNames(CompilationUnit unit) {
+  final names = <String>{};
+  for (final decl in unit.declarations) {
+    if (decl is ClassDeclaration) names.add(decl.name.lexeme);
+    if (decl is EnumDeclaration) names.add(decl.name.lexeme);
+    if (decl is MixinDeclaration) names.add(decl.name.lexeme);
+    if (decl is ExtensionDeclaration) {
+      final n = decl.name?.lexeme;
+      if (n != null) names.add(n);
+    }
+    if (decl is FunctionTypeAlias) names.add(decl.name.lexeme);
+    if (decl is GenericTypeAlias) names.add(decl.name.lexeme);
+  }
+  return names;
+}
+
+/// Translates a `source/<rel>` AssetId to its `lib/<rel>` sibling. The
+/// inverse of [_resolveImportToSourceAsset]'s `lib/` → `source/` redirect.
+/// Passes non-`source/` AssetIds through unchanged.
+AssetId _sourceToLibAsset(AssetId asset) => asset.path.startsWith('source/')
+    ? AssetId(asset.package, 'lib/${asset.path.substring('source/'.length)}')
+    : asset;
+
+/// Returns the relative URI from the lib-path of [fromSource] to the
+/// lib-path of [toSource]. Both AssetIds must be same-package; both paths are
+/// expected under `source/`. The result is the relative form (`'../foo.dart'`
+/// or `'foo.dart'`) suitable for emission inside `lib/`, satisfying the
+/// project-wide `prefer_relative_imports` convention.
+String _relativeLibImportFrom(AssetId fromSource, AssetId toSource) {
+  final fromLib = _sourceToLibAsset(fromSource).path;
+  final toLib = _sourceToLibAsset(toSource).path;
+  // Drop the consumer's own filename — relative path is computed from the
+  // containing directory, not from the file itself.
+  final fromDirSegs = fromLib.split('/')..removeLast();
+  final toSegs = toLib.split('/');
+  var common = 0;
+  while (common < fromDirSegs.length &&
+      common < toSegs.length - 1 &&
+      fromDirSegs[common] == toSegs[common]) {
+    common++;
+  }
+  final ups = List<String>.filled(fromDirSegs.length - common, '..');
+  final downs = toSegs.sublist(common);
+  final combined = [...ups, ...downs].join('/');
+  return combined.isEmpty ? toSegs.last : combined;
 }
 
 /// Maps an `import '<uri>';` URI to the `AssetId` of its source-side input,

--- a/packages/solid_generator/lib/src/annotation_reader.dart
+++ b/packages/solid_generator/lib/src/annotation_reader.dart
@@ -150,6 +150,7 @@ GetterModel? readSolidStateGetter(
     :isBlockBody,
     trackedNames: _,
     trackedQueryNames: _,
+    trackedCrossClassNames: _,
     selfCycleFound: _,
   ) = _readReactiveBody(
     body,
@@ -206,6 +207,7 @@ GetterModel? readSolidStateGetter(
   bool isBlockBody,
   List<String> trackedNames,
   List<String> trackedQueryNames,
+  List<CrossClassDep> trackedCrossClassNames,
   bool selfCycleFound,
 })
 _readReactiveBody(
@@ -267,6 +269,7 @@ _readReactiveBody(
     isBlockBody: isBlockBody,
     trackedNames: result.trackedReadNames,
     trackedQueryNames: result.trackedQueryNames,
+    trackedCrossClassNames: result.trackedCrossClassReadNames,
     selfCycleFound: result.selfCycleFound,
   );
 }
@@ -310,6 +313,7 @@ EffectModel? readSolidEffectMethod(
     :isBlockBody,
     trackedNames: _,
     trackedQueryNames: _,
+    trackedCrossClassNames: _,
     selfCycleFound: _,
   ) = _readReactiveBody(
     decl.body,
@@ -390,6 +394,7 @@ QueryModel? readSolidQueryMethod(
     :isBlockBody,
     :trackedNames,
     :trackedQueryNames,
+    :trackedCrossClassNames,
     :selfCycleFound,
   ) = _readReactiveBody(
     decl.body,
@@ -432,6 +437,7 @@ QueryModel? readSolidQueryMethod(
     isStream: returnTypeName == streamLexeme,
     trackedSignalNames: trackedNames,
     trackedQueryNames: trackedQueryNames,
+    trackedCrossClassSignalNames: trackedCrossClassNames,
     annotationName: extractNameArgument(annotation),
     debounce: extractDebounceArgument(annotation, source),
     useRefreshing: extractUseRefreshingArgument(annotation),

--- a/packages/solid_generator/lib/src/annotation_reader.dart
+++ b/packages/solid_generator/lib/src/annotation_reader.dart
@@ -128,6 +128,7 @@ GetterModel? readSolidStateGetter(
   Map<String, Set<String>> classCollectionFields = const {},
   Map<String, String> environmentFields = const {},
   Set<String> collectionFields = const {},
+  Set<String> widgetBoundFields = const {},
 }) {
   if (!decl.isGetter || decl.isStatic) return null;
   final annotation = findAnnotationByName(solidStateName, decl.metadata);
@@ -166,6 +167,7 @@ GetterModel? readSolidStateGetter(
     classCollectionFields: classCollectionFields,
     environmentFields: environmentFields,
     collectionFields: collectionFields,
+    widgetBoundFields: widgetBoundFields,
   );
 
   return GetterModel(
@@ -219,6 +221,7 @@ _readReactiveBody(
   Map<String, Set<String>> classCollectionFields = const {},
   Map<String, String> environmentFields = const {},
   Set<String> collectionFields = const {},
+  Set<String> widgetBoundFields = const {},
 }) {
   final AstNode node;
   final bool isBlockBody;
@@ -241,6 +244,7 @@ _readReactiveBody(
     classCollectionFields: classCollectionFields,
     environmentFields: environmentFields,
     collectionFields: collectionFields,
+    widgetBoundFields: widgetBoundFields,
   );
   // Zero-deps Effect / Computed are rejected. A reactive dep is either a
   // `.value`-rewritten state read, a tracked query-call invocation, OR a
@@ -291,6 +295,7 @@ EffectModel? readSolidEffectMethod(
   Map<String, Set<String>> classCollectionFields = const {},
   Map<String, String> environmentFields = const {},
   Set<String> collectionFields = const {},
+  Set<String> widgetBoundFields = const {},
 }) {
   if (decl.isGetter || decl.isSetter || decl.isStatic) return null;
   final annotation = findAnnotationByName(solidEffectName, decl.metadata);
@@ -323,6 +328,7 @@ EffectModel? readSolidEffectMethod(
     classCollectionFields: classCollectionFields,
     environmentFields: environmentFields,
     collectionFields: collectionFields,
+    widgetBoundFields: widgetBoundFields,
   );
 
   return EffectModel(
@@ -357,6 +363,7 @@ QueryModel? readSolidQueryMethod(
   Map<String, Set<String>> classRegistry = const {},
   Map<String, Set<String>> classCollectionFields = const {},
   Map<String, String> environmentFields = const {},
+  Set<String> widgetBoundFields = const {},
   Set<String> collectionFields = const {},
 }) {
   if (decl.isGetter || decl.isSetter || decl.isStatic) return null;
@@ -399,6 +406,7 @@ QueryModel? readSolidQueryMethod(
     classCollectionFields: classCollectionFields,
     environmentFields: environmentFields,
     collectionFields: collectionFields,
+    widgetBoundFields: widgetBoundFields,
   );
 
   // A self-cycle is rejected at codegen — solidart would re-run

--- a/packages/solid_generator/lib/src/import_rewriter.dart
+++ b/packages/solid_generator/lib/src/import_rewriter.dart
@@ -94,6 +94,7 @@ List<String> computeOutputImports(
   required bool addSolidart,
   required bool referencesSolidAnnotations,
   bool addProvider = false,
+  Iterable<String> extraImports = const [],
 }) {
   final result = [
     for (final uri in sourceImports)
@@ -106,6 +107,9 @@ List<String> computeOutputImports(
   }
   if (addProvider && !result.contains(providerUri)) {
     result.add(providerUri);
+  }
+  for (final uri in extraImports) {
+    if (!result.contains(uri)) result.add(uri);
   }
   result.sort(_compareImportUris);
   return result;

--- a/packages/solid_generator/lib/src/plain_class_rewriter.dart
+++ b/packages/solid_generator/lib/src/plain_class_rewriter.dart
@@ -59,6 +59,7 @@ RewriteResult rewritePlainClass(
   List<EnvironmentModel> solidEnvironments,
   Map<String, Set<String>> classRegistry,
   Map<String, Set<String>> classCollectionFields,
+  Map<String, Map<String, String>> classFieldTypes,
   String source,
 ) {
   final className = classDecl.name.lexeme;
@@ -97,6 +98,11 @@ RewriteResult rewritePlainClass(
   final queryInnerTypeTexts = solidQueries.isEmpty
       ? const <String, String>{}
       : {for (final q in solidQueries) q.methodName: q.innerTypeText};
+  // Plain classes cannot host `@SolidEnvironment` fields (the target
+  // validator rejects them upstream), so cross-class signal deps in a
+  // `@SolidQuery` body cannot reach a same-host env-receiver — pass the
+  // empty default so the emitter's cross-class branches are no-ops.
+  const environmentFields = <String, String>{};
   final reactiveNames = <String>{
     ...fieldByName.keys,
     ...getterByName.keys,
@@ -174,6 +180,8 @@ RewriteResult rewritePlainClass(
           query,
           reactiveTypeTexts,
           queryInnerTypeTexts,
+          environmentFields,
+          classFieldTypes,
           pieces,
           disposeNames,
         );

--- a/packages/solid_generator/lib/src/query_model.dart
+++ b/packages/solid_generator/lib/src/query_model.dart
@@ -1,5 +1,11 @@
 import 'package:meta/meta.dart';
 
+/// One cross-class signal dependency reached through an `@SolidEnvironment`
+/// receiver — `<envField>.<name>` shape. Shared by [QueryModel] and
+/// `ValueRewriteResult.trackedCrossClassReadNames` so both layers carry the
+/// same shape end-to-end.
+typedef CrossClassDep = ({String envField, String name});
+
 /// Parsed description of one `@SolidQuery`-annotated method.
 ///
 /// Populated by `annotation_reader.dart` from unresolved AST and consumed by
@@ -27,6 +33,7 @@ class QueryModel {
     this.isStream = false,
     this.trackedSignalNames = const [],
     this.trackedQueryNames = const [],
+    this.trackedCrossClassSignalNames = const [],
     this.debounce,
     this.useRefreshing,
     this.annotationName,
@@ -105,10 +112,26 @@ class QueryModel {
   /// rejects self-cycles upstream with a clear error.
   final List<String> trackedQueryNames;
 
-  /// Combined dep count: sum of state and query reads in tracked position.
-  /// Drives the wiring branches (zero / one / many).
+  /// Cross-class `@SolidState` dependencies read in the query body via an
+  /// `@SolidEnvironment` receiver — `(envField, signalName)` pairs in
+  /// source-first-appearance order, deduplicated. Drives `Resource.source:`
+  /// synthesis the same way [trackedSignalNames] does: a single dep is passed
+  /// directly as `source: <envField>.<signalName>`; two or more deps (of any
+  /// mix across the three tracked-name lists) synthesize the Record-Computed
+  /// source where this entry contributes element type
+  /// `classFieldTypes[environmentFields[envField]][signalName]` and read
+  /// expression `<envField>.<signalName>.value`.
+  ///
+  /// Populated by `readSolidQueryMethod` from
+  /// [`ValueRewriteResult.trackedCrossClassReadNames`].
+  final List<CrossClassDep> trackedCrossClassSignalNames;
+
+  /// Combined dep count: sum of state, query, and cross-class reads in
+  /// tracked position. Drives the wiring branches (zero / one / many).
   int get totalTrackedDeps =>
-      trackedSignalNames.length + trackedQueryNames.length;
+      trackedSignalNames.length +
+      trackedQueryNames.length +
+      trackedCrossClassSignalNames.length;
 
   /// True when [totalTrackedDeps] is two or more — i.e. the rewriter must
   /// synthesize a Record-Computed `source:` field. Single-dep queries pass

--- a/packages/solid_generator/lib/src/signal_emitter.dart
+++ b/packages/solid_generator/lib/src/signal_emitter.dart
@@ -212,18 +212,25 @@ String emitResourceField(QueryModel q) {
       ? 'Resource<${q.innerTypeText}>.stream'
       : 'Resource<${q.innerTypeText}>';
   // A single-observable Computed wrapper would be a no-op, so the one-dep
-  // case (whether a state Signal or an upstream Resource) passes the
-  // observable directly as `source:`. State deps come from
-  // `trackedSignalNames`; query deps come from `trackedQueryNames` and pass
-  // the upstream `Resource<T>` field directly (Resource extends Signal so it
-  // qualifies as a `SignalBase<dynamic>` source — auto-tracking of upstream
-  // queries).
+  // case (whether a state Signal, an upstream Resource, or a cross-class
+  // env-injected Signal) passes the observable directly as `source:`.
+  // State deps come from `trackedSignalNames`; query deps come from
+  // `trackedQueryNames` and pass the upstream `Resource<T>` field directly
+  // (Resource extends Signal so it qualifies as a `SignalBase<dynamic>`
+  // source — auto-tracking of upstream queries); cross-class deps come from
+  // `trackedCrossClassSignalNames` and pass `<envField>.<signalName>`,
+  // which is the Signal object reachable through the env-injected receiver.
   // `useRefreshing: true` is the upstream default and is omitted from emitted
   // output to keep generated lines short.
-  final source = switch ((q.trackedSignalNames, q.trackedQueryNames)) {
-    ([], []) => null,
-    ([final only], []) => only,
-    ([], [final only]) => only,
+  final source = switch ((
+    q.trackedSignalNames,
+    q.trackedQueryNames,
+    q.trackedCrossClassSignalNames,
+  )) {
+    ([], [], []) => null,
+    ([final only], [], []) => only,
+    ([], [final only], []) => only,
+    ([], [], [final only]) => '${only.envField}.${only.name}',
     _ => q.sourceFieldName,
   };
   final args = [
@@ -281,13 +288,17 @@ String? emitQuerySourceField(
   QueryModel q,
   Map<String, String> reactiveTypeTexts,
   Map<String, String> queryInnerTypeTexts,
+  Map<String, String> environmentFields,
+  Map<String, Map<String, String>> classFieldTypes,
 ) {
   if (!q.needsSourceComputed) return null;
   // State deps contribute element type `T` and read expression `<name>.value`;
   // query deps contribute element type `ResourceState<T>` and read expression
-  // `<name>.state`. Source order is preserved across the merged list (state
-  // names first per body appearance, then query names per body appearance —
-  // matches the visitor's two parallel name lists).
+  // `<name>.state`; cross-class deps contribute element type `T` looked up
+  // through the env-field's class registry and read expression
+  // `<envField>.<name>.value`. Source order is preserved within each list;
+  // the three lists are concatenated state → query → cross-class, matching
+  // the visitor's three parallel name lists.
   final stateTypes = q.trackedSignalNames.map((n) {
     final t = reactiveTypeTexts[n];
     if (t == null || t.isEmpty) {
@@ -316,10 +327,32 @@ String? emitQuerySourceField(
     }
     return 'ResourceState<$t>';
   }).toList();
-  final tupleType = '(${[...stateTypes, ...queryTypes].join(', ')})';
+  final crossTypes = q.trackedCrossClassSignalNames.map((p) {
+    final receiverType = environmentFields[p.envField];
+    final t = receiverType == null
+        ? null
+        : classFieldTypes[receiverType]?[p.name];
+    if (t == null || t.isEmpty) {
+      throw CodeGenerationError(
+        "@SolidQuery '${q.methodName}' depends on cross-class reactive "
+        "'${p.envField}.${p.name}' which has no explicit type annotation; "
+        'add a type to the @SolidState declaration so the synthesized '
+        'source-Computed Record type can be emitted',
+        null,
+        q.methodName,
+      );
+    }
+    return t;
+  }).toList();
+  final tupleType =
+      '(${[...stateTypes, ...queryTypes, ...crossTypes].join(', ')})';
   final stateReads = q.trackedSignalNames.map((n) => '$n.value');
   final queryReads = q.trackedQueryNames.map((n) => '$n.state');
-  final tupleExpr = '(${[...stateReads, ...queryReads].join(', ')})';
+  final crossReads = q.trackedCrossClassSignalNames.map(
+    (p) => '${p.envField}.${p.name}.value',
+  );
+  final tupleExpr =
+      '(${[...stateReads, ...queryReads, ...crossReads].join(', ')})';
   final fieldName = q.sourceFieldName;
   return '  late final $fieldName = '
       "Computed<$tupleType>(() => $tupleExpr, name: '$fieldName');";
@@ -340,6 +373,8 @@ void emitQueryFields(
   QueryModel q,
   Map<String, String> reactiveTypeTexts,
   Map<String, String> queryInnerTypeTexts,
+  Map<String, String> environmentFields,
+  Map<String, Map<String, String>> classFieldTypes,
   List<String> output,
   List<String> disposeNames,
 ) {
@@ -347,6 +382,8 @@ void emitQueryFields(
     q,
     reactiveTypeTexts,
     queryInnerTypeTexts,
+    environmentFields,
+    classFieldTypes,
   );
   if (sourceField != null) {
     output.add(sourceField);

--- a/packages/solid_generator/lib/src/state_class_rewriter.dart
+++ b/packages/solid_generator/lib/src/state_class_rewriter.dart
@@ -41,6 +41,7 @@ RewriteResult rewriteStateClass(
   List<EnvironmentModel> solidEnvironments,
   Map<String, Set<String>> classRegistry,
   Map<String, Set<String>> classCollectionFields,
+  Map<String, Map<String, String>> classFieldTypes,
   String source,
 ) {
   final className = classDecl.name.lexeme;
@@ -176,6 +177,8 @@ RewriteResult rewriteStateClass(
           query,
           reactiveTypeTexts,
           queryInnerTypeTexts,
+          environmentFields,
+          classFieldTypes,
           pieces,
           disposeNames,
         );

--- a/packages/solid_generator/lib/src/stateless_rewriter.dart
+++ b/packages/solid_generator/lib/src/stateless_rewriter.dart
@@ -27,6 +27,7 @@ RewriteResult rewriteStatelessWidget(
   List<EnvironmentModel> solidEnvironments,
   Map<String, Set<String>> classRegistry,
   Map<String, Set<String>> classCollectionFields,
+  Map<String, Map<String, String>> classFieldTypes,
   String source,
 ) {
   final className = classDecl.name.lexeme;
@@ -108,6 +109,8 @@ RewriteResult rewriteStatelessWidget(
     solidEffects,
     solidQueries,
     solidEnvironments,
+    environmentFields,
+    classFieldTypes,
   );
 
   final widgetClass = _emitWidgetClass(
@@ -216,6 +219,8 @@ _emitReactiveBlock(
   List<EffectModel> solidEffects,
   List<QueryModel> solidQueries,
   List<EnvironmentModel> solidEnvironments,
+  Map<String, String> environmentFields,
+  Map<String, Map<String, String>> classFieldTypes,
 ) {
   final fieldByName = {for (final f in solidFields) f.fieldName: f};
   final envByName = {for (final e in solidEnvironments) e.fieldName: e};
@@ -274,6 +279,8 @@ _emitReactiveBlock(
             q,
             reactiveTypeTexts,
             queryInnerTypeTexts,
+            environmentFields,
+            classFieldTypes,
             lines,
             disposeNames,
           );

--- a/packages/solid_generator/lib/src/stateless_rewriter.dart
+++ b/packages/solid_generator/lib/src/stateless_rewriter.dart
@@ -59,7 +59,7 @@ RewriteResult rewriteStatelessWidget(
   };
 
   final members = _splitMembers(classDecl);
-  final widgetBoundNames = _collectWidgetBoundNames(members.ctors);
+  final widgetBoundNames = collectWidgetBoundNames(members.ctors);
   final partition = _partitionFields(
     members.fields,
     partitionExcludeNames,
@@ -329,7 +329,7 @@ _splitMembers(ClassDeclaration classDecl) {
 /// directly to a parameter. (`ConstructorDeclaration` exposes only
 /// `factoryKeyword` in the public analyzer API; there is no `isFactory`
 /// getter, hence the null-check.)
-Set<String> _collectWidgetBoundNames(List<ConstructorDeclaration> ctors) {
+Set<String> collectWidgetBoundNames(Iterable<ConstructorDeclaration> ctors) {
   final names = <String>{};
   for (final ctor in ctors) {
     if (ctor.factoryKeyword != null) continue;

--- a/packages/solid_generator/lib/src/target_validator.dart
+++ b/packages/solid_generator/lib/src/target_validator.dart
@@ -274,20 +274,8 @@ void _validateQueryMethod(MethodDeclaration method, String className) {
   if (returnName != futureLexeme && returnName != streamLexeme) {
     _rejectQuery('non-Future/Stream method', location);
   }
-  // Future<T> requires `async`. A null body keyword (expression body without
-  // `async`, e.g. `=> Future.value(0)`) is intentionally caught here —
-  // `?.lexeme` returns `null`, and `null != 'async'` is `true`. Mirrors
-  // `annotation_reader.dart`'s `?.lexeme ?? ''` pattern. Stream-form
-  // mismatches are out of scope (Stream has two valid shapes: sync-return or
-  // async*); they are exercised positively by the simple_query_with_stream
-  // golden.
-  final bodyKeyword = method.body.keyword?.lexeme;
-  if (returnName == futureLexeme && bodyKeyword != 'async') {
-    _rejectQuery(
-      'method whose body keyword does not match the return type',
-      location,
-    );
-  }
+  // Body-keyword/return-type mismatch is intentionally NOT validated; see
+  // the rejection-suite header for the rationale.
 }
 
 /// Rejects `@SolidQuery` on top-level declarations.

--- a/packages/solid_generator/lib/src/value_rewriter.dart
+++ b/packages/solid_generator/lib/src/value_rewriter.dart
@@ -1,5 +1,6 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:solid_generator/src/query_model.dart';
 import 'package:solid_generator/src/transformation_error.dart';
 
 /// A single value-level edit emitted by [collectValueEdits].
@@ -28,12 +29,14 @@ class ValueEdit {
 /// callbacks or `<field>.untracked` reads are excluded.
 class ValueRewriteResult {
   /// Creates a result holding [edits], [trackedReadNamesByOffset],
-  /// [trackedReadNames], [trackedQueryNames], and [selfCycleFound].
+  /// [trackedReadNames], [trackedQueryNames], [trackedCrossClassReadNames],
+  /// and [selfCycleFound].
   const ValueRewriteResult(
     this.edits,
     this.trackedReadNamesByOffset,
     this.trackedReadNames,
     this.trackedQueryNames,
+    this.trackedCrossClassReadNames,
     // Positional to keep the constructor signature consistent with the
     // list/map-typed args above; the field is single-use sentinel data.
     // ignore: avoid_positional_boolean_parameters
@@ -61,6 +64,17 @@ class ValueRewriteResult {
   /// `ResourceState<T>` (read via `<name>.state`) to the synthesized
   /// Record-Computed source.
   final List<String> trackedQueryNames;
+
+  /// Cross-class `@SolidState` reads — `<envField>.<signalName>` shapes where
+  /// `<envField>` is an `@SolidEnvironment` field on the enclosing class and
+  /// `<signalName>` is a `@SolidState` field/getter on the env-field's type.
+  /// Source-first-appearance order, deduplicated. Drives `Resource.source:`
+  /// synthesis for `@SolidQuery` bodies that depend on cross-class signals;
+  /// the same Signal would otherwise be read via `.value` (subscribing
+  /// `Computed`/`Effect` bodies at runtime) but a Resource needs an explicit
+  /// `source:` to re-fetch on dependency changes. Disjoint from
+  /// [trackedReadNames] (which is same-class only).
+  final List<CrossClassDep> trackedCrossClassReadNames;
 
   /// True if the visitor saw a zero-arg call to its own [collectValueEdits]
   /// `currentMember` — i.e. a `@SolidQuery` body invokes itself. Consumed
@@ -168,6 +182,7 @@ ValueRewriteResult collectValueEdits(
     visitor.trackedReadNamesByOffset,
     visitor.trackedReadNames,
     visitor.trackedQueryNames,
+    visitor.trackedCrossClassReadNames,
     visitor.selfCycleFound,
   );
 }
@@ -308,6 +323,13 @@ class _ValueRewriteVisitor extends RecursiveAstVisitor<void> {
   /// Same-class `@SolidQuery` method names invoked as tracked zero-arg
   /// calls. Source-first-appearance order, deduplicated.
   final List<String> trackedQueryNames = [];
+
+  /// Cross-class `@SolidState` reads in tracked position —
+  /// `<envField>.<signalName>` pairs where the prefix is an
+  /// `@SolidEnvironment` field on the enclosing class and the property is a
+  /// `@SolidState` field/getter on the env-field's declared type.
+  /// Source-first-appearance order, deduplicated by pair.
+  final List<CrossClassDep> trackedCrossClassReadNames = [];
 
   /// Set true when the body invokes [_currentMember] as a zero-arg tracked
   /// call — a self-cycle. The reader checks this and throws.
@@ -508,12 +530,19 @@ class _ValueRewriteVisitor extends RecursiveAstVisitor<void> {
     // record an offset so SignalBuilder placement wraps the surrounding
     // subtree (see [_trackedSignalApiGetters]).
     final outerParent = node.parent;
+    final isEnvReceiver = _environmentFields.containsKey(node.prefix.name);
     if (outerParent is PropertyAccess &&
         outerParent.target == node &&
         _signalApiGetters.contains(outerParent.propertyName.name)) {
       if (_trackedSignalApiGetters.contains(outerParent.propertyName.name) &&
           _untrackedDepth == 0) {
         _recordTrackedRead(node.offset, node.identifier.name);
+        if (isEnvReceiver) {
+          _recordTrackedCrossClassRead(
+            node.prefix.name,
+            node.identifier.name,
+          );
+        }
       }
       return;
     }
@@ -534,6 +563,19 @@ class _ValueRewriteVisitor extends RecursiveAstVisitor<void> {
     }
     if (_untrackedDepth == 0) {
       _recordTrackedRead(node.offset, node.identifier.name);
+      // Cross-class scalar signal reads through an `@SolidEnvironment`
+      // receiver feed `Resource.source:` synthesis for enclosing `@SolidQuery`
+      // bodies. Collection-typed signals are intentionally excluded: their
+      // mutations notify via the mixin's own listeners — a Resource that
+      // depends on a ListSignal's contents would need a deeper dep model
+      // than the `source:` Signal-reference path can express, and is
+      // deferred until a real example exercises it.
+      if (isEnvReceiver && !isCollection) {
+        _recordTrackedCrossClassRead(
+          node.prefix.name,
+          node.identifier.name,
+        );
+      }
     }
   }
 
@@ -748,6 +790,17 @@ class _ValueRewriteVisitor extends RecursiveAstVisitor<void> {
   /// exactly once to the synthesized source-Computed tuple.
   void _recordTrackedQueryName(String name) {
     if (!trackedQueryNames.contains(name)) trackedQueryNames.add(name);
+  }
+
+  /// Appends the `(envField, name)` pair to [trackedCrossClassReadNames] iff
+  /// not already present, preserving source-first-appearance order. A query
+  /// body reading the same cross-class signal at multiple offsets contributes
+  /// the pair exactly once to the synthesized source-Computed tuple.
+  void _recordTrackedCrossClassRead(String envField, String name) {
+    for (final p in trackedCrossClassReadNames) {
+      if (p.envField == envField && p.name == name) return;
+    }
+    trackedCrossClassReadNames.add((envField: envField, name: name));
   }
 
   /// True if [id] sits in receiver position of a chain access whose property

--- a/packages/solid_generator/test/golden/inputs/computed_reads_widget_ctor_field.dart
+++ b/packages/solid_generator/test/golden/inputs/computed_reads_widget_ctor_field.dart
@@ -1,0 +1,22 @@
+// `@SolidState` getter on a `StatelessWidget` whose body reads BOTH a
+// widget-bound constructor field and a `@SolidState` field. The lowered
+// Computed must read the ctor field through `widget.<name>` because the
+// getter lives on the State class, not the Widget.
+
+import 'package:flutter/widgets.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+class TempBadge extends StatelessWidget {
+  TempBadge({super.key, required this.label});
+
+  final String label;
+
+  @SolidState()
+  double celsius = 0;
+
+  @SolidState()
+  String get display => '$label ${celsius.toStringAsFixed(1)}';
+
+  @override
+  Widget build(BuildContext context) => Text(display);
+}

--- a/packages/solid_generator/test/golden/inputs/effect_reads_widget_ctor_field.dart
+++ b/packages/solid_generator/test/golden/inputs/effect_reads_widget_ctor_field.dart
@@ -1,0 +1,23 @@
+// `@SolidEffect` on a `StatelessWidget` whose body reads BOTH a widget-bound
+// constructor field and a `@SolidState` field. The lowered Effect closure
+// must read the ctor field through `widget.<name>`.
+
+import 'package:flutter/widgets.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+class TempLogger extends StatelessWidget {
+  TempLogger({super.key, required this.label});
+
+  final String label;
+
+  @SolidState()
+  double celsius = 0;
+
+  @SolidEffect()
+  void logTemp() {
+    debugPrint('$label is at $celsius');
+  }
+
+  @override
+  Widget build(BuildContext context) => Text('$celsius');
+}

--- a/packages/solid_generator/test/golden/inputs/future_without_async.dart
+++ b/packages/solid_generator/test/golden/inputs/future_without_async.dart
@@ -1,6 +1,0 @@
-import 'package:solid_annotations/solid_annotations.dart';
-
-class Counter {
-  @SolidQuery()
-  Future<int> fetchCount() => Future.value(0);
-}

--- a/packages/solid_generator/test/golden/inputs/query_future_arrow_body.dart
+++ b/packages/solid_generator/test/golden/inputs/query_future_arrow_body.dart
@@ -1,0 +1,11 @@
+// `@SolidQuery` on a `Future<T>`-returning method using an expression body
+// without `async`. The arrow body produces a Future directly, which is valid
+// Dart — `await` is only required when the body actually awaits a value.
+// The generator should accept this shape unchanged.
+
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Answers {
+  @SolidQuery()
+  Future<int> answer() => Future.value(42);
+}

--- a/packages/solid_generator/test/golden/inputs/query_reads_widget_ctor_field.dart
+++ b/packages/solid_generator/test/golden/inputs/query_reads_widget_ctor_field.dart
@@ -1,0 +1,21 @@
+// `@SolidQuery` on a `StatelessWidget` whose body reads widget-bound
+// constructor fields. The lowered Resource closure must read the ctor
+// fields through `widget.<name>` because the closure lives on the State
+// class. Unlike Computed/Effect, queries don't require reactive deps, so
+// this fixture exercises the rewrite without an accompanying Signal read.
+
+import 'package:flutter/widgets.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+class WeatherCard extends StatelessWidget {
+  const WeatherCard({super.key, required this.lat, required this.lon});
+
+  final double lat;
+  final double lon;
+
+  @SolidQuery()
+  Future<String> forecast() async => 'temp@$lat,$lon';
+
+  @override
+  Widget build(BuildContext context) => Text('$lat,$lon');
+}

--- a/packages/solid_generator/test/golden/inputs/query_with_cross_class_signal_already_imported_type/controllers.dart
+++ b/packages/solid_generator/test/golden/inputs/query_with_cross_class_signal_already_imported_type/controllers.dart
@@ -1,0 +1,8 @@
+import 'package:solid_annotations/solid_annotations.dart';
+
+import 'types.dart';
+
+class Settings {
+  @SolidState()
+  Unit unit = Unit.a;
+}

--- a/packages/solid_generator/test/golden/inputs/query_with_cross_class_signal_already_imported_type/types.dart
+++ b/packages/solid_generator/test/golden/inputs/query_with_cross_class_signal_already_imported_type/types.dart
@@ -1,0 +1,6 @@
+// Same setup as `query_with_cross_class_signal_unimported_type/`, but
+// `widget.dart` ALSO imports `types.dart` directly. The generator must NOT
+// double-add the import — the lib output's import block contains
+// `types.dart` exactly once.
+
+enum Unit { a, b }

--- a/packages/solid_generator/test/golden/inputs/query_with_cross_class_signal_already_imported_type/widget.dart
+++ b/packages/solid_generator/test/golden/inputs/query_with_cross_class_signal_already_imported_type/widget.dart
@@ -1,0 +1,25 @@
+// Consumer source imports `types.dart` directly. The synthesized import
+// must NOT duplicate the existing source-side import — dedup against the
+// source's import URI list.
+
+import 'package:flutter/widgets.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+import 'controllers.dart';
+import 'types.dart';
+
+class Display extends StatelessWidget {
+  Display({super.key});
+
+  @SolidEnvironment()
+  late Settings settings;
+
+  @SolidState()
+  int seed = 0;
+
+  @SolidQuery()
+  Future<String> q() async => '$seed-${settings.unit}-${Unit.b}';
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/golden/inputs/query_with_cross_class_signal_unimported_type/controllers.dart
+++ b/packages/solid_generator/test/golden/inputs/query_with_cross_class_signal_unimported_type/controllers.dart
@@ -1,0 +1,11 @@
+// Cross-file `@SolidState` host. The `unit` field's type `Unit` is declared
+// in a sibling file (`types.dart`) which this file imports.
+
+import 'package:solid_annotations/solid_annotations.dart';
+
+import 'types.dart';
+
+class Settings {
+  @SolidState()
+  Unit unit = Unit.a;
+}

--- a/packages/solid_generator/test/golden/inputs/query_with_cross_class_signal_unimported_type/types.dart
+++ b/packages/solid_generator/test/golden/inputs/query_with_cross_class_signal_unimported_type/types.dart
@@ -1,0 +1,8 @@
+// A plain Dart enum declared in a sibling file. `controllers.dart` imports
+// this file to type its `@SolidState Unit unit` field; `widget.dart` does
+// NOT import it, because the widget's source body never names `Unit`
+// textually — it only writes `settings.unit`. The generator must inject the
+// import into `widget.g.dart` so the synthesized `Computed<(int, Unit)>`
+// Record resolves at lib-time.
+
+enum Unit { a, b }

--- a/packages/solid_generator/test/golden/inputs/query_with_cross_class_signal_unimported_type/widget.dart
+++ b/packages/solid_generator/test/golden/inputs/query_with_cross_class_signal_unimported_type/widget.dart
@@ -1,0 +1,26 @@
+// Cross-file `@SolidEnvironment` consumer whose `@SolidQuery` body reads a
+// cross-class signal whose declared type (`Unit`) lives in a file the source
+// does NOT import. The synthesized Record-Computed `Computed<(int, Unit)>`
+// names `Unit` in the lib output; the generator must inject the
+// `package:a/.../types.dart` import.
+
+import 'package:flutter/widgets.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+import 'controllers.dart';
+
+class Display extends StatelessWidget {
+  Display({super.key});
+
+  @SolidEnvironment()
+  late Settings settings;
+
+  @SolidState()
+  int seed = 0;
+
+  @SolidQuery()
+  Future<String> q() async => '$seed-${settings.unit}';
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/golden/inputs/query_with_mixed_signal_deps.dart
+++ b/packages/solid_generator/test/golden/inputs/query_with_mixed_signal_deps.dart
@@ -1,0 +1,31 @@
+// A `@SolidQuery` body that mixes ONE same-class `@SolidState` field with ONE
+// cross-class `@SolidState` signal (through an `@SolidEnvironment` receiver)
+// synthesizes a Record-Computed source field that merges both deps. Same-class
+// elements come first in the tuple (matching the visitor's
+// `trackedSignalNames`), then cross-class elements
+// (`trackedCrossClassSignalNames`); query elements would sit between them in
+// the more general case.
+
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+
+class Filter {
+  @SolidState()
+  int factor = 1;
+}
+
+class ValueCard extends StatelessWidget {
+  ValueCard({super.key});
+
+  @SolidEnvironment()
+  late Filter filter;
+
+  @SolidState()
+  int seed = 0;
+
+  @SolidQuery()
+  Future<int> fetchValue() async => seed + filter.factor;
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/golden/inputs/query_with_multi_env_signal_deps.dart
+++ b/packages/solid_generator/test/golden/inputs/query_with_multi_env_signal_deps.dart
@@ -1,0 +1,32 @@
+// A `@SolidQuery` body that reads TWO OR MORE cross-class `@SolidState` signals
+// through an `@SolidEnvironment`-injected receiver synthesizes a Record-Computed
+// source field whose tuple mirrors the body's reads. Each cross-class element
+// contributes element type `T` (looked up from the env-field's class) and read
+// expression `<envField>.<signalName>.value`. Mirrors `query_with_multi_signal_deps`
+// but the deps live on a sibling class reached through an `@SolidEnvironment`
+// field — the exact shape that motivated the fix in `examples/weather`.
+
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+
+class Settings {
+  @SolidState()
+  int factor = 1;
+
+  @SolidState()
+  String? prefix;
+}
+
+class ValueCard extends StatelessWidget {
+  ValueCard({super.key});
+
+  @SolidEnvironment()
+  late Settings settings;
+
+  @SolidQuery()
+  Future<String> fetchValue() async =>
+      '${settings.prefix ?? ''}${10 * settings.factor}';
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/golden/inputs/query_with_one_env_signal_dep.dart
+++ b/packages/solid_generator/test/golden/inputs/query_with_one_env_signal_dep.dart
@@ -1,0 +1,27 @@
+// A `@SolidQuery` body that reads exactly ONE cross-class `@SolidState` signal
+// through an `@SolidEnvironment`-injected receiver passes that Signal directly
+// as the Resource's `source:` argument (no synthesized wrapper Computed, since
+// `Computed(() => signal.value)` would be a no-op). Mirrors the same-class
+// `query_with_one_signal_dep` golden but the single dep is reached through
+// an env receiver instead of a same-class field.
+
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+
+class Filter {
+  @SolidState()
+  int factor = 1;
+}
+
+class ValueCard extends StatelessWidget {
+  ValueCard({super.key});
+
+  @SolidEnvironment()
+  late Filter filter;
+
+  @SolidQuery()
+  Future<int> fetchValue() async => 10 * filter.factor;
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/golden/inputs/query_with_two_env_receivers.dart
+++ b/packages/solid_generator/test/golden/inputs/query_with_two_env_receivers.dart
@@ -1,0 +1,34 @@
+// A `@SolidQuery` body whose deps come from TWO DIFFERENT
+// `@SolidEnvironment`-injected receivers (`auth.userId` + `filter.factor`)
+// folds both pairs into the synthesized Record-Computed source. Each
+// `(envField, signalName)` pair appears in source-first-appearance order and
+// the Computed Record carries one element per pair.
+
+import 'package:solid_annotations/solid_annotations.dart';
+import 'package:flutter/widgets.dart';
+
+class Auth {
+  @SolidState()
+  int userId = 0;
+}
+
+class Filter {
+  @SolidState()
+  int factor = 1;
+}
+
+class ValueCard extends StatelessWidget {
+  ValueCard({super.key});
+
+  @SolidEnvironment()
+  late Auth auth;
+
+  @SolidEnvironment()
+  late Filter filter;
+
+  @SolidQuery()
+  Future<int> fetchValue() async => auth.userId * filter.factor;
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/golden/outputs/computed_reads_widget_ctor_field.g.dart
+++ b/packages/solid_generator/test/golden/outputs/computed_reads_widget_ctor_field.g.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class TempBadge extends StatefulWidget {
+  const TempBadge({super.key, required this.label});
+
+  final String label;
+
+  @override
+  State<TempBadge> createState() => _TempBadgeState();
+}
+
+class _TempBadgeState extends State<TempBadge> {
+  final celsius = Signal<double>(0, name: 'celsius');
+  late final display = Computed<String>(
+    () => '${widget.label} ${celsius.value.toStringAsFixed(1)}',
+    name: 'display',
+  );
+
+  @override
+  void dispose() {
+    display.dispose();
+    celsius.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => SignalBuilder(
+    builder: (context, child) {
+      return Text(display.value);
+    },
+  );
+}

--- a/packages/solid_generator/test/golden/outputs/effect_reads_widget_ctor_field.g.dart
+++ b/packages/solid_generator/test/golden/outputs/effect_reads_widget_ctor_field.g.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class TempLogger extends StatefulWidget {
+  const TempLogger({super.key, required this.label});
+
+  final String label;
+
+  @override
+  State<TempLogger> createState() => _TempLoggerState();
+}
+
+class _TempLoggerState extends State<TempLogger> {
+  final celsius = Signal<double>(0, name: 'celsius');
+  late final logTemp = Effect(() {
+    debugPrint('${widget.label} is at ${celsius.value}');
+  }, name: 'logTemp');
+
+  @override
+  void initState() {
+    super.initState();
+    logTemp;
+  }
+
+  @override
+  void dispose() {
+    logTemp.dispose();
+    celsius.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => SignalBuilder(
+    builder: (context, child) {
+      return Text('${celsius.value}');
+    },
+  );
+}

--- a/packages/solid_generator/test/golden/outputs/query_future_arrow_body.g.dart
+++ b/packages/solid_generator/test/golden/outputs/query_future_arrow_body.g.dart
@@ -1,0 +1,11 @@
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Answers implements Disposable {
+  late final answer = Resource<int>(() => Future.value(42), name: 'answer');
+
+  @override
+  void dispose() {
+    answer.dispose();
+  }
+}

--- a/packages/solid_generator/test/golden/outputs/query_reads_widget_ctor_field.g.dart
+++ b/packages/solid_generator/test/golden/outputs/query_reads_widget_ctor_field.g.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+
+class WeatherCard extends StatefulWidget {
+  const WeatherCard({super.key, required this.lat, required this.lon});
+
+  final double lat;
+  final double lon;
+
+  @override
+  State<WeatherCard> createState() => _WeatherCardState();
+}
+
+class _WeatherCardState extends State<WeatherCard> {
+  late final forecast = Resource<String>(
+    () async => 'temp@${widget.lat},${widget.lon}',
+    name: 'forecast',
+  );
+
+  @override
+  void dispose() {
+    forecast.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => Text('${widget.lat},${widget.lon}');
+}

--- a/packages/solid_generator/test/golden/outputs/query_with_cross_class_signal_already_imported_type/controllers.g.dart
+++ b/packages/solid_generator/test/golden/outputs/query_with_cross_class_signal_already_imported_type/controllers.g.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+import 'types.dart';
+
+class Settings implements Disposable {
+  final unit = Signal<Unit>(Unit.a, name: 'unit');
+
+  @override
+  void dispose() {
+    unit.dispose();
+  }
+}

--- a/packages/solid_generator/test/golden/outputs/query_with_cross_class_signal_already_imported_type/types.g.dart
+++ b/packages/solid_generator/test/golden/outputs/query_with_cross_class_signal_already_imported_type/types.g.dart
@@ -1,0 +1,6 @@
+// Same setup as `query_with_cross_class_signal_unimported_type/`, but
+// `widget.dart` ALSO imports `types.dart` directly. The generator must NOT
+// double-add the import — the lib output's import block contains
+// `types.dart` exactly once.
+
+enum Unit { a, b }

--- a/packages/solid_generator/test/golden/outputs/query_with_cross_class_signal_already_imported_type/widget.g.dart
+++ b/packages/solid_generator/test/golden/outputs/query_with_cross_class_signal_already_imported_type/widget.g.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:provider/provider.dart';
+import 'controllers.dart';
+import 'types.dart';
+
+class Display extends StatefulWidget {
+  const Display({super.key});
+
+  @override
+  State<Display> createState() => _DisplayState();
+}
+
+class _DisplayState extends State<Display> {
+  late final settings = context.read<Settings>();
+  final seed = Signal<int>(0, name: 'seed');
+  late final _qSource = Computed<(int, Unit)>(
+    () => (seed.value, settings.unit.value),
+    name: '_qSource',
+  );
+  late final q = Resource<String>(
+    () async => '${seed.value}-${settings.unit.value}-${Unit.b}',
+    source: _qSource,
+    name: 'q',
+  );
+
+  @override
+  void dispose() {
+    q.dispose();
+    _qSource.dispose();
+    seed.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/golden/outputs/query_with_cross_class_signal_unimported_type/controllers.g.dart
+++ b/packages/solid_generator/test/golden/outputs/query_with_cross_class_signal_unimported_type/controllers.g.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+import 'types.dart';
+
+class Settings implements Disposable {
+  final unit = Signal<Unit>(Unit.a, name: 'unit');
+
+  @override
+  void dispose() {
+    unit.dispose();
+  }
+}

--- a/packages/solid_generator/test/golden/outputs/query_with_cross_class_signal_unimported_type/types.g.dart
+++ b/packages/solid_generator/test/golden/outputs/query_with_cross_class_signal_unimported_type/types.g.dart
@@ -1,0 +1,8 @@
+// A plain Dart enum declared in a sibling file. `controllers.dart` imports
+// this file to type its `@SolidState Unit unit` field; `widget.dart` does
+// NOT import it, because the widget's source body never names `Unit`
+// textually — it only writes `settings.unit`. The generator must inject the
+// import into `widget.g.dart` so the synthesized `Computed<(int, Unit)>`
+// Record resolves at lib-time.
+
+enum Unit { a, b }

--- a/packages/solid_generator/test/golden/outputs/query_with_cross_class_signal_unimported_type/widget.g.dart
+++ b/packages/solid_generator/test/golden/outputs/query_with_cross_class_signal_unimported_type/widget.g.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:provider/provider.dart';
+import 'controllers.dart';
+import 'types.dart';
+
+class Display extends StatefulWidget {
+  const Display({super.key});
+
+  @override
+  State<Display> createState() => _DisplayState();
+}
+
+class _DisplayState extends State<Display> {
+  late final settings = context.read<Settings>();
+  final seed = Signal<int>(0, name: 'seed');
+  late final _qSource = Computed<(int, Unit)>(
+    () => (seed.value, settings.unit.value),
+    name: '_qSource',
+  );
+  late final q = Resource<String>(
+    () async => '${seed.value}-${settings.unit.value}',
+    source: _qSource,
+    name: 'q',
+  );
+
+  @override
+  void dispose() {
+    q.dispose();
+    _qSource.dispose();
+    seed.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/golden/outputs/query_with_mixed_signal_deps.g.dart
+++ b/packages/solid_generator/test/golden/outputs/query_with_mixed_signal_deps.g.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:provider/provider.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Filter implements Disposable {
+  final factor = Signal<int>(1, name: 'factor');
+
+  @override
+  void dispose() {
+    factor.dispose();
+  }
+}
+
+class ValueCard extends StatefulWidget {
+  const ValueCard({super.key});
+
+  @override
+  State<ValueCard> createState() => _ValueCardState();
+}
+
+class _ValueCardState extends State<ValueCard> {
+  late final filter = context.read<Filter>();
+  final seed = Signal<int>(0, name: 'seed');
+  late final _fetchValueSource = Computed<(int, int)>(
+    () => (seed.value, filter.factor.value),
+    name: '_fetchValueSource',
+  );
+  late final fetchValue = Resource<int>(
+    () async => seed.value + filter.factor.value,
+    source: _fetchValueSource,
+    name: 'fetchValue',
+  );
+
+  @override
+  void dispose() {
+    fetchValue.dispose();
+    _fetchValueSource.dispose();
+    seed.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/golden/outputs/query_with_multi_env_signal_deps.g.dart
+++ b/packages/solid_generator/test/golden/outputs/query_with_multi_env_signal_deps.g.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:provider/provider.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Settings implements Disposable {
+  final factor = Signal<int>(1, name: 'factor');
+
+  final prefix = Signal<String?>(null, name: 'prefix');
+
+  @override
+  void dispose() {
+    prefix.dispose();
+    factor.dispose();
+  }
+}
+
+class ValueCard extends StatefulWidget {
+  const ValueCard({super.key});
+
+  @override
+  State<ValueCard> createState() => _ValueCardState();
+}
+
+class _ValueCardState extends State<ValueCard> {
+  late final settings = context.read<Settings>();
+  late final _fetchValueSource = Computed<(String?, int)>(
+    () => (settings.prefix.value, settings.factor.value),
+    name: '_fetchValueSource',
+  );
+  late final fetchValue = Resource<String>(
+    () async => '${settings.prefix.value ?? ''}${10 * settings.factor.value}',
+    source: _fetchValueSource,
+    name: 'fetchValue',
+  );
+
+  @override
+  void dispose() {
+    fetchValue.dispose();
+    _fetchValueSource.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/golden/outputs/query_with_one_env_signal_dep.g.dart
+++ b/packages/solid_generator/test/golden/outputs/query_with_one_env_signal_dep.g.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:provider/provider.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Filter implements Disposable {
+  final factor = Signal<int>(1, name: 'factor');
+
+  @override
+  void dispose() {
+    factor.dispose();
+  }
+}
+
+class ValueCard extends StatefulWidget {
+  const ValueCard({super.key});
+
+  @override
+  State<ValueCard> createState() => _ValueCardState();
+}
+
+class _ValueCardState extends State<ValueCard> {
+  late final filter = context.read<Filter>();
+  late final fetchValue = Resource<int>(
+    () async => 10 * filter.factor.value,
+    source: filter.factor,
+    name: 'fetchValue',
+  );
+
+  @override
+  void dispose() {
+    fetchValue.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/golden/outputs/query_with_two_env_receivers.g.dart
+++ b/packages/solid_generator/test/golden/outputs/query_with_two_env_receivers.g.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_solidart/flutter_solidart.dart';
+import 'package:provider/provider.dart';
+import 'package:solid_annotations/solid_annotations.dart';
+
+class Auth implements Disposable {
+  final userId = Signal<int>(0, name: 'userId');
+
+  @override
+  void dispose() {
+    userId.dispose();
+  }
+}
+
+class Filter implements Disposable {
+  final factor = Signal<int>(1, name: 'factor');
+
+  @override
+  void dispose() {
+    factor.dispose();
+  }
+}
+
+class ValueCard extends StatefulWidget {
+  const ValueCard({super.key});
+
+  @override
+  State<ValueCard> createState() => _ValueCardState();
+}
+
+class _ValueCardState extends State<ValueCard> {
+  late final auth = context.read<Auth>();
+  late final filter = context.read<Filter>();
+  late final _fetchValueSource = Computed<(int, int)>(
+    () => (auth.userId.value, filter.factor.value),
+    name: '_fetchValueSource',
+  );
+  late final fetchValue = Resource<int>(
+    () async => auth.userId.value * filter.factor.value,
+    source: _fetchValueSource,
+    name: 'fetchValue',
+  );
+
+  @override
+  void dispose() {
+    fetchValue.dispose();
+    _fetchValueSource.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -103,6 +103,10 @@ const List<String> goldenNames = <String>[
   'late_hasvalue_chain',
   'cross_class_hasvalue_chain',
   'query_when_with_inner_state_reads',
+  'computed_reads_widget_ctor_field',
+  'effect_reads_widget_ctor_field',
+  'query_reads_widget_ctor_field',
+  'query_future_arrow_body',
 ];
 
 /// Memoized golden directory resolution. Resolved relative to the package

--- a/packages/solid_generator/test/integration/golden_helpers.dart
+++ b/packages/solid_generator/test/integration/golden_helpers.dart
@@ -107,6 +107,12 @@ const List<String> goldenNames = <String>[
   'effect_reads_widget_ctor_field',
   'query_reads_widget_ctor_field',
   'query_future_arrow_body',
+  'query_with_one_env_signal_dep',
+  'query_with_multi_env_signal_deps',
+  'query_with_mixed_signal_deps',
+  'query_with_two_env_receivers',
+  'query_with_cross_class_signal_unimported_type',
+  'query_with_cross_class_signal_already_imported_type',
 ];
 
 /// Memoized golden directory resolution. Resolved relative to the package

--- a/packages/solid_generator/test/rejections/solid_query_invalid_targets_test.dart
+++ b/packages/solid_generator/test/rejections/solid_query_invalid_targets_test.dart
@@ -1,10 +1,14 @@
 // Rejection suite for invalid `@SolidQuery` placements.
 //
-// Cases ordered to mirror the bullet list: non-Future/Stream return
-// → Future-without-async body → parameterized → static → abstract/external →
-// getter → setter → top-level function. Class fields are NOT rejected: a
-// field initializer expression (e.g. `Future.value(0)`) is a valid fetcher
-// shape — the lowering wraps it as `Resource<T>(fetcher: () => <init>)`.
+// Cases ordered to mirror the bullet list: non-Future/Stream return →
+// parameterized → static → abstract/external → getter → setter → top-level
+// function. Class fields are NOT rejected: a field initializer expression
+// (e.g. `Future.value(0)`) is a valid fetcher shape — the lowering wraps it
+// as `Resource<T>(fetcher: () => <init>)`. Body-keyword/return-type mismatch
+// is also NOT rejected: a `Future<T>` method with an arrow body that
+// returns a Future is valid Dart and is preserved by the emitter; Dart's
+// own analyzer reports `await_in_non_async_function` when `await` is used
+// without `async`, so the generator does not duplicate that check.
 
 import '../integration/golden_helpers.dart';
 
@@ -13,12 +17,6 @@ const List<({String name, String errorContains})> _cases = [
     name: 'non_future_return',
     errorContains:
         '@SolidQuery cannot be applied to a non-Future/Stream method',
-  ),
-  (
-    name: 'future_without_async',
-    errorContains:
-        '@SolidQuery cannot be applied to a method whose body keyword '
-        'does not match the return type',
   ),
   (
     name: 'solid_query_parameterized',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ workspace:
   - example
   - examples/todos
   - examples/solidart_example
+  - examples/weather
 
 dev_dependencies:
   very_good_analysis: ^10.0.0

--- a/skills/solid/SKILL.md
+++ b/skills/solid/SKILL.md
@@ -132,13 +132,13 @@ If `pubspec.yaml` doesn't yet declare Solid, install it:
    ```
 4. In `source/main.dart`, set `SolidartConfig.autoDispose = false;` before `runApp(...)`. (Temporary — will become the default in a future `flutter_solidart` major release.)
 5. In `analysis_options.yaml`, add `analyzer.errors.must_be_immutable: ignore` (your source widgets are mutable; the generated ones are immutable).
-6. Run `dart run build_runner watch --delete-conflicting-outputs` during development.
+6. Run `dart run build_runner watch` during development.
 
 ## Verify your changes
 
 After writing or editing `source/`, regenerate `lib/` and apply lint fixes:
 
-- **`scripts/verify.sh`** — run from any package root. Runs `dart run build_runner build --delete-conflicting-outputs`, then `dart fix --apply` on the package (adds `const`, removes unused imports, applies relative-import lints). Prints PASS/FAIL plus the first `[SEVERE]` error on failure. Exit code reflects build_runner success; `dart fix` failure is non-fatal.
+- **`scripts/verify.sh`** — run from any package root. Runs `dart run build_runner build`, then `dart fix --apply` on the package (adds `const`, removes unused imports, applies relative-import lints). Prints PASS/FAIL plus the first `[SEVERE]` error on failure. Exit code reflects build_runner success; `dart fix` failure is non-fatal.
 
 Why `dart fix --apply` matters: the generator prioritises correct, runnable code over polish. The emitted `lib/` may miss `const` opportunities, leave unused imports, or pick a non-preferred import form. `dart fix --apply` cleans this up using the project's lint rules (`prefer_const_constructors`, `unnecessary_import`, `prefer_relative_imports`, …). Always run it after generation — in CI too.
 

--- a/skills/solid/assets/AGENTS.md
+++ b/skills/solid/assets/AGENTS.md
@@ -41,7 +41,7 @@ When you install a pub package whose docs say "create `lib/<x>.dart`" (go_router
 After editing anything under `source/`:
 
 ```bash
-dart run build_runner build --delete-conflicting-outputs
+dart run build_runner build
 dart fix --apply
 ```
 

--- a/skills/solid/references/troubleshooting.md
+++ b/skills/solid/references/troubleshooting.md
@@ -8,9 +8,9 @@ Common errors and fixes. Source: <https://solid.mariuti.com/faq> plus the "commo
 | --- | --- | --- |
 | Edits to a file under `lib/` keep disappearing on save | `lib/` is generated; `build_runner watch` rewrites it from `source/`. | Move the change to the matching `source/<x>.dart`. |
 | `lib/<x>.dart` not produced | `source/**` not in `build.yaml` `targets.$default.sources`. | Add `- source/**` to the sources list. |
-| Generator errors complain about stale outputs | Old `.g.dart` / `lib/` files conflict with regeneration. | `dart run build_runner build --delete-conflicting-outputs` (or `watch ...`). Or run `scripts/verify.sh`. |
+| Generator errors complain about stale outputs | Old `.g.dart` / `lib/` files conflict with regeneration. | `dart run build_runner build` (or `watch`) deletes conflicting outputs automatically. Or run `scripts/verify.sh`. |
 | `flutter run` doesn't pick up a `build_runner` rewrite | No IDE save event fires for filesystem changes. | Press `r` in the `flutter run` terminal, or use [`dashmonx`](https://pub.dev/packages/dashmonx) (`dashmonx -d chrome` etc.). |
-| Working with another generator (`freezed`, `json_serializable`, …) and only Solid runs | `build.yaml` `sources` list missing `lib/**` or `$package$`. | Use the full block: `- lib/**`, `- $package$`, `- source/**`. Run `dart run build_runner watch --delete-conflicting-outputs` once. |
+| Working with another generator (`freezed`, `json_serializable`, …) and only Solid runs | `build.yaml` `sources` list missing `lib/**` or `$package$`. | Use the full block: `- lib/**`, `- $package$`, `- source/**`. Run `dart run build_runner watch` once. |
 | Generated `lib/` files are missing `const`, have unused imports, or use absolute `package:` imports | The generator prioritises correctness over polish; lint-driven fixes aren't applied. | Run `dart fix --apply` after `build_runner` — or use `scripts/verify.sh` which chains them. Apply in CI too. |
 
 ## Annotation rejections

--- a/skills/solid/scripts/verify.sh
+++ b/skills/solid/scripts/verify.sh
@@ -21,7 +21,7 @@ log="$(mktemp -t solid-verify.XXXXXX)"
 trap 'rm -f "$log"' EXIT
 
 # Step 1: build_runner. This is the hard requirement.
-if ! dart run build_runner build --delete-conflicting-outputs >"$log" 2>&1; then
+if ! dart run build_runner build >"$log" 2>&1; then
   echo "FAIL: build_runner returned non-zero." >&2
   first_severe="$(grep -m1 '\[SEVERE\]' "$log" || true)"
   if [[ -n "$first_severe" ]]; then


### PR DESCRIPTION
## Summary

- **New weather example** (`examples/weather/`) stress-tests Solid generator on `@SolidQuery(debounce:)`, `.refresh()`, per-instance resources keyed off widget constructor params, and three-level `@SolidEnvironment` chains
- **Fix: Widget constructor field rewrites** — `@SolidQuery`, `@SolidEffect`, and `@SolidState` getter bodies now correctly rewrite bare widget-bound field references to `widget.X` (same rewrite as `build()` method). Added three regression test goldens
- **Fix: Arrow-body Future query validation** — removed over-strict validation that rejected `Future<T>` queries with arrow bodies; all four body shapes (`=> expr`, `async => expr`, `{ return expr; }`, `async { return expr; }`) are now accepted
- **Docs: Remove deprecated build_runner flag** — updated docs and scripts to drop `--delete-conflicting-outputs` (removed in recent build_runner versions; deletion is now implicit)
- **Evaluation doc** — `examples/weather/EVALUATION.md` documents findings, root causes, fixes, and lingering generator restrictions encountered during authoring

## Testing

- `dart run build_runner build` passes cleanly in `examples/weather/`
- `dart analyze --fatal-infos` passes in `examples/weather/`
- `dart format --set-exit-if-changed .` passes in `examples/weather/`
- New regression goldens verify widget ctor field rewrites in `@SolidQuery`, `@SolidEffect`, and `@SolidState` getter bodies
- Removed rejection test `future_without_async` and replaced with positive golden `query_future_arrow_body`