### PR TITLE
v3.0.0-dev.1 — target solidart v3, upgrade deps, migrate to analyzer 12

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,8 +5,10 @@ on:
     tags:
       - "solid_generator-v[0-9]+.[0-9]+.[0-9]+" # Matches solid_generator-v1.2.3
       - 'solid_generator-v[0-9]+.[0-9]+.[0-9]+\+[0-9]+' # Matches solid_generator-v1.2.3+4
+      - "solid_generator-v[0-9]+.[0-9]+.[0-9]+-*" # Matches solid_generator-v1.2.3-dev.1
       - "solid_annotations-v[0-9]+.[0-9]+.[0-9]+" # Matches solid_annotations-v1.2.3
       - 'solid_annotations-v[0-9]+.[0-9]+.[0-9]+\+[0-9]+' # Matches solid_annotations-v1.2.3+4
+      - "solid_annotations-v[0-9]+.[0-9]+.[0-9]+-*" # Matches solid_annotations-v1.2.3-dev.1
 
 jobs:
   publish_solid_annotations:

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,9 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_solidart/flutter_solidart.dart';
 
 import 'counter.dart';
 
 void main() {
-  SolidartConfig.autoDispose = false;
   runApp(const MaterialApp(home: CounterPage()));
 }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,23 +4,23 @@ publish_to: 'none'
 version: 0.0.1
 
 environment:
-  sdk: ^3.9.2
+  sdk: ^3.10.0
 
 resolution: workspace
 
 dependencies:
   flutter:
     sdk: flutter
-  flutter_solidart: ^2.7.3
-  provider: ^6.1.0
+  flutter_solidart: ^3.0.0-dev.1
+  provider: ^6.1.5
   solid_annotations:
     path: ../packages/solid_annotations
 
 dev_dependencies:
-  build_runner: ^2.14.0
+  build_runner: ^2.15.0
   solid_generator:
     path: ../packages/solid_generator
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.3.0
 
 flutter:
   uses-material-design: true

--- a/example/source/main.dart
+++ b/example/source/main.dart
@@ -1,9 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_solidart/flutter_solidart.dart';
 
 import 'counter.dart';
 
 void main() {
-  SolidartConfig.autoDispose = false;
   runApp(MaterialApp(home: CounterPage()));
 }

--- a/examples/chat/lib/main.dart
+++ b/examples/chat/lib/main.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_solidart/flutter_solidart.dart';
 import 'package:provider/provider.dart';
 import 'package:solid_annotations/solid_annotations.dart';
 
