### PR TITLE
Clarify 'autoDispose' flag status in getting started guide

### DIFF
--- a/docs/src/content/docs/guides/getting-started.mdx
+++ b/docs/src/content/docs/guides/getting-started.mdx
@@ -142,7 +142,7 @@ void main() {
 Setting `SolidartConfig.autoDispose = false` tells the library to let Solid manage disposal of reactive atoms manually, rather than automatically disposing them when they go out of scope.
 
 <Aside>
-This is a temporary step. A future major release of `flutter_solidart` will disable `autoDispose` by default, at which point you won't need to set this flag anymore.
+This is a temporary step, no longer needed from version v3.0.0-dev.1. A future major release of `flutter_solidart` will disable `autoDispose` by default, at which point you won't need to set this flag anymore.
 </Aside>
 
 ## Usage


### PR DESCRIPTION
Updated note about 'autoDispose' flag removal in future release.