@@ -12,7 +11,6 @@ import 'controllers/session_controller.dart';
 import 'controllers/users_controller.dart';
 
 void main() {
-  SolidartConfig.autoDispose = false;
   // `.environment(X)` wraps the receiver in `Provider<X>(child: receiver)`,
   // so X ends up ABOVE the receiver in the widget tree. For a Provider's
   // `create` callback to find a dependency via `ctx.read<T>()`, the

--- a/examples/chat/pubspec.yaml
+++ b/examples/chat/pubspec.yaml
@@ -4,25 +4,25 @@ publish_to: 'none'
 version: 0.0.1
 
 environment:
-  sdk: ^3.9.2
+  sdk: ^3.10.0
 
 resolution: workspace
 
 dependencies:
   flutter:
     sdk: flutter
-  flutter_solidart: ^2.7.4
-  provider: ^6.1.0
+  flutter_solidart: ^3.0.0-dev.1
+  provider: ^6.1.5
   solid_annotations:
     path: ../../packages/solid_annotations
 
 dev_dependencies:
-  build_runner: ^2.14.0
+  build_runner: ^2.15.0
   flutter_test:
     sdk: flutter
   solid_generator:
     path: ../../packages/solid_generator
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.3.0
 
 flutter:
   uses-material-design: true

--- a/examples/chat/source/main.dart
+++ b/examples/chat/source/main.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_solidart/flutter_solidart.dart';
 import 'package:provider/provider.dart';
 import 'package:solid_annotations/solid_annotations.dart';
 
@@ -12,7 +11,6 @@ import 'controllers/session_controller.dart';
 import 'controllers/users_controller.dart';
 
 void main() {
-  SolidartConfig.autoDispose = false;
   // `.environment(X)` wraps the receiver in `Provider<X>(child: receiver)`,
   // so X ends up ABOVE the receiver in the widget tree. For a Provider's
   // `create` callback to find a dependency via `ctx.read<T>()`, the

--- a/examples/solidart_example/pubspec.yaml
+++ b/examples/solidart_example/pubspec.yaml
@@ -4,26 +4,26 @@ publish_to: 'none'
 version: 0.0.1
 
 environment:
-  sdk: ^3.9.2
+  sdk: ^3.10.0
 
 resolution: workspace
 
 dependencies:
   flutter:
     sdk: flutter
-  flutter_solidart: ^2.7.4
-  http: ^1.3.0
-  provider: ^6.1.0
+  flutter_solidart: ^3.0.0-dev.1
+  http: ^1.6.0
+  provider: ^6.1.5
   solid_annotations:
     path: ../../packages/solid_annotations
 
 dev_dependencies:
-  build_runner: ^2.14.0
+  build_runner: ^2.15.0
   flutter_test:
     sdk: flutter
   solid_generator:
     path: ../../packages/solid_generator
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.3.0
 
 flutter:
   uses-material-design: true

--- a/examples/todos/lib/main.dart
+++ b/examples/todos/lib/main.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_solidart/flutter_solidart.dart';
 import 'package:solid_annotations/solid_annotations.dart';
 
 import 'controllers/filter.dart';
@@ -8,7 +7,6 @@ import 'domain/todo.dart';
 import 'pages/todos.dart';
 
 void main() {
-  SolidartConfig.autoDispose = false;
   runApp(const MyApp());
 }
 

--- a/examples/todos/pubspec.yaml
+++ b/examples/todos/pubspec.yaml
@@ -4,26 +4,26 @@ publish_to: 'none'
 version: 0.0.1
 
 environment:
-  sdk: ^3.9.2
+  sdk: ^3.10.0
 
 resolution: workspace
 
 dependencies:
   flutter:
     sdk: flutter
-  flutter_solidart: ^2.7.4
-  provider: ^6.1.0
+  flutter_solidart: ^3.0.0-dev.1
+  provider: ^6.1.5
   solid_annotations:
     path: ../../packages/solid_annotations
-  uuid: ^4.5.1
+  uuid: ^4.5.3
 
 dev_dependencies:
-  build_runner: ^2.14.0
+  build_runner: ^2.15.0
   flutter_test:
     sdk: flutter
   solid_generator:
     path: ../../packages/solid_generator
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.3.0
 
 flutter:
   uses-material-design: true

--- a/examples/todos/source/main.dart
+++ b/examples/todos/source/main.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_solidart/flutter_solidart.dart';
 import 'package:solid_annotations/solid_annotations.dart';
 
 import 'controllers/filter.dart';
@@ -8,7 +7,6 @@ import 'domain/todo.dart';
 import 'pages/todos.dart';
 
 void main() {
-  SolidartConfig.autoDispose = false;
   runApp(const MyApp());
 }
 

--- a/examples/weather/lib/main.dart
+++ b/examples/weather/lib/main.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_solidart/flutter_solidart.dart';
 import 'package:solid_annotations/solid_annotations.dart';
 
 import 'api/weather_api.dart';
@@ -9,7 +8,6 @@ import 'domain/city.dart';
 import 'pages/home_page.dart';
 
 void main() {
-  SolidartConfig.autoDispose = false;
   runApp(
     const WeatherApp()
         .environment(

--- a/examples/weather/pubspec.yaml
+++ b/examples/weather/pubspec.yaml
@@ -4,26 +4,26 @@ publish_to: 'none'
 version: 0.0.1
 
 environment:
-  sdk: ^3.9.2
+  sdk: ^3.10.0
 
 resolution: workspace
 
 dependencies:
   flutter:
     sdk: flutter
-  flutter_solidart: ^2.7.4
-  http: ^1.2.2
-  provider: ^6.1.0
+  flutter_solidart: ^3.0.0-dev.1
+  http: ^1.6.0
+  provider: ^6.1.5
   solid_annotations:
     path: ../../packages/solid_annotations
 
 dev_dependencies:
-  build_runner: ^2.14.0
+  build_runner: ^2.15.0
   flutter_test:
     sdk: flutter
   solid_generator:
     path: ../../packages/solid_generator
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.3.0
 
 flutter:
   uses-material-design: true

--- a/examples/weather/source/main.dart
+++ b/examples/weather/source/main.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_solidart/flutter_solidart.dart';
 import 'package:solid_annotations/solid_annotations.dart';
 
 import 'api/weather_api.dart';
@@ -9,7 +8,6 @@ import 'domain/city.dart';
 import 'pages/home_page.dart';
 
 void main() {
-  SolidartConfig.autoDispose = false;
   runApp(
     const WeatherApp()
         .environment((_) => WeatherApi())

--- a/packages/integration_tests/pubspec.yaml
+++ b/packages/integration_tests/pubspec.yaml
@@ -4,25 +4,25 @@ publish_to: 'none'
 version: 0.0.1
 
 environment:
-  sdk: ^3.9.2
+  sdk: ^3.10.0
 
 resolution: workspace
 
 dependencies:
   flutter:
     sdk: flutter
-  flutter_solidart: ^2.7.4
-  provider: ^6.1.0
+  flutter_solidart: ^3.0.0-dev.1
+  provider: ^6.1.5
   solid_annotations:
     path: ../solid_annotations
 
 dev_dependencies:
-  build_runner: ^2.14.0
+  build_runner: ^2.15.0
   flutter_test:
     sdk: flutter
   solid_generator:
     path: ../solid_generator
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.3.0
 
 flutter:
   uses-material-design: true

--- a/packages/solid_annotations/CHANGELOG.md
+++ b/packages/solid_annotations/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.0-dev.1
+
+- **BREAKING**: Raise the Dart SDK lower bound to `^3.10.0` and align with the solidart v3 ecosystem (`flutter_solidart` `^3.0.0-dev.1`).
+- **CHORE**: Bump `meta`, `provider`, and `very_good_analysis`.
+
 ## 2.0.0+1
 
 - **DOCS**: Update README installation.

--- a/packages/solid_annotations/pubspec.yaml
+++ b/packages/solid_annotations/pubspec.yaml
@@ -1,6 +1,6 @@
 name: solid_annotations
 description: Annotations for the solid transpiler to enable fine-grained reactivity in Flutter applications.
-version: 2.0.0+1
+version: 3.0.0-dev.1
 homepage: https://solid.mariuti.com
 repository: https://github.com/nank1ro/solid
 issue_tracker: https://github.com/nank1ro/solid/issues
@@ -13,15 +13,15 @@ topics:
   - solidjs
 
 environment:
-  sdk: ^3.9.2
+  sdk: ^3.10.0
 
 resolution: workspace
 
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.16.0
-  provider: ^6.1.0
+  meta: ^1.18.0
+  provider: ^6.1.5
 
 dev_dependencies:
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.3.0

--- a/packages/solid_generator/CHANGELOG.md
+++ b/packages/solid_generator/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.0.0-dev.1
+
+- **BREAKING**: Raise the Dart SDK lower bound to `^3.10.0` to target the solidart v3 ecosystem.
+- **CHORE**: Upgrade `analyzer` to `^12.0.0` and adapt to its reshaped class/enum declaration AST (name and members moved onto `namePart`/`body` for primary constructors).
+- **CHORE**: Bump `solid_annotations` to `^3.0.0-dev.1`, `dart_style` to `^3.1.8`, and `build`/`build_runner`/`build_test`.
+
 ## 2.0.0+1
 
 - **DOCS**: Update README installation.

--- a/packages/solid_generator/lib/builder.dart
+++ b/packages/solid_generator/lib/builder.dart
@@ -8,6 +8,7 @@ import 'package:dart_style/dart_style.dart';
 import 'package:glob/glob.dart';
 
 import 'package:solid_generator/src/annotation_reader.dart';
+import 'package:solid_generator/src/ast_compat.dart';
 import 'package:solid_generator/src/class_kind.dart';
 import 'package:solid_generator/src/const_call_site_rewriter.dart';
 import 'package:solid_generator/src/effect_model.dart';
@@ -154,7 +155,7 @@ class _SolidBuilder implements Builder {
     }
     // Acquire a TYPE-RESOLVED CompilationUnit when possible. Path:
     //   1. `libraryFor(inputId)` returns a fully-resolved `LibraryElement`
-    //      (analyzer 8.x forces full type resolution at this step).
+    //      (the analyzer resolves types fully at this step).
     //   2. `astNodeFor(anyElement, resolve: true)` returns that element's
     //      resolved declaration node — `Expression.staticType` is populated
     //      on every node beneath it.
@@ -625,8 +626,8 @@ Future<CompilationUnit> _resolveUnit(
       buildStep.inputId,
       allowSyntaxErrors: true,
     );
-    // analyzer 9 `astNodeFor` takes a `Fragment` (the per-file
-    // declaration-level element). The library's defining-file fragment is
+    // `astNodeFor` takes a `Fragment` (the per-file declaration-level
+    // element). The library's defining-file fragment is
     // available as `library.firstFragment` (a `LibraryFragment`); passing
     // it with `resolve: true` returns the resolved `CompilationUnit` for
     // that file directly. Falls back to the parsed AST if the resolver

--- a/packages/solid_generator/lib/src/ast_compat.dart
+++ b/packages/solid_generator/lib/src/ast_compat.dart
@@ -1,0 +1,42 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/token.dart';
+
+/// Compatibility accessors restoring the pre-analyzer-12 AST surface of
+/// [ClassDeclaration] and [EnumDeclaration].
+///
+/// analyzer 12 reshaped class and enum declarations to support primary
+/// constructors:
+///
+/// * the name identifier moved onto `namePart` (a [ClassNamePart] whose
+///   `typeName` token holds the declared name), and
+/// * the members and braces moved onto `body` (a [ClassBody]; the braces live
+///   on its [BlockClassBody] subtype).
+///
+/// These shims re-expose the old getters with identical semantics so the
+/// generator's call sites — and their offset-based source slicing — keep
+/// working unchanged.
+extension ClassDeclarationCompat on ClassDeclaration {
+  /// The members declared in the class body (analyzer 12: `body.members`).
+  NodeList<ClassMember> get members => body.members;
+
+  /// The token for the class name (analyzer 12: `namePart.typeName`).
+  Token get name => namePart.typeName;
+
+  /// The opening brace of the class body (analyzer 12: on [BlockClassBody]).
+  ///
+  /// `body` is always a [BlockClassBody] here: Solid only processes
+  /// brace-bodied declarations, while the brace-less `EmptyClassBody` arises
+  /// only for augmentations, which Solid sources never contain. This mirrors
+  /// the old non-null `ClassDeclaration.leftBracket` contract.
+  Token get leftBracket => (body as BlockClassBody).leftBracket;
+
+  /// The type parameters, if any (analyzer 12: `namePart.typeParameters`).
+  TypeParameterList? get typeParameters => namePart.typeParameters;
+}
+
+/// Restores the pre-analyzer-12 `name` getter on [EnumDeclaration]; the token
+/// now lives on `namePart.typeName`.
+extension EnumDeclarationCompat on EnumDeclaration {
+  /// The token for the enum name (analyzer 12: `namePart.typeName`).
+  Token get name => namePart.typeName;
+}

--- a/packages/solid_generator/lib/src/plain_class_rewriter.dart
+++ b/packages/solid_generator/lib/src/plain_class_rewriter.dart
@@ -1,4 +1,5 @@
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:solid_generator/src/ast_compat.dart';
 import 'package:solid_generator/src/effect_model.dart';
 import 'package:solid_generator/src/environment_model.dart';
 import 'package:solid_generator/src/field_model.dart';

--- a/packages/solid_generator/lib/src/reserved_annotation_validator.dart
+++ b/packages/solid_generator/lib/src/reserved_annotation_validator.dart
@@ -1,5 +1,6 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:solid_generator/src/ast_compat.dart';
 import 'package:solid_generator/src/transformation_error.dart';
 
 /// Reserved annotation names from `package:solid_annotations` whose full

--- a/packages/solid_generator/lib/src/state_class_rewriter.dart
+++ b/packages/solid_generator/lib/src/state_class_rewriter.dart
@@ -1,4 +1,5 @@
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:solid_generator/src/ast_compat.dart';
 import 'package:solid_generator/src/build_rewriter.dart';
 import 'package:solid_generator/src/effect_model.dart';
 import 'package:solid_generator/src/environment_model.dart';

--- a/packages/solid_generator/lib/src/stateless_rewriter.dart
+++ b/packages/solid_generator/lib/src/stateless_rewriter.dart
@@ -1,4 +1,5 @@
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:solid_generator/src/ast_compat.dart';
 import 'package:solid_generator/src/build_rewriter.dart';
 import 'package:solid_generator/src/effect_model.dart';
 import 'package:solid_generator/src/environment_model.dart';

--- a/packages/solid_generator/lib/src/target_validator.dart
+++ b/packages/solid_generator/lib/src/target_validator.dart
@@ -1,6 +1,7 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:solid_generator/src/annotation_reader.dart';
+import 'package:solid_generator/src/ast_compat.dart';
 import 'package:solid_generator/src/element_utils.dart';
 import 'package:solid_generator/src/transformation_error.dart';
 

--- a/packages/solid_generator/pubspec.yaml
+++ b/packages/solid_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: solid_generator
 description: Solid source-to-lib code generator for Flutter reactive state.
-version: 2.0.0+1
+version: 3.0.0-dev.1
 homepage: https://solid.mariuti.com
 repository: https://github.com/nank1ro/solid
 issue_tracker: https://github.com/nank1ro/solid/issues
@@ -12,20 +12,20 @@ topics:
   - swiftui
 
 environment:
-  sdk: ^3.9.2
+  sdk: ^3.10.0
 
 resolution: workspace
 
 dependencies:
-  analyzer: ">=8.2.0 <10.0.0"
-  build: ^4.0.5
+  analyzer: ^12.0.0
+  build: ^4.0.6
   build_config: ^1.3.0
-  dart_style: ^3.1.3
+  dart_style: ^3.1.8
   glob: ^2.1.3
-  meta: ^1.9.0
-  solid_annotations: ^2.0.0
+  meta: ^1.18.0
+  solid_annotations: ^3.0.0-dev.1
 
 dev_dependencies:
-  build_runner: ^2.14.0
-  build_test: ^3.5.1
-  test: ^1.25.6
+  build_runner: ^2.15.0
+  build_test: ^3.5.15
+  test: ^1.31.0

--- a/packages/solid_generator/test/golden/analysis_options.yaml
+++ b/packages/solid_generator/test/golden/analysis_options.yaml
@@ -30,3 +30,8 @@ analyzer:
     # The setter fixture intentionally has no corresponding getter — the
     # whole point is that `@SolidState` on a setter must be rejected.
     avoid_setters_without_getters: ignore
+    # Fixtures carry intentional `ignore_for_file` directives (e.g.
+    # `unreachable_from_main`) that document intent and mirror what the
+    # generated output needs; analysed in isolation an input may not produce
+    # the diagnostic, so the ignore reads as unnecessary.
+    unnecessary_ignore: ignore

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: _
 publish_to: none
 environment:
-  sdk: ^3.9.2
+  sdk: ^3.10.0
 workspace:
   - packages/solid_generator
   - packages/solid_annotations
@@ -13,4 +13,4 @@ workspace:
   - examples/chat
 
 dev_dependencies:
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.3.0

--- a/skills/solid/SKILL.md
+++ b/skills/solid/SKILL.md
@@ -132,9 +132,8 @@ If `pubspec.yaml` doesn't yet declare Solid, install it:
          - lib/**
          - $package$
    ```
-4. In `source/main.dart`, set `SolidartConfig.autoDispose = false;` before `runApp(...)`. (Temporary — will become the default in a future `flutter_solidart` major release.)
-5. In `analysis_options.yaml`, add `analyzer.errors.must_be_immutable: ignore` (your source widgets are mutable; the generated ones are immutable).
-6. Run `dart run build_runner watch` during development.
+4. In `analysis_options.yaml`, add `analyzer.errors.must_be_immutable: ignore` (your source widgets are mutable; the generated ones are immutable).
+5. Run `dart run build_runner watch` during development.
 
 ## Verify your changes
 
@@ -157,7 +156,6 @@ Why `dart fix --apply` matters: the generator prioritises correct, runnable code
 - Following a pub-package README literally when it says `lib/`. Substitute `source/`. See `references/third-party-packages.md`.
 - Adding `final` or `static` to a `@SolidState` field. The generator rejects it.
 - Giving `@SolidQuery` parameters. Use `@SolidState` fields as inputs — the query re-runs when they change.
-- Forgetting `SolidartConfig.autoDispose = false` in `source/main.dart` — atoms leak in tests and long sessions.
 - Importing same-package files via `package:<self>/...` from inside `source/`. Use relative paths.
 - Expecting `flutter run` to pick up build_runner output without `r` or `dashmonx`.
 - Treating `must_be_immutable` lint as a real error — your widgets are mutable; the generated ones are immutable. Set `must_be_immutable: ignore`.

--- a/skills/solid/assets/AGENTS.md
+++ b/skills/solid/assets/AGENTS.md
@@ -76,18 +76,6 @@ linter:
     prefer_relative_imports: true
 ```
 
-## Required `source/main.dart` setup
-
-```dart
-import 'package:flutter/material.dart';
-import 'package:flutter_solidart/flutter_solidart.dart';
-
-void main() {
-  SolidartConfig.autoDispose = false; // Solid manages disposal manually
-  runApp(/* ... */);
-}
-```
-
 ## Common bugs you might be asked about
 
 | Symptom | Diagnosis |

--- a/skills/solid/references/third-party-packages.md
+++ b/skills/solid/references/third-party-packages.md
@@ -57,12 +57,10 @@ final appRouter = GoRouter(
 
 ```dart title="source/main.dart"
 import 'package:flutter/material.dart';
-import 'package:flutter_solidart/flutter_solidart.dart';
 
 import 'router.dart';
 
 void main() {
-  SolidartConfig.autoDispose = false;
   runApp(MaterialApp.router(routerConfig: appRouter));
 }
 ```

--- a/skills/solid/references/troubleshooting.md
+++ b/skills/solid/references/troubleshooting.md
@@ -28,7 +28,6 @@ Common errors and fixes. Source: <https://solid.mariuti.com/faq> plus the "commo
 
 | Symptom | Cause | Fix |
 | --- | --- | --- |
-| Atoms are not disposed in tests / long sessions | `flutter_solidart` defaults to auto-dispose, which Solid manages manually. | In `source/main.dart` set `SolidartConfig.autoDispose = false;` before `runApp(...)`. (Will become the default in a future `flutter_solidart` major release.) |
 | `Provider not found` when reading a `@SolidEnvironment` field | No ancestor `Provider<T>` in the widget tree. | Add `.environment((_) => T(...))` on a parent widget, or wrap with `Provider<T>(create: ..., child: ...)`. |
 | `ProviderNotFoundException` from a `.environment(...)` `create` callback that calls `ctx.read<T>()` | `.environment(X)` wraps the RECEIVER, so X ends up ABOVE it. A consumer chained BEFORE its dependency has the dep BELOW (not above) its own `create` context. | Reorder so the dependency's `.environment(...)` appears AFTER the consumer's (the dep ends up outermost = above). See [patterns.md §6](./patterns.md#6-solidenvironment-reading-an-ancestor-providert) for the worked example. |
 | Reactive read inside `@SolidQuery` body doesn't trigger re-run | The read happens before the resource is observed, or on a non-`@SolidState` source. | Ensure the value comes from a `@SolidState` field (or a `@SolidState` getter) on the same widget. |


### PR DESCRIPTION
Companion release for **solidart / flutter_solidart v3.0.0-dev.1**. Bumps this repo's packages to a matching dev, points everything at the v3 dev line, upgrades the rest of the pub.dev deps, and drops the now-redundant auto-dispose opt-out.

## Changes

**Version**
- `solid_annotations` & `solid_generator`: `2.0.0+1` → **`3.0.0-dev.1`** (+ CHANGELOG entries)

**Point at solidart v3**
- `flutter_solidart` → `^3.0.0-dev.1` across integration_tests + all 5 examples (`solidart 3.0.0-dev.1` follows transitively)
- `solid_annotations` dep in `solid_generator` → `^3.0.0-dev.1`
- Workspace Dart SDK floor `^3.9.2` → `^3.10.0` (required by solidart v3)

**Dependency upgrades**
- `analyzer ^12.0.0`, `dart_style ^3.1.8`, `build ^4.0.6`, `build_runner ^2.15.0`, `build_test ^3.5.15`, `meta ^1.18.0`, `test ^1.31.0`, `provider ^6.1.5`, `very_good_analysis ^10.3.0`, `http ^1.6.0`, `uuid ^4.5.3`

**Generator: analyzer 12 migration**
- analyzer 12 reshaped the class/enum AST for primary constructors (`name`/`members`/`leftBracket`/`typeParameters` moved onto `namePart`/`body`). Adapted via a single compat extension — `packages/solid_generator/lib/src/ast_compat.dart` — wired into the 6 affected files, so the 30+ offset-sensitive call sites and their behavior stay unchanged.

**Remove redundant `SolidartConfig.autoDispose = false`**
- v3 defaults `autoDispose` to `false`, so the manual opt-out is a no-op. Removed from the 4 example `source/main.dart` (+ now-unused `flutter_solidart` import; `lib/` regenerated) and the skill docs (`SKILL.md`, `AGENTS.md`, `third-party-packages.md`, `troubleshooting.md`). Kept in the v2-pinned eval fixtures.

**CI/publish**
- `publish.yml`: also match prerelease `-dev.N` tags so a `…-v3.0.0-dev.1` tag triggers publish.

## Notable constraints
- **analyzer capped at 12.x here**: the Flutter SDK's `flutter_test` pins `test_api`, capping `test` at `1.31.0`, which requires `analyzer <13`. So 13/14 are unreachable in this workspace until Flutter bundles a newer `test_api`. 12.1.0 is the true latest.

## Verification
All `ci.yml` steps pass locally: `dart format` · `dart analyze --fatal-infos` · golden-outputs analyze · solid_annotations analyze · `solid_generator` tests (281) · integration tests (11, against flutter_solidart v3).

Regenerating **all 5 examples** from source under the new toolchain produces output byte-identical to `main` **except** the `SolidartConfig.autoDispose` removal — every `.g.dart`/controller/page is unchanged, and `solidart_example` (no autoDispose) regenerates with a zero-line diff.